### PR TITLE
docs: S3 IAM policy + key-rotation runbook; mark P1.1 (#207) done

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -234,7 +234,18 @@ LOG_LEVEL=INFO
 OPENAI_API_KEY=
 GEMINI_API_KEY=
 ELEVENLABS_API_KEY=
+TRANSISTOR_API_KEY=
+
+# AWS S3 (audio storage) - see "AWS S3 / IAM permissions" below
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_S3_BUCKET=podcaststudiohub-audio
+AWS_REGION=us-east-1
 ```
+
+> Keep real secrets out of version control: these `.env` files are gitignored and must never be
+> committed. A `gitleaks` pre-commit hook (repo root `.pre-commit-config.yaml`) blocks accidental
+> commits of keys.
 
 **Frontend (`/opt/podcaststudiohub/frontend/.env.production`):**
 ```bash
@@ -243,6 +254,50 @@ NEXTAUTH_URL=https://dev.podcaststudiohub.me
 NEXTAUTH_SECRET=<same-as-github-secret>
 PORT=3003
 ```
+
+### AWS S3 / IAM permissions
+
+The API stores generated audio in S3 (`AWS_S3_BUCKET`, default `podcaststudiohub-audio`) using a
+dedicated IAM user (e.g. `fastapi-s3-uploader`). That user needs an identity-based policy granting
+**object-level** access only — the app never lists the bucket:
+
+| Action | Why |
+|---|---|
+| `s3:PutObject` | upload generated audio (incl. multipart for large/long-form files) |
+| `s3:GetObject` | download / `head_object` / presigned playback URLs |
+| `s3:DeleteObject` | remove audio when an episode is deleted |
+| `s3:AbortMultipartUpload` | clean up failed multipart uploads |
+
+`s3:ListBucket` is intentionally **not** granted (least privilege). `aws s3 ls` returns
+`AccessDenied` for this user *by design* — that is expected, not a misconfiguration.
+
+Minimal inline policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "PodcastAudioObjectRW",
+      "Effect": "Allow",
+      "Action": ["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:AbortMultipartUpload"],
+      "Resource": "arn:aws:s3:::podcaststudiohub-audio/*"
+    }
+  ]
+}
+```
+
+Apply it from AWS CloudShell (which runs as your admin console identity):
+
+```bash
+aws iam put-user-policy --user-name fastapi-s3-uploader \
+  --policy-name podcast-audio-object-rw --policy-document file://s3-policy.json
+```
+
+**Rotating the access key:** AWS keys can't be edited in place. Create a new key → update `.env`
+here and on the dev machine → `pm2 restart podcaststudiohub-api` → verify (PutObject/GetObject/
+DeleteObject) → **then** deactivate and delete the old key. Permissions live on the IAM user, not
+the key, so rotation never changes them.
 
 ## Nginx Configuration
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -19,7 +19,7 @@ so issue order == work order.
 ---
 
 ## Phase 1 — Stop the bleeding (urgent security, mostly independent)
-- [ ] **P1.1 #207** Rotate live AWS/OpenAI/ElevenLabs/Gemini/Transistor keys in working-tree `apps/api/.env`
+- [x] **P1.1 #207** Rotate live AWS/OpenAI/ElevenLabs/Gemini/Transistor keys ✅ done 2026-06-14 (old AWS key deactivated; verified never committed to git; S3 object policy added)
       → **Frank rotates** (deactivate the flagged AWS access key — ID is in issue #207 — in IAM). Secret scanner ✅ done (see below).
 - [ ] **P1.2 #205** JWT verification ignores `type` claim — verification/refresh tokens usable as access tokens
 - [ ] **P1.3 #206** SSRF — content URLs + webhook targets fetched server-side, no private-IP/metadata block
@@ -63,7 +63,8 @@ so issue order == work order.
 ## Secrets / secret-scanner status
 - ✅ **gitleaks pre-commit hook installed** (`.pre-commit-config.yaml`, `pre-commit install` run). gitleaks
   passed on all tracked files (no committed secrets; the live keys are in gitignored `.env` only).
-- ⏳ **Frank to rotate** all keys in `apps/api/.env` (P1.1 / #207) and confirm none were ever pushed.
+- ✅ **Rotated 2026-06-14** — all keys cycled, old AWS key deactivated; full-history scan confirmed
+  the keys were never committed/pushed (precautionary rotation, not a leak); S3 object policy added (#207 closed).
 - Recommend moving real secrets to a secret manager / CI secrets; keep placeholders on dev machines.
 
 ## Release gate (Definition of Done for "ready-with-caveats")


### PR DESCRIPTION
## Summary
Captures the lessons from the #207 credential rotation so a future environment rebuild doesn't re-hit them:
- `deployment/README.md`: documents the S3 user's required IAM actions (`PutObject`/`GetObject`/`DeleteObject`/`AbortMultipartUpload`, **no** `ListBucket`), the minimal inline policy JSON, how to apply it via CloudShell, and the access-key rotation runbook. Adds the missing AWS/Transistor vars to the server `.env` example + a gitleaks note.
- `tasks/todo.md`: marks P1.1 (#207) complete.

## Context
#207 rotation is done: all keys cycled, old AWS key `AKIA…OJPI` deactivated, and a full git-history scan confirmed the keys were never committed/pushed (precautionary rotation, not a leak). A real latent bug was also fixed live — the S3 user lacked `s3:PutObject`, so audio writes had been failing; the documented policy resolves it.

Docs-only; no code changes.