### PR TITLE
chore: release-readiness audit plan, issue tooling & secret scanner

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+# Pre-commit hooks for podcaststudiohub.
+# Install once:  pre-commit install
+# Run on demand: pre-commit run --all-files
+#
+# Secret scanning is the priority here (see release-readiness audit, 2026-06):
+# live AWS/LLM/TTS keys live in gitignored .env files and must never be committed.
+
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks
+        name: gitleaks (secret scan)
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: detect-private-key
+      - id: check-added-large-files
+        args: ["--maxkb=2048"]
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: check-json

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ podcaststudiohub/
 ```bash
 git clone https://github.com/frankbria/podcaststudiohub.git
 cd podcaststudiohub
+pre-commit install   # installs secret-scanner and hygiene hooks (requires pre-commit: pip install pre-commit)
 ```
 
 #### 2. Set Up Backend (API)
@@ -396,9 +397,10 @@ Contributions are welcome! Please:
 
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+3. Run `pre-commit install` once after cloning so the secret-scanner and hygiene hooks run on every commit
+4. Commit your changes (`git commit -m 'Add amazing feature'`)
+5. Push to the branch (`git push origin feature/amazing-feature`)
+6. Open a Pull Request
 
 ### Code Style
 

--- a/scripts/audit_issue_map.json
+++ b/scripts/audit_issue_map.json
@@ -1,0 +1,140 @@
+{
+  "fix(generation): podcast generation calls podcastfy 0.4.1 generate_podcast with invalid kwargs (file=, youtube_urls=) \u2014 every generation fails": {
+    "number": 204,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/204",
+    "severity": "critical",
+    "area": "core"
+  },
+  "fix(security): JWT verification ignores `type` claim \u2014 email-verification/refresh tokens usable as API access tokens": {
+    "number": 205,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/205",
+    "severity": "high",
+    "area": "api"
+  },
+  "fix(security): SSRF \u2014 user-supplied content URLs and webhook targets fetched server-side with no private-IP/metadata blocking": {
+    "number": 206,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/206",
+    "severity": "high",
+    "area": "api"
+  },
+  "chore(security): rotate live AWS/OpenAI/ElevenLabs/Gemini/Transistor credentials present in working-tree apps/api/.env": {
+    "number": 207,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/207",
+    "severity": "high",
+    "area": "infra"
+  },
+  "fix(infra): nginx serves authenticated SaaS over plain HTTP \u2014 no TLS, HSTS, CSP, or security headers": {
+    "number": 208,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/208",
+    "severity": "high",
+    "area": "infra"
+  },
+  "fix(infra): deployment runs as root with uvicorn bound to 0.0.0.0 (bypasses nginx)": {
+    "number": 209,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/209",
+    "severity": "high",
+    "area": "infra"
+  },
+  "fix(generation): PDF/file input is non-functional \u2014 no upload endpoint and extraction reads a non-existent local path (S3 key ignored)": {
+    "number": 210,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/210",
+    "severity": "high",
+    "area": "api"
+  },
+  "fix(distribution): platform distribution never triggered and publishes empty metadata \u2014 entire subsystem unreachable": {
+    "number": 211,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/211",
+    "severity": "high",
+    "area": "api"
+  },
+  "fix(security): backend JWT exposed to browser JS via NextAuth session + transmitted in SSE URL query string": {
+    "number": 212,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/212",
+    "severity": "high",
+    "area": "web"
+  },
+  "fix(api): /regenerate endpoint calls generate_podcast with wrong positional args \u2014 endpoint is broken (500) and leaves episode degraded": {
+    "number": 213,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/213",
+    "severity": "high",
+    "area": "api"
+  },
+  "fix(api): no guard against re-submitting generation for an already-running episode (race / indeterminate state)": {
+    "number": 214,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/214",
+    "severity": "medium",
+    "area": "api"
+  },
+  "fix(api): inconsistent S3 key layout \u2014 workflow-chain path drops the user-{id}/ tenant prefix": {
+    "number": 215,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/215",
+    "severity": "medium",
+    "area": "api"
+  },
+  "fix(api): Stripe webhook silently bypasses signature verification when secret unset (latent \u2014 Stripe currently cannot be enabled)": {
+    "number": 216,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/216",
+    "severity": "medium",
+    "area": "api"
+  },
+  "fix(api): TTS provider, conversation_config not forwarded to engine \u2014 every podcast uses OpenAI TTS": {
+    "number": 217,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/217",
+    "severity": "medium",
+    "area": "api"
+  },
+  "fix(api): invitation acceptance not bound to invited email; team tables lack RLS backstop": {
+    "number": 218,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/218",
+    "severity": "medium",
+    "area": "api"
+  },
+  "fix(api): expires_in hardcoded to 86400 but JWT expires in 30 minutes": {
+    "number": 219,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/219",
+    "severity": "medium",
+    "area": "api"
+  },
+  "fix(api): finalize task calls upload_to_s3_task inline (blocks worker, bypasses retries); SSE leaks DB session; on_upload_complete sets wrong status": {
+    "number": 220,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/220",
+    "severity": "medium",
+    "area": "api"
+  },
+  "fix(web): TTS 'Save Configuration' creates broken ElevenLabs configs \u2014 no voice-ID input, backend validates key presence only": {
+    "number": 221,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/221",
+    "severity": "medium",
+    "area": "web"
+  },
+  "fix(web): add server-side route protection (middleware) for the (auth) route group": {
+    "number": 222,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/222",
+    "severity": "medium",
+    "area": "web"
+  },
+  "fix(web): adopt or delete the unused api-client layer; replace ad-hoc fetch; fix signup loading + minor UX": {
+    "number": 223,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/223",
+    "severity": "medium",
+    "area": "web"
+  },
+  "fix(ci): harden agentic/CI workflows \u2014 issue-title shell injection, dispatch-input injection, mutable action pins, secret-in-argv": {
+    "number": 224,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/224",
+    "severity": "medium",
+    "area": "infra"
+  },
+  "docs: rewrite CLAUDE.md/README for the SaaS monorepo; fix broken file refs, auth model, JWT_ALGORITHM drift; remove dev cruft & IP": {
+    "number": 225,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/225",
+    "severity": "medium",
+    "area": "docs"
+  },
+  "fix(web): replace hardcoded gray Tailwind colors with design tokens; review EventSource cleanup & download try/finally": {
+    "number": 226,
+    "url": "https://github.com/frankbria/podcaststudiohub/issues/226",
+    "severity": "low",
+    "area": "web"
+  }
+}

--- a/scripts/create_audit_issues.py
+++ b/scripts/create_audit_issues.py
@@ -11,6 +11,9 @@ import sys
 import tempfile
 import os
 
+if len(sys.argv) < 2:
+    print("Usage: create_audit_issues.py <audit_json_file>", file=sys.stderr)
+    sys.exit(1)
 AUDIT_JSON = sys.argv[1]
 
 # Raw finding-label -> existing repo label (only labels that exist or we created).
@@ -50,9 +53,19 @@ SEV_LABELS = {
 }
 SEV_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
 
-with open(AUDIT_JSON) as f:
-    data = json.load(f)
-issues = data["result"]["report"]["issues"]
+try:
+    with open(AUDIT_JSON) as f:
+        data = json.load(f)
+    issues = data["result"]["report"]["issues"]
+except FileNotFoundError:
+    print(f"Error: audit file not found: {AUDIT_JSON}", file=sys.stderr)
+    sys.exit(1)
+except json.JSONDecodeError as e:
+    print(f"Error: invalid JSON in {AUDIT_JSON}: {e}", file=sys.stderr)
+    sys.exit(1)
+except KeyError as e:
+    print(f"Error: missing expected key in audit JSON: {e}", file=sys.stderr)
+    sys.exit(1)
 issues.sort(key=lambda i: SEV_ORDER.get(i["severity"], 9))
 
 mapping = {}
@@ -69,15 +82,17 @@ for idx, issue in enumerate(issues, 1):
     with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as tf:
         tf.write(body)
         body_file = tf.name
-    cmd = ["gh", "issue", "create", "--title", issue["title"], "--body-file", body_file]
-    for lab in sorted(labels):
-        cmd += ["--label", lab]
-    print(f"[{idx}/{len(issues)}] ({issue['severity']}) {issue['title'][:70]}...")
-    res = subprocess.run(cmd, capture_output=True, text=True)
-    os.unlink(body_file)
+    try:
+        cmd = ["gh", "issue", "create", "--title", issue["title"], "--body-file", body_file]
+        for lab in sorted(labels):
+            cmd += ["--label", lab]
+        print(f"[{idx}/{len(issues)}] ({issue['severity']}) {issue['title'][:70]}...")
+        res = subprocess.run(cmd, capture_output=True, text=True)
+    finally:
+        os.unlink(body_file)
     if res.returncode != 0:
         print("  ERROR:", res.stderr.strip())
-        mapping[issue["title"]] = {"error": res.stderr.strip(), "severity": issue["severity"]}
+        mapping[issue["title"]] = {"number": None, "url": None, "error": res.stderr.strip(), "severity": issue["severity"], "area": issue["area"]}
         continue
     url = res.stdout.strip()
     num = url.rstrip("/").split("/")[-1]

--- a/scripts/create_audit_issues.py
+++ b/scripts/create_audit_issues.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Create GitHub issues from the release-readiness audit output.
+
+Reads the workflow JSON, maps each issue's raw labels onto the repo's existing
+label taxonomy, and creates issues via `gh` (critical/high first). Writes a
+title->number mapping to scripts/audit_issue_map.json for the plan doc.
+"""
+import json
+import subprocess
+import sys
+import tempfile
+import os
+
+AUDIT_JSON = sys.argv[1]
+
+# Raw finding-label -> existing repo label (only labels that exist or we created).
+LABEL_MAP = {
+    "bug": "bug",
+    "blocker": "blocker",
+    "generation": "area-generation",
+    "integration": "area-generation",
+    "security": "area-security",
+    "auth": "area-auth",
+    "authz": "area-auth",
+    "ssrf": "area-security",
+    "secrets": "area-security",
+    "deployment": "area-deployment",
+    "tls": "area-deployment",
+    "storage": "area-storage",
+    "unfinished": "unfinished",
+    "distribution": "area-distribution",
+    "reliability": "area-reliability",
+    "tts": "area-tts",
+    "tech-debt": "tech-debt",
+    "ux": "area-ux",
+    "design-system": "area-ux",
+    "slop": "area-quality",
+    "hygiene": "area-quality",
+    "ci": "area-deployment",
+    "docs": "documentation",
+    "billing": "area-api",
+    "teams": "area-api",
+    "defense-in-depth": "area-security",
+}
+SEV_LABELS = {
+    "critical": ["priority-p0", "critical"],
+    "high": ["priority-p1"],
+    "medium": ["priority-p2"],
+    "low": ["priority-p3"],
+}
+SEV_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+
+with open(AUDIT_JSON) as f:
+    data = json.load(f)
+issues = data["result"]["report"]["issues"]
+issues.sort(key=lambda i: SEV_ORDER.get(i["severity"], 9))
+
+mapping = {}
+for idx, issue in enumerate(issues, 1):
+    labels = set(["release-audit"])
+    labels.update(SEV_LABELS.get(issue["severity"], []))
+    for raw in issue.get("labels", []):
+        if raw in LABEL_MAP:
+            labels.add(LABEL_MAP[raw])
+    body = issue["body"] + (
+        "\n\n---\n_Filed from the automated release-readiness audit (2026-06-13). "
+        f"Severity: **{issue['severity']}** · Area: **{issue['area']}**._"
+    )
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as tf:
+        tf.write(body)
+        body_file = tf.name
+    cmd = ["gh", "issue", "create", "--title", issue["title"], "--body-file", body_file]
+    for lab in sorted(labels):
+        cmd += ["--label", lab]
+    print(f"[{idx}/{len(issues)}] ({issue['severity']}) {issue['title'][:70]}...")
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    os.unlink(body_file)
+    if res.returncode != 0:
+        print("  ERROR:", res.stderr.strip())
+        mapping[issue["title"]] = {"error": res.stderr.strip(), "severity": issue["severity"]}
+        continue
+    url = res.stdout.strip()
+    num = url.rstrip("/").split("/")[-1]
+    print("  ->", url)
+    mapping[issue["title"]] = {"number": int(num), "url": url, "severity": issue["severity"], "area": issue["area"]}
+
+with open("scripts/audit_issue_map.json", "w") as f:
+    json.dump(mapping, f, indent=2)
+print("\nDone. Map written to scripts/audit_issue_map.json")

--- a/scripts/renumber_audit_issues.py
+++ b/scripts/renumber_audit_issues.py
@@ -17,10 +17,14 @@ PHASE = {
 }
 
 for num, tag in sorted(PHASE.items(), key=lambda kv: kv[1]):
-    cur = subprocess.run(
+    view = subprocess.run(
         ["gh", "issue", "view", str(num), "--json", "title", "-q", ".title"],
         capture_output=True, text=True,
-    ).stdout.strip()
+    )
+    if view.returncode != 0:
+        print(f"#{num} ERROR: failed to fetch title: {view.stderr.strip()}")
+        continue
+    cur = view.stdout.strip()
     if cur.startswith(f"[{tag}]"):
         print(f"#{num} already tagged {tag}")
         continue

--- a/scripts/renumber_audit_issues.py
+++ b/scripts/renumber_audit_issues.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Prepend [PX.Y] phase tags to the release-readiness audit issue titles."""
+import subprocess
+import json
+
+PHASE = {
+    # Phase 1 - stop the bleeding (urgent security)
+    207: "P1.1", 205: "P1.2", 206: "P1.3", 212: "P1.4",
+    # Phase 2 - restore the core product (generation)
+    204: "P2.1", 213: "P2.2", 217: "P2.3", 214: "P2.4", 210: "P2.5", 211: "P2.6",
+    # Phase 3 - deploy hardening
+    208: "P3.1", 209: "P3.2", 224: "P3.3",
+    # Phase 4 - correctness & authz mediums
+    215: "P4.1", 220: "P4.2", 216: "P4.3", 218: "P4.4", 219: "P4.5", 222: "P4.6",
+    # Phase 5 - UX, tech-debt, docs
+    221: "P5.1", 223: "P5.2", 226: "P5.3", 225: "P5.4",
+}
+
+for num, tag in sorted(PHASE.items(), key=lambda kv: kv[1]):
+    cur = subprocess.run(
+        ["gh", "issue", "view", str(num), "--json", "title", "-q", ".title"],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    if cur.startswith(f"[{tag}]"):
+        print(f"#{num} already tagged {tag}")
+        continue
+    # strip any pre-existing [PX.Y] tag, then prepend the correct one
+    base = cur
+    if base.startswith("[P") and "]" in base:
+        base = base.split("]", 1)[1].lstrip()
+    new = f"[{tag}] {base}"
+    r = subprocess.run(["gh", "issue", "edit", str(num), "--title", new], capture_output=True, text=True)
+    status = "ok" if r.returncode == 0 else f"ERR {r.stderr.strip()}"
+    print(f"#{num} -> {new[:80]}  [{status}]")

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,81 @@
+# Release-Readiness Plan — podcaststudiohub
+
+**Audit date:** 2026-06-13 · **Verdict:** 🔴 NOT READY (9 blockers) · **Issues:** #204–#226 (23 total)
+
+Generated from a multi-agent audit (10 reviewers + adversarial verification). Each issue
+carries file:line evidence + acceptance criteria on GitHub. Titles are phase-tagged `[PX.Y]`
+so issue order == work order.
+
+> ⚠️ **The core mirage:** the app "seems to work" only because the test suite **mocks the
+> generation engine**. Against the pinned `podcastfy==0.4.1` (pip-installed in the venv — there
+> is **no** `podcastfy/` engine in the repo; `podcast-generator/` is empty scaffolding),
+> **every** generation call fails (`#204`). Fixing that + replacing mocked tests with a real
+> end-to-end demo is the gate to "ready-with-caveats".
+
+---
+
+## Phase 1 — Stop the bleeding (urgent security, mostly independent)
+- [ ] **P1.1 #207** Rotate live AWS/OpenAI/ElevenLabs/Gemini/Transistor keys in working-tree `apps/api/.env`
+      → **Frank rotates** (deactivate the flagged AWS access key — ID is in issue #207 — in IAM). Secret scanner ✅ done (see below).
+- [ ] **P1.2 #205** JWT verification ignores `type` claim — verification/refresh tokens usable as access tokens
+- [ ] **P1.3 #206** SSRF — content URLs + webhook targets fetched server-side, no private-IP/metadata block
+- [ ] **P1.4 #212** Backend JWT exposed to browser JS (NextAuth session) + leaked in SSE `?token=` URL
+
+## Phase 2 — Restore the core product (generation pipeline)
+- [ ] **P2.1 #204** 🔴 `generate_podcast()` called with invalid kwargs → **every generation fails**. *Unblocks the rest of Phase 2.* Add an autospec/signature-asserting test; pin `podcastfy==0.4.1`.
+- [ ] **P2.2 #213** `/regenerate` passes wrong positional args → guaranteed 500, leaves episode degraded
+- [ ] **P2.3 #217** Episode `tts_model`/`conversation_config` never forwarded → always OpenAI TTS
+- [ ] **P2.4 #214** No guard against re-submitting generation for an in-progress episode (race)
+- [ ] **P2.5 #210** PDF/file input non-functional — no upload endpoint; extraction ignores S3 key *(needs StorageService + #204)*
+- [ ] **P2.6 #211** Distribution subsystem unreachable + would publish blank episodes *(needs #204 producing real episodes + metadata)*
+
+## Phase 3 — Deployment hardening (gate before any prod deploy)
+- [ ] **P3.1 #208** nginx serves authenticated SaaS over plain HTTP — enable TLS + HSTS/CSP/security headers
+- [ ] **P3.2 #209** Deploys as root, uvicorn bound `0.0.0.0` (bypasses nginx); reconcile 8000/8001 port mismatch
+- [ ] **P3.3 #224** Harden CI/agentic workflows — issue-title shell injection, dispatch-input injection, SHA-pin actions
+
+## Phase 4 — Correctness & authz mediums
+- [ ] **P4.1 #215** Inconsistent S3 key layout — workflow-chain path drops `user-{id}/` tenant prefix *(after #204/#210)*
+- [ ] **P4.2 #220** finalize task runs upload inline (no retry); SSE session leak; wrong status in `on_upload_complete`
+- [ ] **P4.3 #216** Stripe webhook signature bypass when secret unset *(latent — Stripe currently unreachable)*
+- [ ] **P4.4 #218** Invitation acceptance not bound to invited email; team tables lack RLS backstop
+- [ ] **P4.5 #219** `expires_in` hardcoded 86400 but JWT expires in 30 min *(relates to #205)*
+- [ ] **P4.6 #222** No server-side route protection (middleware) for the `(auth)` group — defense-in-depth
+
+## Phase 5 — UX, tech-debt, docs
+- [ ] **P5.1 #221** TTS "Save Configuration" creates broken ElevenLabs configs (no voice-ID input) *(do after #217)*
+- [ ] **P5.2 #223** Adopt or delete the dead `api-client` layer; fix signup loading; minor UX
+- [ ] **P5.3 #226** Replace hardcoded gray Tailwind colors with design tokens; minor robustness nits
+- [ ] **P5.4 #225** Rewrite CLAUDE.md/README for the SaaS monorepo; fix broken refs & config drift *(do last so docs reflect fixes)*
+
+---
+
+## Cross-phase dependencies
+- `#204` (P2.1) gates meaningful work/testing on `#213 #217 #210 #211 #214 #215`.
+- `#221` (P5.1) is only meaningful once `#217` (P2.3) forwards TTS config.
+- `#210` (P2.5) needs `StorageService.download_file` wired (already exists, unused).
+- `#225` (P5.4) last — so docs describe the fixed system.
+
+## Secrets / secret-scanner status
+- ✅ **gitleaks pre-commit hook installed** (`.pre-commit-config.yaml`, `pre-commit install` run). gitleaks
+  passed on all tracked files (no committed secrets; the live keys are in gitignored `.env` only).
+- ⏳ **Frank to rotate** all keys in `apps/api/.env` (P1.1 / #207) and confirm none were ever pushed.
+- Recommend moving real secrets to a secret manager / CI secrets; keep placeholders on dev machines.
+
+## Release gate (Definition of Done for "ready-with-caveats")
+1. Phase 1 + Phase 2 complete and **verified by a real, non-mocked end-to-end generation demo**
+   (URL → transcript → audio → S3 → playable episode).
+2. Phase 3 complete: HTTPS in front, non-root deploy, hardened CI.
+3. New tests exist for: generation kwargs (autospec), `/regenerate`, webhook signature, SSRF rejection,
+   route protection — so green CI reflects a working product.
+4. P4/P5 can trail into a fast-follow milestone if explicitly accepted as known caveats.
+
+## Ops changes already made this session
+- README server IP removed (commit `bf9e606`).
+- gitleaks pre-commit secret scanner added.
+- Issues #161 / #162 (agentic noise) closed as not planned.
+- Disabled (reversible via `gh workflow enable "<name>"`): Community Response, Issue Triage,
+  PR Review, and all 6 Repo Maintainer workflows. **Kept active:** Test Suite, Deploy to Development,
+  Playwright E2E, Draft PDF, Claude Code (manual `@claude` helper).
+- Helper scripts: `scripts/create_audit_issues.py`, `scripts/renumber_audit_issues.py`,
+  `scripts/audit_issue_map.json`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,6 +6,10 @@ Generated from a multi-agent audit (10 reviewers + adversarial verification). Ea
 carries file:line evidence + acceptance criteria on GitHub. Titles are phase-tagged `[PX.Y]`
 so issue order == work order.
 
+> The **9 blockers** are #204, #205, #206, #207, #208, #209, #210, #211, #212 — they span
+> Phases 1–3 (not every Phase 1/2 item is a blocker: #213, #214, #217 are high/medium correctness
+> fixes, not release blockers). The release gate below requires Phases 1–3 done.
+
 > ⚠️ **The core mirage:** the app "seems to work" only because the test suite **mocks the
 > generation engine**. Against the pinned `podcastfy==0.4.1` (pip-installed in the venv — there
 > is **no** `podcastfy/` engine in the repo; `podcast-generator/` is empty scaffolding),


### PR DESCRIPTION
## Summary

Adds the artifacts from the 2026-06-13 release-readiness audit (multi-agent fan-out review). No application code changes — planning, tooling, and a secret scanner only.

- **`tasks/todo.md`** — phased release plan (P1–P5) covering the 23 audit issues (#204–#226), dependency-ordered with a release gate.
- **`.pre-commit-config.yaml`** — gitleaks secret scanner + basic hygiene hooks (`pre-commit install` already run locally). It already paid off: it blocked an AWS key ID from being committed in the plan doc during this PR's first commit attempt.
- **`scripts/create_audit_issues.py`**, **`scripts/renumber_audit_issues.py`**, **`scripts/audit_issue_map.json`** — the helpers that filed and phase-tagged issues #204–#226 (kept as a record / re-runnable reference).

## Context

The audit verdict was **NOT READY** (9 blockers) — headline being that podcast generation fails against the pinned `podcastfy==0.4.1` (invalid kwargs), hidden by mocked tests. Full details live in issues #204–#226; `tasks/todo.md` is the roadmap.

## Follow-ups (not in this PR)
- Rotate the live credentials in `apps/api/.env` (#207 / P1.1).
- Agentic + repo-maintainer GitHub workflows were disabled at the Actions level (reversible); permanent cleanup is tracked in #224 (P3.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)