### PR TITLE
fix(security): JWT verification ignores `type` claim — reject verification/refresh tokens on the access path (#205)

### DIFF
--- a/apps/api/src/middleware/auth.py
+++ b/apps/api/src/middleware/auth.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 from uuid import UUID
 
 from ..database import get_db
-from ..services.auth_service import verify_jwt_token
+from ..services.auth_service import verify_jwt_token, verify_access_token
 from ..models.user import User
 
 # HTTPBearer with auto_error=False so missing credentials raise 401 (not 403)
@@ -91,8 +91,8 @@ async def get_current_user(
     token = credentials.credentials
 
     try:
-        # Decode and verify JWT token
-        payload = verify_jwt_token(token)
+        # Decode and verify JWT token (must be an access token, not verification/refresh)
+        payload = verify_access_token(token)
         user_id = payload.get("sub")
         tenant_id = payload.get("tenant_id")
 
@@ -230,8 +230,8 @@ async def get_current_user_from_query(
         )
 
     try:
-        # Decode and verify JWT token
-        payload = verify_jwt_token(jwt_token)
+        # Decode and verify JWT token (must be an access token, not verification/refresh)
+        payload = verify_access_token(jwt_token)
         user_id = payload.get("sub")
         tenant_id = payload.get("tenant_id")
 

--- a/apps/api/src/services/auth_service.py
+++ b/apps/api/src/services/auth_service.py
@@ -122,6 +122,32 @@ def verify_jwt_token(token: str) -> dict:
         raise ValueError(f"Invalid token: {str(e)}")
 
 
+def verify_access_token(token: str) -> dict:
+    """
+    Decode and validate a JWT *access* token.
+
+    Unlike verify_jwt_token, this enforces that the token's `type` claim is
+    'access', so long-lived verification (24h) and refresh (7d) tokens — which
+    are signed with the same JWT_SECRET_KEY — cannot be used as API access
+    credentials (see issue #205).
+
+    Args:
+        token: JWT token string to verify
+
+    Returns:
+        Decoded payload dictionary
+
+    Raises:
+        ValueError: If token is invalid, expired, or not an access token
+    """
+    payload = verify_jwt_token(token)  # raises ValueError on bad token
+
+    if payload.get("type") != "access":
+        raise ValueError("Invalid token type")
+
+    return payload
+
+
 # ============================================================================
 # Email Verification Token Functions
 # ============================================================================

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -20,11 +20,13 @@ from src.services.auth_service import (
     verify_password,
     create_jwt_token,
     verify_jwt_token,
+    verify_access_token,
     create_user,
     authenticate_user,
     create_verification_token,
     verify_verification_token,
 )
+from src.utils.jwt import create_refresh_token
 
 
 # =============================================================================
@@ -130,6 +132,41 @@ def test_verify_expired_jwt_token():
 
     with pytest.raises(ValueError, match="Invalid token"):
         verify_jwt_token(token)
+
+
+# =============================================================================
+# Access Token Type Enforcement Tests (issue #205)
+# =============================================================================
+
+def test_verify_access_token_accepts_access_token():
+    """verify_access_token returns the payload for a genuine access token."""
+    user_id = uuid4()
+    tenant_id = uuid4()
+    email = "access@example.com"
+
+    token = create_jwt_token(user_id, tenant_id, email)
+    payload = verify_access_token(token)
+
+    assert payload["sub"] == str(user_id)
+    assert payload["type"] == "access"
+
+
+def test_verify_access_token_rejects_verification_token():
+    """A 24h email-verification token must not pass as an access credential."""
+    user_id = uuid4()
+    tenant_id = uuid4()
+    token = create_verification_token(user_id, "verify@example.com", tenant_id)
+
+    with pytest.raises(ValueError, match="Invalid token type"):
+        verify_access_token(token)
+
+
+def test_verify_access_token_rejects_refresh_token():
+    """A 7-day refresh token must not pass as an access credential."""
+    token = create_refresh_token({"sub": str(uuid4()), "tenant_id": str(uuid4())})
+
+    with pytest.raises(ValueError, match="Invalid token type"):
+        verify_access_token(token)
 
 
 # =============================================================================
@@ -535,6 +572,54 @@ async def test_middleware_inactive_user_via_get_me(client: AsyncClient, test_db:
 
     assert response.status_code == 403
     assert "inactive" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_middleware_rejects_verification_token(client: AsyncClient):
+    """A real verification token for a real user must be rejected on the access path (issue #205)."""
+    register_response = await client.post(
+        "/auth/register",
+        json={
+            "email": "verifytoken@example.com",
+            "password": "VerifyToken123!",
+            "full_name": "Verify Token",
+        },
+    )
+    user = register_response.json()["user"]
+    verification_token = create_verification_token(
+        UUID(user["id"]), user["email"], UUID(user["tenant_id"])
+    )
+
+    response = await client.get(
+        "/auth/me",
+        headers={"Authorization": f"Bearer {verification_token}"},
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_middleware_rejects_refresh_token(client: AsyncClient):
+    """A real refresh token for a real user must be rejected on the access path (issue #205)."""
+    register_response = await client.post(
+        "/auth/register",
+        json={
+            "email": "refreshtoken@example.com",
+            "password": "RefreshToken123!",
+            "full_name": "Refresh Token",
+        },
+    )
+    user = register_response.json()["user"]
+    refresh_token = create_refresh_token(
+        {"sub": user["id"], "tenant_id": user["tenant_id"]}
+    )
+
+    response = await client.get(
+        "/auth/me",
+        headers={"Authorization": f"Bearer {refresh_token}"},
+    )
+
+    assert response.status_code == 401
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

`verify_jwt_token` (auth_service.py) validated only signature + expiry and returned the payload with no `type` check, so the access path accepted **any** validly-signed token. Email-verification (24h) and refresh (7d) tokens are signed with the same `JWT_SECRET_KEY` and are exposed via email logs, browser history, and the `?token=` SSE query string — meaning a long-lived link/email token could be replayed as a full API credential far beyond the 30-min access window.

Fixes #205 (P1.2 · release blocker · security/auth).

## Changes

- **`auth_service.py`** — add `verify_access_token(token)`, mirroring the existing `verify_verification_token` idiom: decode via `verify_jwt_token`, then `raise ValueError("Invalid token type")` unless `payload.get("type") == "access"`. A token with no `type` claim is also rejected.
- **`middleware/auth.py`** — point both access-path consumers (`get_current_user` and `get_current_user_from_query` / SSE) at `verify_access_token`. Their existing `except ValueError -> 401` handlers turn rejection into a clean 401.
- `verify_jwt_token` is **retained** for email verification (`verify_verification_token`) and tenant-context extraction (`get_tenant_id_from_token`), which must continue to accept non-access token types.

## Acceptance criteria

- [x] Enforce `payload.get('type') == 'access'` on the access path (reject otherwise)
- [x] Negative tests: verification token **and** refresh token both rejected as access credentials

## Tests

New in `tests/test_auth.py` (all passing against a real Postgres):
- Unit: `verify_access_token` accepts a genuine access token; rejects a verification token; rejects a refresh token.
- Integration: `GET /auth/me` with a real verification token → **401**; with a real refresh token → **401**.

Full `apps/api` suite: **1344 passed, 7 skipped, 1 failed** — see Known Limitations.

## Known Limitations / out of scope

- **`get_tenant_id_from_token` (tenant middleware) still decodes any valid token** to set the RLS tenant context. This is intentional and not exploitable on its own: the request is still rejected by `get_current_user`/`get_current_user_from_query` (now hardened) before any data is returned. Tightening the tenant-context path to access-tokens-only is a possible defense-in-depth follow-up, outside this issue's scope.
- **Pre-existing unrelated failure:** `tests/test_audio_snippets.py::test_download_url_no_s3_config` fails on `main` as well (a mock-targeting bug in the audio-snippet download test — patches `generate_download_url` but the endpoint returns 200). Confirmed independent of this change by stashing this PR's edits and reproducing the failure on a clean tree. Not addressed here to keep this security PR focused.

## Review note

- **Cross-family review (CodeRabbit): unavailable** — the automated CodeRabbit pass hit the account PR review rate limit, so no independent cross-family review ran on this PR. Mitigation: focused 116-line diff, adversarial self-review of token-type edge cases (incl. missing `type` claim), and unit + integration negative tests against a real Postgres. Disclosed here per the merge invariant.
