### PR TITLE
docs: track #234 as P4.7 (DNS-rebinding SSRF IP-pinning fast-follow)

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -22,7 +22,7 @@ so issue order == work order.
 - [x] **P1.1 #207** Rotate live AWS/OpenAI/ElevenLabs/Gemini/Transistor keys ✅ done 2026-06-14 (old AWS key deactivated; verified never committed to git; S3 object policy added)
       → **Frank rotates** (deactivate the flagged AWS access key — ID is in issue #207 — in IAM). Secret scanner ✅ done (see below).
 - [ ] **P1.2 #205** JWT verification ignores `type` claim — verification/refresh tokens usable as access tokens
-- [ ] **P1.3 #206** SSRF — content URLs + webhook targets fetched server-side, no private-IP/metadata block
+- [x] **P1.3 #206** SSRF — content URLs + webhook targets fetched server-side, no private-IP/metadata block ✅ done 2026-06-14 (PR #235; guard at validation+dispatch, redirects constrained; residual DNS-rebinding tracked as P4.7 #234)
 - [ ] **P1.4 #212** Backend JWT exposed to browser JS (NextAuth session) + leaked in SSE `?token=` URL
 
 ## Phase 2 — Restore the core product (generation pipeline)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -45,6 +45,7 @@ so issue order == work order.
 - [ ] **P4.4 #218** Invitation acceptance not bound to invited email; team tables lack RLS backstop
 - [ ] **P4.5 #219** `expires_in` hardcoded 86400 but JWT expires in 30 min *(relates to #205)*
 - [ ] **P4.6 #222** No server-side route protection (middleware) for the `(auth)` group — defense-in-depth
+- [ ] **P4.7 #234** IP-pin outbound fetches to close the residual DNS-rebinding SSRF TOCTOU *(fast-follow to #206/P1.3, which is done; core SSRF already mitigated — this is defense-in-depth, not a release blocker)*
 
 ## Phase 5 — UX, tech-debt, docs
 - [ ] **P5.1 #221** TTS "Save Configuration" creates broken ElevenLabs configs (no voice-ID input) *(do after #217)*
@@ -59,6 +60,7 @@ so issue order == work order.
 - `#221` (P5.1) is only meaningful once `#217` (P2.3) forwards TTS config.
 - `#210` (P2.5) needs `StorageService.download_file` wired (already exists, unused).
 - `#225` (P5.4) last — so docs describe the fixed system.
+- `#234` (P4.7) depends on `#206` (P1.3, done) — IP-pinning hardening of the shipped SSRF guard.
 
 ## Secrets / secret-scanner status
 - ✅ **gitleaks pre-commit hook installed** (`.pre-commit-config.yaml`, `pre-commit install` run). gitleaks


### PR DESCRIPTION
Adds **P4.7 #234** to the release-readiness plan (`tasks/todo.md`) so issue-order stays work-order.

#234 is the IP-pinning hardening that closes the residual DNS-rebinding SSRF TOCTOU left by #206 (P1.3, merged via #235). Placed in Phase 4 (correctness/authz mediums, `priority-p2`) rather than Phase 1 because the core SSRF is already mitigated and tested — this is defense-in-depth, not a release blocker. Depends on #206 (done).

Mirrors the incremental plan-update pattern from #232 (`de17863`, mark P1.1 done).