### PR TITLE
fix(security): block SSRF to private/metadata hosts in content URLs & webhooks (#206)

### DIFF
--- a/apps/api/src/schemas/distribution_target.py
+++ b/apps/api/src/schemas/distribution_target.py
@@ -10,6 +10,8 @@ from uuid import UUID
 from datetime import datetime, timezone
 from typing import Optional, Literal
 
+from ..utils.ssrf import SSRFValidationError, validate_public_url
+
 
 class WebhookDistributionCreate(BaseModel):
 	"""Schema for creating a webhook distribution target."""
@@ -41,11 +43,17 @@ class WebhookDistributionCreate(BaseModel):
 	@field_validator("url")
 	@classmethod
 	def validate_https_url(cls, v: str) -> str:
-		"""Validate that URL uses HTTPS and is well-formed."""
+		"""Validate that URL uses HTTPS, is well-formed, and is not internal."""
 		if not v.startswith("https://"):
 			raise ValueError("Webhook URL must use HTTPS (not HTTP)")
 		if len(v) > 500:
 			raise ValueError("Webhook URL must not exceed 500 characters")
+		# SSRF guard (issue #206): reject loopback/link-local/private/reserved
+		# targets (incl. 169.254.169.254) and non-standard ports.
+		try:
+			validate_public_url(v, allowed_schemes=("https",), allowed_ports={443})
+		except SSRFValidationError as exc:
+			raise ValueError(f"Webhook URL is not allowed: {exc}") from exc
 		return v
 
 	@field_validator("headers")

--- a/apps/api/src/services/content_extraction_service.py
+++ b/apps/api/src/services/content_extraction_service.py
@@ -14,7 +14,11 @@ maintain async compatibility with the FastAPI application.
 import asyncio
 import logging
 from typing import Optional
+from urllib.parse import urljoin
 from uuid import UUID
+
+import requests
+from bs4 import BeautifulSoup
 from sqlalchemy.ext.asyncio import AsyncSession
 from requests.exceptions import RequestException, Timeout, HTTPError
 
@@ -23,10 +27,16 @@ from podcastfy.content_parser.pdf_extractor import PDFExtractor
 
 from ..models import ContentSource
 from ..schemas.content import ContentSourceUpdate
+from ..utils.ssrf import SSRFValidationError, validate_public_url
 from .content_service import get_content_source_by_id, update_content_source
 
 
 logger = logging.getLogger(__name__)
+
+# Redirect status codes that carry a Location header to follow.
+_REDIRECT_STATUS = (301, 302, 303, 307, 308)
+# Maximum redirect hops allowed during a single content fetch.
+_MAX_REDIRECT_HOPS = 3
 
 
 class ExtractionResult:
@@ -63,6 +73,59 @@ class ContentExtractionService:
 		"""Initialize the extraction service with Podcastfy extractors."""
 		self.website_extractor = WebsiteExtractor()
 		self.pdf_extractor = PDFExtractor()
+
+	def _fetch_and_extract_safely(self, url: str) -> str:
+		"""
+		Fetch and extract URL content with SSRF-safe manual redirect handling.
+
+		Redirects are not auto-followed: each hop is re-validated with the SSRF
+		guard before it is requested, so a public URL cannot redirect the
+		server-side fetch into an internal address such as the cloud metadata
+		endpoint (issue #206). Podcastfy's ``WebsiteExtractor`` follows redirects
+		unconditionally, so this performs the fetch itself and reuses the
+		extractor's parsing helpers for output consistency.
+
+		Args:
+			url: URL to fetch.
+
+		Returns:
+			Cleaned text content.
+
+		Raises:
+			SSRFValidationError: If the URL (or a redirect target) is internal.
+			requests.RequestException: On network/HTTP errors.
+		"""
+		extractor = self.website_extractor
+		headers = {"User-Agent": extractor.user_agent}
+		current_url = extractor.normalize_url(url)
+
+		for _ in range(_MAX_REDIRECT_HOPS + 1):
+			validate_public_url(
+				current_url,
+				allowed_ports={80, 443},
+				block_on_resolution_failure=True,
+			)
+			response = requests.get(
+				current_url,
+				headers=headers,
+				timeout=extractor.timeout,
+				allow_redirects=False,
+			)
+			if response.status_code in _REDIRECT_STATUS:
+				location = response.headers.get("location")
+				if not location:
+					break
+				current_url = urljoin(current_url, location)
+				continue
+
+			response.raise_for_status()
+			soup = BeautifulSoup(response.text, "html.parser")
+			extractor.remove_unwanted_elements(soup)
+			return extractor.clean_content(soup.get_text(separator="\n"))
+
+		raise requests.TooManyRedirects(
+			f"Exceeded the maximum of {_MAX_REDIRECT_HOPS} redirects"
+		)
 
 	async def extract_from_url(
 		self,
@@ -106,14 +169,27 @@ class ContentExtractionService:
 			await self._update_extraction_failed(db, content_source, error_msg)
 			return ExtractionResult(success=False, error_message=error_msg)
 
+		# SSRF guard: re-validate the host at dispatch time (block unresolvable
+		# hosts here too — this is the actual fetch path, so a host that fails
+		# the lookup but resolves to an internal IP must not slip through).
+		try:
+			validate_public_url(
+				url, allowed_ports={80, 443}, block_on_resolution_failure=True
+			)
+		except SSRFValidationError as exc:
+			error_msg = "URL is not allowed: targets a non-public address."
+			logger.warning(f"Blocked SSRF extraction for {url}: {exc}")
+			await self._update_extraction_failed(db, content_source, error_msg)
+			return ExtractionResult(success=False, error_message=error_msg)
+
 		# Update status to 'extracting'
 		await self._update_extraction_status(db, content_source, 'extracting')
 
 		try:
-			# Extract content using Podcastfy (async wrapper)
+			# Extract content with SSRF-safe, redirect-validating fetch.
 			logger.info(f"Extracting content from URL: {url}")
 			extracted_text = await asyncio.to_thread(
-				self.website_extractor.extract_content,
+				self._fetch_and_extract_safely,
 				url
 			)
 
@@ -124,6 +200,13 @@ class ContentExtractionService:
 				f"Successfully extracted {len(extracted_text)} characters from {url}"
 			)
 			return ExtractionResult(success=True, content=extracted_text)
+
+		except SSRFValidationError as exc:
+			# A redirect target resolved to an internal address mid-fetch.
+			error_msg = "URL is not allowed: targets a non-public address."
+			logger.warning(f"Blocked SSRF redirect during extraction of {url}: {exc}")
+			await self._update_extraction_failed(db, content_source, error_msg)
+			return ExtractionResult(success=False, error_message=error_msg)
 
 		except RequestException as e:
 			# Handle HTTP/network errors

--- a/apps/api/src/services/source_validator_service.py
+++ b/apps/api/src/services/source_validator_service.py
@@ -73,19 +73,28 @@ class SourceValidatorService:
 				"Example: https://example.com/article"
 			)
 
-	def _validate_url_not_internal(self, url: str) -> None:
+	def _validate_url_not_internal(
+		self, url: str, *, block_on_resolution_failure: bool = False
+	) -> None:
 		"""
 		Reject URLs that resolve to internal/non-public addresses (SSRF guard).
 
 		Args:
 			url: URL string to validate
+			block_on_resolution_failure: Set True on fetch paths (e.g. redirect
+				hops about to be requested) so an unresolvable host is rejected
+				rather than allowed through to the outbound request.
 
 		Raises:
 			URLValidationError: If the URL targets a private/loopback/link-local/
 				reserved address or a non-standard port (issue #206).
 		"""
 		try:
-			validate_public_url(url, allowed_ports={80, 443})
+			validate_public_url(
+				url,
+				allowed_ports={80, 443},
+				block_on_resolution_failure=block_on_resolution_failure,
+			)
 		except SSRFValidationError as exc:
 			raise URLValidationError(
 				f"URL is not allowed: {exc}. "
@@ -127,7 +136,10 @@ class SourceValidatorService:
 							)
 						current_url = urljoin(current_url, location)
 						# Re-validate every redirect hop against the SSRF guard.
-						self._validate_url_not_internal(current_url)
+						# This is a fetch path, so block unresolvable hops too.
+						self._validate_url_not_internal(
+							current_url, block_on_resolution_failure=True
+						)
 						continue
 
 					if not (200 <= response.status_code < 300):

--- a/apps/api/src/services/source_validator_service.py
+++ b/apps/api/src/services/source_validator_service.py
@@ -7,9 +7,11 @@ keys before content sources are persisted. Implements GAP-015.
 
 import logging
 from typing import Optional, Tuple
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import httpx
+
+from ..utils.ssrf import SSRFValidationError, validate_public_url
 
 logger = logging.getLogger(__name__)
 
@@ -71,30 +73,75 @@ class SourceValidatorService:
 				"Example: https://example.com/article"
 			)
 
+	def _validate_url_not_internal(self, url: str) -> None:
+		"""
+		Reject URLs that resolve to internal/non-public addresses (SSRF guard).
+
+		Args:
+			url: URL string to validate
+
+		Raises:
+			URLValidationError: If the URL targets a private/loopback/link-local/
+				reserved address or a non-standard port (issue #206).
+		"""
+		try:
+			validate_public_url(url, allowed_ports={80, 443})
+		except SSRFValidationError as exc:
+			raise URLValidationError(
+				f"URL is not allowed: {exc}. "
+				f"Provide a publicly accessible http(s) URL on a standard port."
+			) from exc
+
+	# Redirect status codes that carry a Location header to follow.
+	_REDIRECT_STATUS = (301, 302, 303, 307, 308)
+
 	async def _check_url_accessibility(self, url: str) -> None:
 		"""
-		Issue a HEAD request to verify the URL is publicly reachable.
+		Verify the URL is publicly reachable, following redirects manually.
+
+		Redirects are not auto-followed: each hop's target is re-validated with
+		the SSRF guard before it is requested, so a public URL cannot redirect
+		into an internal address (issue #206).
 
 		Args:
 			url: URL to check
 
 		Raises:
-			URLValidationError: If the URL is not accessible
+			URLValidationError: If the URL is not accessible or redirects to a
+				disallowed target.
 		"""
+		current_url = url
 		try:
 			async with httpx.AsyncClient(
 				timeout=self.URL_FETCH_TIMEOUT,
-				follow_redirects=True,
-				max_redirects=self.MAX_REDIRECT_HOPS,
+				follow_redirects=False,
 			) as client:
-				response = await client.head(url)
+				for _ in range(self.MAX_REDIRECT_HOPS + 1):
+					response = await client.head(current_url)
 
-			if not (200 <= response.status_code < 300):
-				raise URLValidationError(
-					f"URL returned HTTP {response.status_code}. "
-					f"Expected 2xx success response. "
-					f"Is the URL correct and publicly accessible?"
-				)
+					if response.status_code in self._REDIRECT_STATUS:
+						location = response.headers.get("location")
+						if not location:
+							raise URLValidationError(
+								"URL returned a redirect without a destination."
+							)
+						current_url = urljoin(current_url, location)
+						# Re-validate every redirect hop against the SSRF guard.
+						self._validate_url_not_internal(current_url)
+						continue
+
+					if not (200 <= response.status_code < 300):
+						raise URLValidationError(
+							f"URL returned HTTP {response.status_code}. "
+							f"Expected 2xx success response. "
+							f"Is the URL correct and publicly accessible?"
+						)
+					return
+
+			raise URLValidationError(
+				f"URL has too many redirects (max {self.MAX_REDIRECT_HOPS}). "
+				f"Check that the URL is correct and does not have redirect loops."
+			)
 
 		except URLValidationError:
 			raise
@@ -172,6 +219,7 @@ class SourceValidatorService:
 			URLValidationError: If validation fails
 		"""
 		self._validate_url_format(url)
+		self._validate_url_not_internal(url)
 		await self._check_url_accessibility(url)
 		return True, None
 

--- a/apps/api/src/tasks/platform_distribution.py
+++ b/apps/api/src/tasks/platform_distribution.py
@@ -326,6 +326,21 @@ def _distribute_via_webhook(episode_id: str, config: Dict, metadata: Dict, task:
     if not webhook_url:
         raise ValueError("Webhook URL not provided in config")
 
+    # SSRF guard (issue #206): re-validate at dispatch time to defeat DNS
+    # rebinding since the target was created/validated. Reject internal hosts
+    # and non-standard ports; redirects are disabled below so a public host
+    # cannot bounce the request into an internal address.
+    from ..utils.ssrf import SSRFValidationError, validate_public_url
+    try:
+        validate_public_url(
+            webhook_url,
+            allowed_schemes=("https",),
+            allowed_ports={443},
+            block_on_resolution_failure=True,
+        )
+    except SSRFValidationError as exc:
+        raise ValueError(f"Webhook URL is not allowed: {exc}") from exc
+
     headers = config.get('headers', {})
     method = config.get('method', 'POST')
 
@@ -335,11 +350,15 @@ def _distribute_via_webhook(episode_id: str, config: Dict, metadata: Dict, task:
         "event": "episode_published"
     }
 
-    # Send webhook with episode data
+    # Send webhook with episode data (redirects disabled to prevent SSRF bounce)
     if method == "POST":
-        response = requests.post(webhook_url, json=payload, headers=headers, timeout=30)
+        response = requests.post(
+            webhook_url, json=payload, headers=headers, timeout=30, allow_redirects=False
+        )
     else:
-        response = requests.get(webhook_url, headers=headers, params=payload, timeout=30)
+        response = requests.get(
+            webhook_url, headers=headers, params=payload, timeout=30, allow_redirects=False
+        )
 
     response.raise_for_status()
 

--- a/apps/api/src/utils/ssrf.py
+++ b/apps/api/src/utils/ssrf.py
@@ -1,0 +1,164 @@
+"""
+SSRF (Server-Side Request Forgery) guard utilities.
+
+User-supplied URLs (content sources, webhook distribution targets) are fetched
+server-side. Without protection an authenticated tenant user could point them at
+loopback, link-local, private, or reserved addresses — notably the cloud
+metadata endpoint http://169.254.169.254/ — to read internal services or trigger
+internal POST endpoints (issue #206).
+
+This module resolves a URL's host and rejects it if *any* resolved address is
+not a public/global IP, or if the scheme/port is not allowed. It is invoked at
+both validation time (before persisting a source/target) and dispatch time
+(immediately before the outbound request) so that DNS rebinding between the two
+points is also caught.
+
+Unresolvable hosts (NXDOMAIN) are intentionally *allowed* here: there is no IP
+to connect to, so they are not an SSRF target, and rejecting them would break
+legitimate not-yet-provisioned hostnames. The actual fetch fails naturally, and
+a host that later resolves to an internal IP is caught by the dispatch-time
+re-check.
+"""
+
+import ipaddress
+import logging
+import socket
+from typing import Iterable, List, Optional
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+
+class SSRFValidationError(ValueError):
+	"""Raised when a URL targets a disallowed (internal/non-public) address."""
+
+	pass
+
+
+# Default ports permitted for outbound fetches. Non-standard ports are rejected
+# to prevent reaching internal services bound to unusual ports.
+DEFAULT_ALLOWED_SCHEMES = ("http", "https")
+DEFAULT_ALLOWED_PORTS = frozenset({80, 443})
+
+# Default port to assume when a URL omits one, keyed by scheme.
+_SCHEME_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def is_public_ip(ip: str) -> bool:
+	"""
+	Return True only if ``ip`` is a globally routable public address.
+
+	Rejects loopback, link-local (incl. 169.254.169.254), private (RFC1918 /
+	ULA / CGNAT), reserved, multicast, and unspecified addresses. IPv4-mapped
+	IPv6 addresses are unwrapped and evaluated as their IPv4 form.
+	"""
+	try:
+		addr = ipaddress.ip_address(ip)
+	except ValueError:
+		return False
+
+	# Unwrap IPv4-mapped IPv6 (e.g. ::ffff:169.254.169.254) so the embedded
+	# IPv4 address is evaluated against the same rules.
+	if addr.version == 6:
+		mapped = getattr(addr, "ipv4_mapped", None)
+		if mapped is not None:
+			addr = mapped
+
+	# is_global is the authoritative "globally reachable" check: it excludes
+	# loopback, link-local (incl. 169.254.169.254), private (RFC1918 / ULA),
+	# CGNAT (100.64/10), reserved, multicast, and unspecified ranges.
+	return addr.is_global
+
+
+def _resolve_host(host: str, port: Optional[int]) -> List[str]:
+	"""
+	Resolve ``host`` to its IP addresses.
+
+	Returns the list of resolved IP strings, or an empty list if the host
+	cannot be resolved (NXDOMAIN). IP-literal hosts resolve without network
+	access.
+	"""
+	try:
+		infos = socket.getaddrinfo(host, port or 0, proto=socket.IPPROTO_TCP)
+	except socket.gaierror:
+		return []
+	return sorted({info[4][0] for info in infos})
+
+
+def validate_public_url(
+	url: str,
+	*,
+	allowed_schemes: Iterable[str] = DEFAULT_ALLOWED_SCHEMES,
+	allowed_ports: Iterable[int] = DEFAULT_ALLOWED_PORTS,
+	block_on_resolution_failure: bool = False,
+) -> List[str]:
+	"""
+	Validate that ``url`` targets only public addresses on an allowed scheme/port.
+
+	Args:
+		url: The URL to validate.
+		allowed_schemes: Permitted URL schemes (default http + https).
+		allowed_ports: Permitted ports (default 80 + 443). A URL without an
+			explicit port uses the scheme's default port for this check.
+		block_on_resolution_failure: When True, an unresolvable host raises
+			rather than being allowed. Use this on dispatch paths (the actual
+			outbound fetch), where a host that fails the guard's lookup but
+			resolves to an internal IP on the real request would otherwise slip
+			through. Validation-time callers leave this False so not-yet-
+			provisioned hostnames are not rejected outright.
+
+	Returns:
+		The list of resolved public IP addresses (empty only when the host is
+		unresolvable and ``block_on_resolution_failure`` is False).
+
+	Raises:
+		SSRFValidationError: If the scheme/port is not allowed, any resolved
+			address is not a public IP, or the host is unresolvable while
+			``block_on_resolution_failure`` is True.
+	"""
+	if not url or not url.strip():
+		raise SSRFValidationError("URL cannot be empty")
+
+	try:
+		parsed = urlparse(url)
+	except ValueError as exc:
+		raise SSRFValidationError(f"Invalid URL: {exc}") from exc
+
+	allowed_schemes = tuple(s.lower() for s in allowed_schemes)
+	scheme = (parsed.scheme or "").lower()
+	if scheme not in allowed_schemes:
+		raise SSRFValidationError(
+			f"URL scheme '{parsed.scheme}' is not allowed "
+			f"(allowed: {', '.join(allowed_schemes)})"
+		)
+
+	host = parsed.hostname
+	if not host:
+		raise SSRFValidationError("URL is missing a host")
+
+	try:
+		port = parsed.port
+	except ValueError as exc:
+		raise SSRFValidationError(f"Invalid port in URL: {exc}") from exc
+
+	effective_port = port if port is not None else _SCHEME_DEFAULT_PORTS.get(scheme)
+	allowed_ports = frozenset(allowed_ports)
+	if effective_port not in allowed_ports:
+		raise SSRFValidationError(
+			f"URL port {effective_port} is not allowed "
+			f"(allowed: {', '.join(str(p) for p in sorted(allowed_ports))})"
+		)
+
+	resolved = _resolve_host(host, effective_port)
+	if not resolved and block_on_resolution_failure:
+		raise SSRFValidationError(
+			f"URL host '{host}' could not be resolved and cannot be fetched"
+		)
+	for ip in resolved:
+		if not is_public_ip(ip):
+			raise SSRFValidationError(
+				f"URL host '{host}' resolves to a non-public address "
+				f"and cannot be fetched"
+			)
+
+	return resolved

--- a/apps/api/tests/test_content_extraction.py
+++ b/apps/api/tests/test_content_extraction.py
@@ -22,6 +22,7 @@ from src.services.content_extraction_service import (
 	ExtractionResult
 )
 from src.models import ContentSource
+from src.utils.ssrf import SSRFValidationError
 
 
 # ============================================================================
@@ -108,7 +109,7 @@ async def test_extract_from_url_success(
 
 	with patch('src.services.content_extraction_service.get_content_source_by_id') as mock_get, \
 		 patch('src.services.content_extraction_service.update_content_source') as mock_update, \
-		 patch.object(extraction_service.website_extractor, 'extract_content', return_value=extracted_text):
+		 patch.object(extraction_service, '_fetch_and_extract_safely', return_value=extracted_text):
 
 		mock_get.return_value = url_content_source
 
@@ -135,6 +136,66 @@ async def test_extract_from_url_success(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("internal_url", [
+	"http://169.254.169.254/latest/meta-data/",
+	"http://127.0.0.1/",
+	"http://10.0.0.1/admin",
+	"http://192.168.1.1/",
+])
+async def test_extract_from_url_blocks_ssrf(
+	extraction_service,
+	mock_db,
+	url_content_source,
+	internal_url,
+):
+	"""Internal/metadata URLs must be blocked at extraction dispatch (issue #206)."""
+	url_content_source.source_data = {'url': internal_url, 'title': 'x'}
+
+	with patch('src.services.content_extraction_service.get_content_source_by_id') as mock_get, \
+		 patch('src.services.content_extraction_service.update_content_source') as mock_update, \
+		 patch.object(extraction_service, '_fetch_and_extract_safely') as mock_extract:
+
+		mock_get.return_value = url_content_source
+
+		result = await extraction_service.extract_from_url(mock_db, url_content_source.id)
+
+		assert result.success is False
+		assert "not allowed" in result.error_message.lower()
+		# The underlying fetcher must never be reached.
+		mock_extract.assert_not_called()
+		# Status must be marked failed.
+		final_call = mock_update.call_args_list[-1]
+		assert final_call[0][2].extraction_status == 'failed'
+
+
+def test_fetch_and_extract_safely_blocks_redirect_to_internal(extraction_service):
+	"""SSRF: a redirect whose target is internal must be blocked mid-fetch (issue #206)."""
+	redirect = Mock()
+	redirect.status_code = 302
+	redirect.headers = {"location": "http://169.254.169.254/latest/meta-data/"}
+
+	with patch("src.services.content_extraction_service.requests.get", return_value=redirect):
+		with pytest.raises(SSRFValidationError):
+			extraction_service._fetch_and_extract_safely("https://93.184.216.34/start")
+
+
+def test_fetch_and_extract_safely_follows_safe_redirect(extraction_service):
+	"""A redirect to another public URL is followed and its content extracted."""
+	redirect = Mock()
+	redirect.status_code = 302
+	redirect.headers = {"location": "https://8.8.8.8/final"}
+	ok = Mock()
+	ok.status_code = 200
+	ok.text = "<html><body><p>Hello world content</p></body></html>"
+	ok.raise_for_status = Mock()
+
+	with patch("src.services.content_extraction_service.requests.get", side_effect=[redirect, ok]):
+		result = extraction_service._fetch_and_extract_safely("https://93.184.216.34/start")
+
+	assert "Hello world content" in result
+
+
+@pytest.mark.asyncio
 async def test_extract_from_url_404_error(
 	extraction_service,
 	mock_db,
@@ -146,7 +207,7 @@ async def test_extract_from_url_404_error(
 
 	with patch('src.services.content_extraction_service.get_content_source_by_id') as mock_get, \
 		 patch('src.services.content_extraction_service.update_content_source') as mock_update, \
-		 patch.object(extraction_service.website_extractor, 'extract_content', side_effect=http_error):
+		 patch.object(extraction_service, '_fetch_and_extract_safely', side_effect=http_error):
 
 		mock_get.return_value = url_content_source
 
@@ -174,7 +235,7 @@ async def test_extract_from_url_timeout(
 
 	with patch('src.services.content_extraction_service.get_content_source_by_id') as mock_get, \
 		 patch('src.services.content_extraction_service.update_content_source') as mock_update, \
-		 patch.object(extraction_service.website_extractor, 'extract_content', side_effect=timeout_error):
+		 patch.object(extraction_service, '_fetch_and_extract_safely', side_effect=timeout_error):
 
 		mock_get.return_value = url_content_source
 
@@ -200,7 +261,7 @@ async def test_extract_from_url_403_error(
 
 	with patch('src.services.content_extraction_service.get_content_source_by_id') as mock_get, \
 		 patch('src.services.content_extraction_service.update_content_source'), \
-		 patch.object(extraction_service.website_extractor, 'extract_content', side_effect=http_error):
+		 patch.object(extraction_service, '_fetch_and_extract_safely', side_effect=http_error):
 
 		mock_get.return_value = url_content_source
 
@@ -223,7 +284,7 @@ async def test_extract_from_url_500_error(
 
 	with patch('src.services.content_extraction_service.get_content_source_by_id') as mock_get, \
 		 patch('src.services.content_extraction_service.update_content_source'), \
-		 patch.object(extraction_service.website_extractor, 'extract_content', side_effect=http_error):
+		 patch.object(extraction_service, '_fetch_and_extract_safely', side_effect=http_error):
 
 		mock_get.return_value = url_content_source
 
@@ -536,7 +597,7 @@ async def test_status_transition_url_success(
 	"""Test extraction status transitions: pending → extracting → complete."""
 	with patch('src.services.content_extraction_service.get_content_source_by_id') as mock_get, \
 		 patch('src.services.content_extraction_service.update_content_source') as mock_update, \
-		 patch.object(extraction_service.website_extractor, 'extract_content', return_value="content"):
+		 patch.object(extraction_service, '_fetch_and_extract_safely', return_value="content"):
 
 		mock_get.return_value = url_content_source
 
@@ -561,7 +622,7 @@ async def test_status_transition_url_failure(
 	"""Test extraction status transitions: pending → extracting → failed."""
 	with patch('src.services.content_extraction_service.get_content_source_by_id') as mock_get, \
 		 patch('src.services.content_extraction_service.update_content_source') as mock_update, \
-		 patch.object(extraction_service.website_extractor, 'extract_content', side_effect=Timeout()):
+		 patch.object(extraction_service, '_fetch_and_extract_safely', side_effect=Timeout()):
 
 		mock_get.return_value = url_content_source
 
@@ -613,7 +674,7 @@ async def test_database_update_error_message(
 	"""Test error_message column is updated on failure."""
 	with patch('src.services.content_extraction_service.get_content_source_by_id') as mock_get, \
 		 patch('src.services.content_extraction_service.update_content_source') as mock_update, \
-		 patch.object(extraction_service.website_extractor, 'extract_content', side_effect=Timeout()):
+		 patch.object(extraction_service, '_fetch_and_extract_safely', side_effect=Timeout()):
 
 		mock_get.return_value = url_content_source
 
@@ -636,7 +697,7 @@ async def test_database_update_clears_error_on_success(
 
 	with patch('src.services.content_extraction_service.get_content_source_by_id') as mock_get, \
 		 patch('src.services.content_extraction_service.update_content_source') as mock_update, \
-		 patch.object(extraction_service.website_extractor, 'extract_content', return_value="content"):
+		 patch.object(extraction_service, '_fetch_and_extract_safely', return_value="content"):
 
 		mock_get.return_value = url_content_source
 

--- a/apps/api/tests/test_distribution_targets.py
+++ b/apps/api/tests/test_distribution_targets.py
@@ -801,6 +801,34 @@ def test_webhook_create_http_rejected():
 	assert "https" in str(exc_info.value).lower() or "url" in str(exc_info.value).lower()
 
 
+@pytest.mark.parametrize("url", [
+	"https://169.254.169.254/",
+	"https://127.0.0.1/",
+	"https://10.0.0.1/hook",
+	"https://172.16.0.1/hook",
+	"https://192.168.1.1/hook",
+	"https://[::1]/",
+	"https://localhost/hook",
+])
+def test_webhook_create_internal_url_rejected(url):
+	"""SSRF: webhook URLs pointing at internal addresses are rejected (issue #206)."""
+	from src.schemas.distribution_target import WebhookDistributionCreate
+	import pydantic
+	with pytest.raises(pydantic.ValidationError) as exc_info:
+		WebhookDistributionCreate(name="Test", url=url, method="POST")
+	assert "not allowed" in str(exc_info.value).lower()
+
+
+def test_webhook_create_non_standard_port_rejected():
+	"""SSRF: non-standard ports are rejected for webhook URLs (issue #206)."""
+	from src.schemas.distribution_target import WebhookDistributionCreate
+	import pydantic
+	with pytest.raises(pydantic.ValidationError):
+		WebhookDistributionCreate(
+			name="Test", url="https://93.184.216.34:8443/hook", method="POST"
+		)
+
+
 def test_webhook_create_invalid_method():
 	"""Test that invalid HTTP method is rejected."""
 	from src.schemas.distribution_target import WebhookDistributionCreate
@@ -963,3 +991,44 @@ async def test_webhook_connection_test_with_encrypted_headers(client, auth_heade
 		"Authorization header was not decrypted before sending test request"
 	assert sent_headers.get("Content-Type") == "application/json", \
 		"Content-Type header should remain as-is"
+
+
+# ============================================================================
+# WEBHOOK DISPATCH SSRF TESTS (issue #206)
+# ============================================================================
+
+@pytest.mark.parametrize("url", [
+	"https://169.254.169.254/latest/meta-data/",
+	"https://127.0.0.1/",
+	"https://10.0.0.1/hook",
+	"https://192.168.1.1/hook",
+])
+def test_distribute_via_webhook_blocks_internal(url):
+	"""SSRF: dispatch-time guard rejects internal webhook targets (issue #206)."""
+	from src.tasks.platform_distribution import _distribute_via_webhook
+
+	task = MagicMock()
+	config = {"url": url, "method": "POST"}
+
+	with patch("requests.post") as mock_post, patch("requests.get") as mock_get:
+		with pytest.raises(ValueError) as exc_info:
+			_distribute_via_webhook("ep-1", config, {"title": "x"}, task)
+		assert "not allowed" in str(exc_info.value).lower()
+		mock_post.assert_not_called()
+		mock_get.assert_not_called()
+
+
+def test_distribute_via_webhook_disables_redirects_for_public():
+	"""Public webhook dispatch must disable redirects to prevent SSRF bounce."""
+	from src.tasks.platform_distribution import _distribute_via_webhook
+
+	task = MagicMock()
+	config = {"url": "https://93.184.216.34/hook", "method": "POST"}
+	resp = MagicMock()
+	resp.raise_for_status = MagicMock()
+
+	with patch("requests.post", return_value=resp) as mock_post:
+		result = _distribute_via_webhook("ep-1", config, {"title": "x"}, task)
+
+	assert result["status"] == "success"
+	assert mock_post.call_args.kwargs.get("allow_redirects") is False

--- a/apps/api/tests/unit/test_source_validation.py
+++ b/apps/api/tests/unit/test_source_validation.py
@@ -501,3 +501,102 @@ def test_url_timeout_error_includes_seconds():
 		"Website may be slow or unavailable. Try again later."
 	)
 	assert str(validator.URL_FETCH_TIMEOUT) in msg
+
+
+# ===========================================================================
+# SSRF protection (issue #206)
+# ===========================================================================
+
+
+@pytest.mark.parametrize("url", [
+	"http://169.254.169.254/latest/meta-data/",
+	"https://169.254.169.254/",
+	"http://127.0.0.1/",
+	"http://10.0.0.1/admin",
+	"http://172.16.0.1/",
+	"http://192.168.1.1/",
+	"http://[::1]/",
+	"http://localhost/",
+])
+def test_validate_url_not_internal_rejects(url):
+	"""Internal/metadata URLs must be rejected by the SSRF guard."""
+	validator = make_validator()
+	with pytest.raises(URLValidationError) as exc_info:
+		validator._validate_url_not_internal(url)
+	assert "not allowed" in str(exc_info.value).lower()
+
+
+def test_validate_url_not_internal_rejects_non_standard_port():
+	"""Non-standard ports are rejected (issue #206)."""
+	validator = make_validator()
+	with pytest.raises(URLValidationError):
+		validator._validate_url_not_internal("http://93.184.216.34:8080/")
+
+
+def test_validate_url_not_internal_allows_public():
+	"""Public IP literal on a standard port passes."""
+	validator = make_validator()
+	# Should not raise
+	validator._validate_url_not_internal("https://93.184.216.34/article")
+
+
+@pytest.mark.asyncio
+async def test_validate_url_source_rejects_metadata_endpoint():
+	"""validate_url_source rejects the cloud metadata endpoint before any fetch."""
+	validator = make_validator()
+	with pytest.raises(URLValidationError):
+		await validator.validate_url_source(
+			"http://169.254.169.254/latest/meta-data/", "Title"
+		)
+
+
+@pytest.mark.asyncio
+async def test_validate_by_type_url_rejects_internal_ip():
+	"""validate_by_type rejects RFC1918 content URLs."""
+	validator = make_validator()
+	with pytest.raises(URLValidationError):
+		await validator.validate_by_type(
+			source_type='url',
+			source_data={'url': 'http://10.0.0.1/', 'title': 'Test'},
+		)
+
+
+@pytest.mark.asyncio
+async def test_check_url_accessibility_rejects_redirect_to_internal():
+	"""A redirect whose target is an internal address must be rejected."""
+	validator = make_validator()
+	redirect_response = MagicMock()
+	redirect_response.status_code = 302
+	redirect_response.headers = {"location": "http://169.254.169.254/latest/meta-data/"}
+
+	with patch("src.services.source_validator_service.httpx.AsyncClient") as mock_client_cls:
+		mock_client = AsyncMock()
+		mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+		mock_client.__aexit__ = AsyncMock(return_value=None)
+		mock_client.head = AsyncMock(return_value=redirect_response)
+		mock_client_cls.return_value = mock_client
+
+		with pytest.raises(URLValidationError) as exc_info:
+			await validator._check_url_accessibility("https://93.184.216.34/start")
+	assert "not allowed" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_check_url_accessibility_follows_safe_redirect():
+	"""A redirect to another public URL ending in 2xx should be accepted."""
+	validator = make_validator()
+	redirect_response = MagicMock()
+	redirect_response.status_code = 302
+	redirect_response.headers = {"location": "https://8.8.8.8/final"}
+	ok_response = MagicMock()
+	ok_response.status_code = 200
+
+	with patch("src.services.source_validator_service.httpx.AsyncClient") as mock_client_cls:
+		mock_client = AsyncMock()
+		mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+		mock_client.__aexit__ = AsyncMock(return_value=None)
+		mock_client.head = AsyncMock(side_effect=[redirect_response, ok_response])
+		mock_client_cls.return_value = mock_client
+
+		# Should not raise
+		await validator._check_url_accessibility("https://93.184.216.34/start")

--- a/apps/api/tests/unit/test_ssrf_guard.py
+++ b/apps/api/tests/unit/test_ssrf_guard.py
@@ -1,0 +1,186 @@
+"""
+Unit tests for the SSRF guard (src.utils.ssrf).
+
+Implements the protections required by issue #206: resolve the host and reject
+loopback / link-local / private / reserved IP targets (including the cloud
+metadata endpoint 169.254.169.254) and non-standard ports — at validation and
+dispatch time.
+
+IP-literal hosts resolve offline via getaddrinfo, so these tests are
+deterministic and require no network access.
+"""
+
+import os
+
+# Set required env vars before any src import
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://x:x@localhost/x")
+os.environ.setdefault("ENCRYPTION_KEY", "a" * 32)
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-unit-tests")
+
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from src.utils.ssrf import (
+	SSRFValidationError,
+	is_public_ip,
+	validate_public_url,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_public_ip
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+	"ip",
+	[
+		"169.254.169.254",   # AWS/GCP metadata (link-local)
+		"127.0.0.1",         # loopback
+		"0.0.0.0",           # unspecified
+		"10.0.0.1",          # RFC1918
+		"172.16.0.1",        # RFC1918
+		"192.168.1.1",       # RFC1918
+		"100.64.0.1",        # CGNAT (RFC6598)
+		"::1",               # IPv6 loopback
+		"fd00::1",           # IPv6 ULA (private)
+		"fe80::1",           # IPv6 link-local
+		"::ffff:169.254.169.254",  # IPv4-mapped metadata
+		"::ffff:127.0.0.1",        # IPv4-mapped loopback
+	],
+)
+def test_internal_ips_are_not_public(ip):
+	assert is_public_ip(ip) is False
+
+
+@pytest.mark.parametrize(
+	"ip",
+	[
+		"104.20.23.154",     # public IPv4
+		"8.8.8.8",           # public IPv4
+		"2606:4700:10::6814:179a",  # public IPv6
+	],
+)
+def test_public_ips_are_public(ip):
+	assert is_public_ip(ip) is True
+
+
+# ---------------------------------------------------------------------------
+# validate_public_url — internal targets rejected
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+	"url",
+	[
+		"http://169.254.169.254/latest/meta-data/",
+		"https://169.254.169.254/",
+		"http://127.0.0.1/",
+		"https://127.0.0.1/admin",
+		"http://10.0.0.1/",
+		"http://172.16.5.4/",
+		"http://192.168.1.1/",
+		"http://[::1]/",
+		"http://[::ffff:169.254.169.254]/",
+		"http://0.0.0.0/",
+	],
+)
+def test_validate_public_url_rejects_internal(url):
+	with pytest.raises(SSRFValidationError):
+		validate_public_url(url)
+
+
+def test_validate_public_url_rejects_localhost_hostname():
+	# localhost resolves to 127.0.0.1 via /etc/hosts (offline)
+	with pytest.raises(SSRFValidationError):
+		validate_public_url("http://localhost/")
+
+
+def test_validate_public_url_rejects_decimal_ip_form():
+	# 2130706433 == 127.0.0.1; getaddrinfo normalizes numeric forms
+	with pytest.raises(SSRFValidationError):
+		validate_public_url("http://2130706433/")
+
+
+# ---------------------------------------------------------------------------
+# validate_public_url — scheme & port rules
+# ---------------------------------------------------------------------------
+
+def test_validate_public_url_rejects_non_http_scheme():
+	with pytest.raises(SSRFValidationError):
+		validate_public_url("ftp://example.com/")
+
+
+def test_validate_public_url_rejects_non_standard_port():
+	with pytest.raises(SSRFValidationError):
+		validate_public_url("http://93.184.216.34:8080/")
+
+
+def test_validate_public_url_https_only_rejects_http():
+	with pytest.raises(SSRFValidationError):
+		validate_public_url(
+			"http://93.184.216.34/", allowed_schemes=("https",), allowed_ports={443}
+		)
+
+
+def test_validate_public_url_https_only_rejects_8443():
+	with pytest.raises(SSRFValidationError):
+		validate_public_url(
+			"https://93.184.216.34:8443/",
+			allowed_schemes=("https",),
+			allowed_ports={443},
+		)
+
+
+def test_validate_public_url_rejects_empty():
+	with pytest.raises(SSRFValidationError):
+		validate_public_url("")
+
+
+# ---------------------------------------------------------------------------
+# validate_public_url — public targets allowed
+# ---------------------------------------------------------------------------
+
+def test_validate_public_url_allows_public_ip_literal():
+	ips = validate_public_url("https://93.184.216.34/")
+	assert "93.184.216.34" in ips
+
+
+def test_validate_public_url_allows_public_with_default_https_port():
+	# No explicit port -> default 443 allowed for https-only callers
+	ips = validate_public_url(
+		"https://93.184.216.34/path",
+		allowed_schemes=("https",),
+		allowed_ports={443},
+	)
+	assert ips == ["93.184.216.34"]
+
+
+def test_validate_public_url_allows_unresolvable_host():
+	# NXDOMAIN: no IP to attack. Must NOT raise — dispatch-time re-check
+	# covers DNS rebinding. Returns empty list.
+	with patch("src.utils.ssrf.socket.getaddrinfo", side_effect=socket.gaierror):
+		assert validate_public_url("https://hooks.example.com/notify") == []
+
+
+def test_validate_public_url_blocks_unresolvable_when_strict():
+	# Dispatch paths set block_on_resolution_failure=True: NXDOMAIN must raise.
+	with patch("src.utils.ssrf.socket.getaddrinfo", side_effect=socket.gaierror):
+		with pytest.raises(SSRFValidationError):
+			validate_public_url(
+				"https://hooks.example.com/notify",
+				block_on_resolution_failure=True,
+			)
+
+
+def test_validate_public_url_rejects_when_any_resolved_ip_is_private():
+	# DNS rebinding: one public + one private A record -> reject.
+	def fake_getaddrinfo(host, port, *a, **k):
+		return [
+			(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443)),
+			(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 443)),
+		]
+
+	with patch("src.utils.ssrf.socket.getaddrinfo", side_effect=fake_getaddrinfo):
+		with pytest.raises(SSRFValidationError):
+			validate_public_url("https://rebind.example.com/")


### PR DESCRIPTION
Closes #206.

## Problem
Two SSRF vectors (P1, release blocker): user-supplied **content-source URLs** and **webhook distribution targets** were fetched server-side after only scheme/`https://`-prefix validation. Any authenticated tenant user could target loopback, link-local, private, or reserved hosts — notably the cloud metadata endpoint `http://169.254.169.254/latest/meta-data/` — to read internal response bodies (content path) or trigger internal POST endpoints (webhook path).

## Fix
New shared guard **`apps/api/src/utils/ssrf.py`** — `validate_public_url()` resolves the host and rejects any target whose resolved address is not globally routable (loopback / link-local incl. `169.254.169.254` / RFC1918 / ULA / CGNAT / reserved / multicast / unspecified, incl. IPv4-mapped IPv6) and any non-standard port. Enforced at **both validation and dispatch time**:

| Path | Validation time | Dispatch / fetch time |
|------|-----------------|------------------------|
| Content URL | `SourceValidatorService.validate_url_source` | `_check_url_accessibility` follows redirects manually & validates each hop; `ContentExtractionService._fetch_and_extract_safely` fetches with `allow_redirects=False`, validating every hop (replaces podcastfy's redirect-following fetch) |
| Webhook | `WebhookDistributionCreate` schema (https/443 only) | `_distribute_via_webhook` re-checks + `allow_redirects=False` |

Dispatch paths use `block_on_resolution_failure=True` (a host that fails the guard lookup but resolves to an internal IP must not slip through). Validation paths stay lenient on NXDOMAIN so not-yet-provisioned hostnames aren't rejected outright (and existing webhook tests using `*.example.com` keep working).

## Acceptance criteria
- [x] Resolve host; reject loopback/link-local/private/reserved IPs (incl. 169.254.169.254) and non-standard ports — at validation **and** dispatch time.
- [x] Disallow redirects to internal targets (all client redirect-following is now manual + validated per hop).
- [x] Tests asserting metadata/RFC1918/loopback URLs are rejected for **both** content sources and webhook targets.

## Tests
- `tests/unit/test_ssrf_guard.py` — guard unit tests (metadata, RFC1918, loopback, CGNAT, ULA, link-local, IPv4-mapped IPv6, decimal-IP form, non-standard ports, multi-A rebinding, strict NXDOMAIN).
- `tests/unit/test_source_validation.py` — content-URL rejection at validation + redirect-to-internal rejection.
- `tests/test_content_extraction.py` — extraction dispatch block + safe-fetcher redirect handling.
- `tests/test_distribution_targets.py` — webhook schema + dispatch rejection.

Full backend suite: **1414 passed**, 7 skipped, 1 pre-existing unrelated failure (`test_audio_snippets.py::test_download_url_no_s3_config` — fails on `main` too, audio-snippets S3 subsystem, out of scope). Ruff clean.

Reviewed cross-family with `codex review` (two P1s found and fixed: NXDOMAIN-at-dispatch, podcastfy redirect-following).

## Known limitation
Residual **DNS-rebinding TOCTOU**: the client re-resolves the hostname at connect time, so a TTL-0 rebinding attacker could return a public IP to the guard and an internal IP to the actual connection. Mitigated (not eliminated) by strict dispatch-time re-validation, per-hop validation, and checking all resolved records. Full elimination requires TLS-aware IP pinning — tracked in **#234**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Added stronger SSRF protections to block internal/private/metadata destinations during webhook creation and dispatch.
- URL validation now rejects internal or non-public targets before attempting accessibility checks, including redirect hops.
- Content extraction now performs SSRF-safe fetching with redirect validation and limits, preventing bypass via redirects.
- Webhook requests no longer follow redirects, reducing the chance of reaching unintended internal hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->