### PR TITLE
fix(ci): add CORS origin for E2E verify in rm-review

### DIFF
--- a/.github/workflows/rm-review.yml
+++ b/.github/workflows/rm-review.yml
@@ -404,6 +404,7 @@ jobs:
           JWT_SECRET_KEY: test-jwt-secret-for-ci
           CELERY_BROKER_URL: redis://localhost:6379/0
           CELERY_RESULT_BACKEND: redis://localhost:6379/0
+          CORS_ORIGINS: '["http://localhost:3200"]'
         run: |
           uv run uvicorn src.main:app --host 0.0.0.0 --port 8200 &
           echo "Waiting for API..."


### PR DESCRIPTION
## Summary

Fixes the root cause of all E2E auth test failures in the repo-maintainer review workflow.

## Root Cause

The rm-review verify job starts:
- API server on `localhost:8200`
- Frontend on `localhost:3200`

The API's default `CORS_ORIGINS` only allows `localhost:3000` and `localhost:8000`. When Playwright navigates to the signup page and the form submits a `fetch()` to `localhost:8200/auth/register`, the browser blocks the cross-origin request. The page never redirects, and the test times out after 10 seconds.

**Why it looked intermittent:** Global setup uses server-side `fetch()` (Node.js, no CORS enforcement) and passed fine. Only browser-based requests from Playwright were blocked.

## Fix

Add `CORS_ORIGINS: '["http://localhost:3200"]'` to the API server environment in the verify job.

## Impact

This one-line change should fix all 7 failing E2E auth tests that have been blocking every rm-review verification cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to enable proper API connectivity with frontend services during testing and verification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->