### PR TITLE
fix: remove npm cache from Node.js setup

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -35,8 +35,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: 'apps/web/package-lock.json'
 
       - name: Install API dependencies
         working-directory: apps/api


### PR DESCRIPTION
Removes npm cache configuration that was failing because package-lock.json doesn't exist.