### PR TITLE
fix(api): /regenerate calls generate_podcast with keyword args (#213)

### DIFF
--- a/apps/api/src/routers/generation.py
+++ b/apps/api/src/routers/generation.py
@@ -224,24 +224,24 @@ async def regenerate_podcast(
     """
     Regenerate podcast for an episode
 
-    Resets generation status and restarts the generation process
+    Restarts the generation process by delegating to ``generate_podcast``, which
+    validates the episode's content sources and resets ``generation_status`` to
+    ``"queued"`` with fresh progress.
+
+    We intentionally do NOT pre-reset the episode to ``"draft"`` before delegating.
+    ``generate_podcast`` can raise (404 missing episode, 400 no usable content)
+    before it queues anything; committing a status/progress reset first would leave
+    the episode degraded on those failures (issue #213). Delegating directly keeps
+    the episode untouched unless generation is actually queued.
     """
-    # Get episode
-    result = await db.execute(
-        select(Episode).where(
-            Episode.id == episode_id,
-            Episode.tenant_id == current_user.tenant_id,
-        )
+    # Delegate with explicit keyword arguments. ``generate_podcast`` inserts the
+    # ``enable_composition`` / ``enable_distribution`` Query params between
+    # ``episode_id`` and ``current_user``; positional binding would misalign the
+    # arguments and pass the Depends() sentinels as ``current_user`` / ``db``.
+    return await generate_podcast(
+        episode_id=episode_id,
+        enable_composition=False,
+        enable_distribution=False,
+        current_user=current_user,
+        db=db,
     )
-    episode = result.scalar_one_or_none()
-
-    if not episode:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Episode not found")
-
-    # Reset generation status
-    episode.generation_status = "draft"
-    episode.generation_progress = {}
-    await db.commit()
-
-    # Call generate endpoint
-    return await generate_podcast(episode_id, current_user, db)

--- a/apps/api/tests/test_regenerate_endpoint.py
+++ b/apps/api/tests/test_regenerate_endpoint.py
@@ -1,0 +1,159 @@
+"""
+Integration tests for the ``/generation/episodes/{id}/regenerate`` endpoint.
+
+Covers issue #213: ``regenerate_podcast`` previously called ``generate_podcast``
+with positional arguments, which misaligned against the ``enable_composition`` /
+``enable_distribution`` Query params and passed the unresolved ``Depends()``
+sentinels as ``current_user`` / ``db`` — crashing with a 500 and (because the
+status reset committed first) leaving the episode degraded. The endpoint now
+delegates with explicit keyword arguments and does not pre-reset the episode.
+"""
+
+import pytest
+from typing import Any
+from uuid import uuid4
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import HTTPException
+from httpx import AsyncClient
+
+from src.routers.generation import regenerate_podcast
+
+Headers = dict[str, str]
+
+# Long enough to satisfy the text source validator (>=50 chars, >=10 words).
+SAMPLE_TEXT = (
+    "This is a sufficiently long sample body of text that comfortably exceeds "
+    "the minimum length and word-count requirements for a podcast content source."
+)
+
+
+@pytest.fixture
+async def episode_with_content(client: AsyncClient) -> tuple[str, Headers]:
+    """Create user + project + episode + text content source.
+
+    Returns (episode_id, auth_headers). The text source lets ``generate_podcast``
+    pass content validation so regeneration reaches the dispatch path.
+    """
+    reg = await client.post("/auth/register", json={
+        "email": f"regen_{uuid4()}@example.com",
+        "password": "SecurePass123!",
+        "full_name": "Regen Tester",
+    })
+    assert reg.status_code == 201, reg.text
+    headers = {"Authorization": f"Bearer {reg.json()['access_token']}"}
+
+    proj = await client.post("/projects", headers=headers, json={
+        "name": "Regen Project",
+        "podcast_metadata": {
+            "show_title": "Regen Show",
+            "author": "Author",
+            "description": "Desc",
+        },
+    })
+    assert proj.status_code == 201, proj.text
+    project_id = proj.json()["id"]
+
+    ep = await client.post("/episodes", headers=headers, json={
+        "project_id": project_id,
+        "episode_number": 1,
+        "episode_metadata": {"title": "Ep", "description": "Episode"},
+    })
+    assert ep.status_code == 201, ep.text
+    episode_id = ep.json()["id"]
+
+    content = await client.post(
+        f"/episodes/{episode_id}/content?auto_extract=false",
+        headers=headers,
+        json={
+            "episode_id": episode_id,
+            "source_type": "text",
+            "source_data": {"content": SAMPLE_TEXT},
+        },
+    )
+    assert content.status_code == 201, content.text
+
+    return episode_id, headers
+
+
+@pytest.mark.asyncio
+async def test_regenerate_happy_path(client, episode_with_content):
+    """POST /regenerate queues generation and returns 202 with the episode id."""
+    episode_id, headers = episode_with_content
+
+    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+        mock_delay.return_value = MagicMock(id="task-regen-123")
+        resp = await client.post(
+            f"/generation/episodes/{episode_id}/regenerate", headers=headers
+        )
+
+    assert resp.status_code == 202, resp.text
+    body: dict[str, Any] = resp.json()
+    assert body["status"] == "queued"
+    assert body["episode_id"] == episode_id
+    mock_delay.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_regenerate_requires_authentication(client, episode_with_content):
+    """POST /regenerate without a token returns 401 (the prior bug returned 500)."""
+    episode_id, _ = episode_with_content
+
+    resp = await client.post(f"/generation/episodes/{episode_id}/regenerate")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_regenerate_nonexistent_episode(client, episode_with_content):
+    """POST /regenerate for an unknown episode returns 404."""
+    _, headers = episode_with_content
+    fake_episode_id = uuid4()
+
+    resp = await client.post(
+        f"/generation/episodes/{fake_episode_id}/regenerate", headers=headers
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_regenerate_does_not_degrade_episode_on_failure():
+    """A failed regenerate must not commit a degraded reset to the episode.
+
+    The original bug reset ``generation_status`` to ``"draft"`` and wiped
+    ``generation_progress`` and committed BEFORE delegating, so any subsequent
+    failure left the episode degraded. The fix delegates directly to
+    ``generate_podcast`` with no pre-reset, so when generation fails validation
+    (no content source -> HTTP 400) nothing is mutated or committed first.
+
+    Driven at the unit level: the shared test-DB transaction is rolled back on
+    any erroring request, so persisted state cannot be re-read through the API.
+    """
+    episode = MagicMock()
+    episode.generation_status = "complete"
+    episode.generation_progress = {"stage": "complete", "progress": 100}
+
+    # First db.execute -> episode lookup; second -> content sources (none).
+    episode_result = MagicMock()
+    episode_result.scalar_one_or_none.return_value = episode
+    content_result = MagicMock()
+    content_result.scalars.return_value.all.return_value = []
+
+    db = AsyncMock()
+    db.execute.side_effect = [episode_result, content_result]
+
+    current_user = MagicMock()
+    current_user.tenant_id = uuid4()
+
+    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+        with pytest.raises(HTTPException) as exc_info:
+            await regenerate_podcast(
+                episode_id=uuid4(), current_user=current_user, db=db
+            )
+
+    # No usable content -> 400, and crucially nothing was queued or committed,
+    # and the episode's status/progress were never reset to a degraded state.
+    assert exc_info.value.status_code == 400
+    mock_delay.assert_not_called()
+    db.commit.assert_not_called()
+    assert episode.generation_status == "complete"
+    assert episode.generation_progress == {"stage": "complete", "progress": 100}


### PR DESCRIPTION
## Summary

Fixes #213. The `POST /generation/episodes/{id}/regenerate` endpoint was broken (HTTP 500) and left episodes in a degraded state.

`regenerate_podcast` called `generate_podcast(episode_id, current_user, db)` positionally. But `generate_podcast` inserts two `Query` params (`enable_composition`, `enable_distribution`) between `episode_id` and `current_user`, so positional binding mapped:

- `current_user` → `enable_composition`
- `db` → `enable_distribution`

…and the real `current_user`/`db` fell back to their unresolved `Depends()` sentinels. The first `await db.execute(...)` then raised `AttributeError` → 500.

Compounding it, `regenerate` reset `generation_status` to `"draft"` and wiped `generation_progress`, **committing before the crash** — so the episode was left degraded.

## Changes

- **`apps/api/src/routers/generation.py`** — `regenerate_podcast` now delegates to `generate_podcast` with explicit keyword args (`enable_composition=False`, `enable_distribution=False`) and **drops the premature status reset**. `generate_podcast` already validates content sources and sets status to `"queued"` with fresh progress, so a failed regenerate (404/400) now leaves the episode untouched rather than degraded.
- **`apps/api/tests/test_regenerate_endpoint.py`** (new) — integration tests:
  - happy path → 202 with `status: "queued"` and correct `episode_id`
  - 401 when unauthenticated
  - 404 for a non-existent episode
  - unit test asserting a failed regenerate (no content → 400) queues nothing and commits no degraded state

## Acceptance criteria

- [x] Call uses keyword args: `generate_podcast(episode_id=..., enable_composition=False, enable_distribution=False, current_user=..., db=...)`
- [x] Integration test exercises `/regenerate` end-to-end

## Testing

- `uv run pytest tests/test_regenerate_endpoint.py` → 4 passed
- Full API suite → **661 passed**
- `ruff check` → clean

## Notes

The acceptance criteria asked only for the keyword fix + test; the reset-ordering hardening (eliminating the degraded-state path) was added per maintainer direction during planning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the podcast regeneration endpoint to prevent data degradation when generation failures occur, ensuring episode state is preserved if regeneration fails.

* **Tests**
  * Added comprehensive tests for the regeneration endpoint, including success scenarios, authentication validation, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->