### PR TITLE
fix(generation): forward episode/project TTS model & conversation_config to engine (#217)

### DIFF
--- a/apps/api/src/routers/generation.py
+++ b/apps/api/src/routers/generation.py
@@ -187,9 +187,12 @@ async def generate_podcast(
     conversation_config = None
     if effective_template or effective_tts:
         conversation_config = {}
-        if effective_template and effective_template.config:
+        # config columns are JSONB; they are dict-validated on write (Pydantic),
+        # but guard against a non-dict value from the store so a corrupt row
+        # degrades to "use defaults" instead of raising at dispatch time.
+        if effective_template and isinstance(effective_template.config, dict):
             conversation_config.update(effective_template.config)
-        if effective_tts and effective_tts.config:
+        if effective_tts and isinstance(effective_tts.config, dict):
             conversation_config["text_to_speech"] = _podcastfy_text_to_speech(
                 effective_tts.provider, effective_tts.config
             )

--- a/apps/api/src/routers/generation.py
+++ b/apps/api/src/routers/generation.py
@@ -24,6 +24,44 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/generation", tags=["Generation"])
 
+# podcastfy 0.4.1's TTSProviderFactory registers providers as
+# {openai, elevenlabs, edge, gemini, geminimulti}. The app stores the
+# multi-speaker provider as "gemini_multi" (underscore), which podcastfy would
+# reject as unsupported — normalize it before forwarding (issue #217).
+_PODCASTFY_TTS_PROVIDER = {"gemini_multi": "geminimulti"}
+
+
+def _podcastfy_tts_model(provider: str) -> str:
+    """Map a stored TTS provider name to podcastfy's expected provider key."""
+    return _PODCASTFY_TTS_PROVIDER.get(provider, provider)
+
+
+def _podcastfy_text_to_speech(provider: str, config: dict) -> dict:
+    """Translate a stored TTS config into podcastfy's ``text_to_speech`` schema.
+
+    The app persists a flat per-provider dict (``model`` plus ``voice_1``/
+    ``voice_2`` or ``voice_1_id``/``voice_2_id``), but podcastfy 0.4.1 reads
+    ``text_to_speech.<provider>.default_voices.{question,answer}`` and
+    ``text_to_speech.<provider>.model``. Without this mapping the user's voice/
+    model selection lands on keys podcastfy never reads and is silently ignored.
+    """
+    pf_provider = _podcastfy_tts_model(provider)
+    question = config.get("voice_1") or config.get("voice_1_id")
+    answer = config.get("voice_2") or config.get("voice_2_id")
+
+    provider_block: dict = {}
+    voices = {}
+    if question:
+        voices["question"] = question
+    if answer:
+        voices["answer"] = answer
+    if voices:
+        provider_block["default_voices"] = voices
+    if config.get("model"):
+        provider_block["model"] = config["model"]
+
+    return {"default_tts_model": pf_provider, pf_provider: provider_block}
+
 
 @router.post("/episodes/{episode_id}/generate", status_code=status.HTTP_202_ACCEPTED)
 async def generate_podcast(
@@ -144,7 +182,7 @@ async def generate_podcast(
     effective_tts = episode.tts_config or (project.default_tts_config if project else None)
     effective_template = episode.template or (project.default_template if project else None)
 
-    tts_model = effective_tts.provider if effective_tts else None
+    tts_model = _podcastfy_tts_model(effective_tts.provider) if effective_tts else None
 
     conversation_config = None
     if effective_template or effective_tts:
@@ -152,7 +190,9 @@ async def generate_podcast(
         if effective_template and effective_template.config:
             conversation_config.update(effective_template.config)
         if effective_tts and effective_tts.config:
-            conversation_config["text_to_speech"] = effective_tts.config
+            conversation_config["text_to_speech"] = _podcastfy_text_to_speech(
+                effective_tts.provider, effective_tts.config
+            )
 
     # Only pass resolved config kwargs; omit them so the task keeps its defaults
     # (tts_model='openai', conversation_config=None) for unconfigured episodes.

--- a/apps/api/src/routers/generation.py
+++ b/apps/api/src/routers/generation.py
@@ -9,10 +9,12 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
+from sqlalchemy.orm import joinedload
 
 from ..config import settings
 from ..database import get_db
 from ..models.episode import Episode
+from ..models.project import Project
 from ..models.content_source import ContentSource
 from ..models.user import User
 from ..dependencies import get_current_user
@@ -42,14 +44,22 @@ async def generate_podcast(
 
     Returns HTTP 202 Accepted with task ID for progress tracking
     """
-    # Get episode
+    # Get episode, eager-loading the TTS/template config relationships so they
+    # can be resolved below without triggering lazy loads in the async context.
     result = await db.execute(
-        select(Episode).where(
+        select(Episode)
+        .where(
             Episode.id == episode_id,
             Episode.tenant_id == current_user.tenant_id,
         )
+        .options(
+            joinedload(Episode.tts_config),
+            joinedload(Episode.template),
+            joinedload(Episode.project).joinedload(Project.default_tts_config),
+            joinedload(Episode.project).joinedload(Project.default_template),
+        )
     )
-    episode = result.scalar_one_or_none()
+    episode = result.unique().scalar_one_or_none()
 
     if not episode:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Episode not found")
@@ -126,6 +136,32 @@ async def generate_podcast(
     use_composition = enable_composition and settings.ENABLE_AUDIO_COMPOSITION
     use_distribution = enable_distribution and settings.ENABLE_PLATFORM_DISTRIBUTION
 
+    # Resolve the effective TTS config and conversation template: prefer the
+    # episode-level override, then fall back to the project default. Without this
+    # the task always used its default tts_model ('openai'), silently ignoring the
+    # user's selection (issue #217).
+    project = episode.project
+    effective_tts = episode.tts_config or (project.default_tts_config if project else None)
+    effective_template = episode.template or (project.default_template if project else None)
+
+    tts_model = effective_tts.provider if effective_tts else None
+
+    conversation_config = None
+    if effective_template or effective_tts:
+        conversation_config = {}
+        if effective_template and effective_template.config:
+            conversation_config.update(effective_template.config)
+        if effective_tts and effective_tts.config:
+            conversation_config["text_to_speech"] = effective_tts.config
+
+    # Only pass resolved config kwargs; omit them so the task keeps its defaults
+    # (tts_model='openai', conversation_config=None) for unconfigured episodes.
+    extra_kwargs = {}
+    if tts_model is not None:
+        extra_kwargs["tts_model"] = tts_model
+    if conversation_config is not None:
+        extra_kwargs["conversation_config"] = conversation_config
+
     # Start Celery task
     task = generate_podcast_task.delay(
         episode_id=str(episode_id),
@@ -133,6 +169,7 @@ async def generate_podcast(
         text_content="\n\n".join(text_content) if text_content else None,
         enable_composition=use_composition,
         enable_distribution=use_distribution,
+        **extra_kwargs,
     )
 
     # Update episode status

--- a/apps/api/tests/test_generation_router.py
+++ b/apps/api/tests/test_generation_router.py
@@ -82,6 +82,190 @@ async def _mark_complete(client: AsyncClient, content_id: str, headers: Headers,
     assert resp.status_code == 200, resp.text
 
 
+# ---------------------------------------------------------------------------
+# Issue #217: episode/project TTS provider + conversation_config must be
+# forwarded to the Celery task (otherwise every podcast silently uses OpenAI).
+# ---------------------------------------------------------------------------
+
+# Text long enough to clear the source validator (>=50 chars, >=10 words).
+_TEXT_BODY = (
+    "This is a sufficiently long piece of text content used by the generation "
+    "tests so that source validation accepts it as a usable podcast source."
+)
+
+ELEVENLABS_TTS_CONFIG = {
+    "model": "eleven_multilingual_v2",
+    "voice_1_id": "21m00Tcm4TlvDq8ikWAM",
+    "voice_2_id": "AZnzlk1XvdvUeBnXmlld",
+}
+GEMINI_TTS_CONFIG = {"model": "en-US-Studio-MultiSpeaker", "language_code": "en-US"}
+
+
+async def _create_text_source(client: AsyncClient, episode_id: str, headers: Headers) -> None:
+    """Attach a usable text content source so generation has something to do."""
+    resp = await client.post(
+        f"/episodes/{episode_id}/content?auto_extract=false",
+        headers=headers,
+        json={
+            "episode_id": episode_id,
+            "source_type": "text",
+            "source_data": {"content": _TEXT_BODY},
+        },
+    )
+    assert resp.status_code == 201, resp.text
+
+
+async def _create_tts_config(
+    client: AsyncClient, headers: Headers, provider: str, config: dict[str, Any]
+) -> str:
+    resp = await client.post(
+        "/tts-configs",
+        headers=headers,
+        json={"name": f"{provider} cfg", "provider": provider, "config": config},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _create_template(client: AsyncClient, headers: Headers, config: dict[str, Any]) -> str:
+    resp = await client.post(
+        "/conversation-templates",
+        headers=headers,
+        json={"name": "Tmpl", "description": "t", "config": config},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+@pytest.fixture
+async def episode_project_and_auth(client: AsyncClient) -> tuple[str, str, Headers]:
+    """Create user + project + episode, return (episode_id, project_id, auth_headers)."""
+    reg = await client.post("/auth/register", json={
+        "email": f"gencfg_{uuid4()}@example.com",
+        "password": "SecurePass123!",
+        "full_name": "Gen Cfg Tester",
+    })
+    assert reg.status_code == 201
+    headers = {"Authorization": f"Bearer {reg.json()['access_token']}"}
+
+    proj = await client.post("/projects", headers=headers, json={
+        "name": "Gen Cfg Project",
+        "podcast_metadata": {"show_title": "Show", "author": "A", "description": "D"},
+    })
+    assert proj.status_code == 201
+    project_id = proj.json()["id"]
+
+    ep = await client.post("/episodes", headers=headers, json={
+        "project_id": project_id,
+        "episode_number": 1,
+        "episode_metadata": {"title": "Ep", "description": "Episode"},
+    })
+    assert ep.status_code == 201
+    return ep.json()["id"], project_id, headers
+
+
+@pytest.mark.asyncio
+async def test_generate_forwards_episode_tts_provider(client, episode_project_and_auth):
+    """A non-OpenAI episode TTS config is forwarded as tts_model to the task."""
+    episode_id, _project_id, headers = episode_project_and_auth
+    await _create_text_source(client, episode_id, headers)
+
+    tts_id = await _create_tts_config(client, headers, "elevenlabs", ELEVENLABS_TTS_CONFIG)
+    upd = await client.put(
+        f"/episodes/{episode_id}", headers=headers, json={"tts_config_id": tts_id}
+    )
+    assert upd.status_code == 200, upd.text
+
+    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+        mock_delay.return_value = MagicMock(id="task-tts")
+        resp = await client.post(
+            f"/generation/episodes/{episode_id}/generate", headers=headers
+        )
+
+    assert resp.status_code == 202, resp.text
+    mock_delay.assert_called_once()
+    assert mock_delay.call_args.kwargs["tts_model"] == "elevenlabs"
+
+
+@pytest.mark.asyncio
+async def test_generate_falls_back_to_project_default_tts(client, episode_project_and_auth):
+    """With no episode TTS config, the project default provider is forwarded."""
+    episode_id, project_id, headers = episode_project_and_auth
+    await _create_text_source(client, episode_id, headers)
+
+    tts_id = await _create_tts_config(client, headers, "gemini", GEMINI_TTS_CONFIG)
+    upd = await client.put(
+        f"/projects/{project_id}", headers=headers, json={"default_tts_config_id": tts_id}
+    )
+    assert upd.status_code == 200, upd.text
+
+    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+        mock_delay.return_value = MagicMock(id="task-gemini")
+        resp = await client.post(
+            f"/generation/episodes/{episode_id}/generate", headers=headers
+        )
+
+    assert resp.status_code == 202, resp.text
+    mock_delay.assert_called_once()
+    assert mock_delay.call_args.kwargs["tts_model"] == "gemini"
+
+
+@pytest.mark.asyncio
+async def test_generate_forwards_conversation_config(client, episode_project_and_auth):
+    """An episode template + TTS config produce a conversation_config dict."""
+    episode_id, _project_id, headers = episode_project_and_auth
+    await _create_text_source(client, episode_id, headers)
+
+    template_cfg = {
+        "word_count": 300,
+        "conversation_style": ["casual"],
+        "roles_person1": "host",
+        "roles_person2": "expert guest",
+        "dialogue_structure": ["Introduction", "Main Content", "Conclusion"],
+        "podcast_name": "X",
+        "output_language": "en",
+        "creativity": 0.7,
+    }
+    template_id = await _create_template(client, headers, template_cfg)
+    tts_id = await _create_tts_config(client, headers, "elevenlabs", ELEVENLABS_TTS_CONFIG)
+    upd = await client.put(
+        f"/episodes/{episode_id}",
+        headers=headers,
+        json={"template_id": template_id, "tts_config_id": tts_id},
+    )
+    assert upd.status_code == 200, upd.text
+
+    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+        mock_delay.return_value = MagicMock(id="task-cfg")
+        resp = await client.post(
+            f"/generation/episodes/{episode_id}/generate", headers=headers
+        )
+
+    assert resp.status_code == 202, resp.text
+    conv = mock_delay.call_args.kwargs["conversation_config"]
+    assert conv["word_count"] == 300
+    assert conv["text_to_speech"] == ELEVENLABS_TTS_CONFIG
+
+
+@pytest.mark.asyncio
+async def test_generate_without_config_uses_task_default(client, episode_project_and_auth):
+    """With no TTS/template config, the task default (openai) is preserved."""
+    episode_id, _project_id, headers = episode_project_and_auth
+    await _create_text_source(client, episode_id, headers)
+
+    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+        mock_delay.return_value = MagicMock(id="task-default")
+        resp = await client.post(
+            f"/generation/episodes/{episode_id}/generate", headers=headers
+        )
+
+    assert resp.status_code == 202, resp.text
+    call_kwargs = mock_delay.call_args.kwargs
+    # Not passed → task default tts_model="openai" / conversation_config=None applies.
+    assert "tts_model" not in call_kwargs
+    assert "conversation_config" not in call_kwargs
+
+
 @pytest.mark.asyncio
 async def test_generate_rejects_unextracted_file_source(client, episode_and_auth):
     """A PDF source still pending extraction must yield HTTP 400, not dispatch."""

--- a/apps/api/tests/test_generation_router.py
+++ b/apps/api/tests/test_generation_router.py
@@ -211,6 +211,32 @@ async def test_generate_falls_back_to_project_default_tts(client, episode_projec
 
 
 @pytest.mark.asyncio
+async def test_generate_normalizes_gemini_multi_provider(client, episode_project_and_auth):
+    """The app's 'gemini_multi' provider is normalized to podcastfy's 'geminimulti'."""
+    episode_id, _project_id, headers = episode_project_and_auth
+    await _create_text_source(client, episode_id, headers)
+
+    tts_id = await _create_tts_config(client, headers, "gemini_multi", GEMINI_TTS_CONFIG)
+    upd = await client.put(
+        f"/episodes/{episode_id}", headers=headers, json={"tts_config_id": tts_id}
+    )
+    assert upd.status_code == 200, upd.text
+
+    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+        mock_delay.return_value = MagicMock(id="task-gm")
+        resp = await client.post(
+            f"/generation/episodes/{episode_id}/generate", headers=headers
+        )
+
+    assert resp.status_code == 202, resp.text
+    kwargs = mock_delay.call_args.kwargs
+    assert kwargs["tts_model"] == "geminimulti"
+    # The nested text_to_speech block is keyed by the normalized provider name.
+    assert "geminimulti" in kwargs["conversation_config"]["text_to_speech"]
+    assert kwargs["conversation_config"]["text_to_speech"]["default_tts_model"] == "geminimulti"
+
+
+@pytest.mark.asyncio
 async def test_generate_forwards_conversation_config(client, episode_project_and_auth):
     """An episode template + TTS config produce a conversation_config dict."""
     episode_id, _project_id, headers = episode_project_and_auth
@@ -243,8 +269,17 @@ async def test_generate_forwards_conversation_config(client, episode_project_and
 
     assert resp.status_code == 202, resp.text
     conv = mock_delay.call_args.kwargs["conversation_config"]
+    # Template fields are forwarded at the top level (podcastfy reads them there).
     assert conv["word_count"] == 300
-    assert conv["text_to_speech"] == ELEVENLABS_TTS_CONFIG
+    # The flat TTS config is translated into podcastfy's nested text_to_speech
+    # schema so the user's model + voices are actually honored (issue #217).
+    tts = conv["text_to_speech"]
+    assert tts["default_tts_model"] == "elevenlabs"
+    assert tts["elevenlabs"]["model"] == "eleven_multilingual_v2"
+    assert tts["elevenlabs"]["default_voices"] == {
+        "question": "21m00Tcm4TlvDq8ikWAM",
+        "answer": "AZnzlk1XvdvUeBnXmlld",
+    }
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_generation_router.py
+++ b/apps/api/tests/test_generation_router.py
@@ -118,6 +118,7 @@ async def _create_text_source(client: AsyncClient, episode_id: str, headers: Hea
 async def _create_tts_config(
     client: AsyncClient, headers: Headers, provider: str, config: dict[str, Any]
 ) -> str:
+    """Create a TTS configuration via the API and return its id."""
     resp = await client.post(
         "/tts-configs",
         headers=headers,
@@ -128,6 +129,7 @@ async def _create_tts_config(
 
 
 async def _create_template(client: AsyncClient, headers: Headers, config: dict[str, Any]) -> str:
+    """Create a conversation template via the API and return its id."""
     resp = await client.post(
         "/conversation-templates",
         headers=headers,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -28,7 +28,7 @@ so issue order == work order.
 ## Phase 2 — Restore the core product (generation pipeline)
 - [ ] **P2.1 #204** 🔴 `generate_podcast()` called with invalid kwargs → **every generation fails**. *Unblocks the rest of Phase 2.* Add an autospec/signature-asserting test; pin `podcastfy==0.4.1`.
 - [ ] **P2.2 #213** `/regenerate` passes wrong positional args → guaranteed 500, leaves episode degraded
-- [ ] **P2.3 #217** Episode `tts_model`/`conversation_config` never forwarded → always OpenAI TTS
+- [x] **P2.3 #217** Episode `tts_model`/`conversation_config` never forwarded → always OpenAI TTS ✅ done (generation.py eager-loads tts_config/template, normalises gemini_multi→geminimulti, forwards to task)
 - [ ] **P2.4 #214** No guard against re-submitting generation for an in-progress episode (race)
 - [ ] **P2.5 #210** PDF/file input non-functional — no upload endpoint; extraction ignores S3 key *(needs StorageService + #204)*
 - [ ] **P2.6 #211** Distribution subsystem unreachable + would publish blank episodes *(needs #204 producing real episodes + metadata)*
@@ -96,7 +96,7 @@ podcastfy 0.4.1 `generate_podcast()`. `create_episode` does **not** persist
 (`EpisodeUpdate`), so tests configure episodes/projects via PUT.
 
 ### Step 1 — Eager-load config relationships in the generate query
-- [ ] `apps/api/src/routers/generation.py` — import `joinedload` (`sqlalchemy.orm`) and
+- [x] `apps/api/src/routers/generation.py` — import `joinedload` (`sqlalchemy.orm`) and
       `Project` (`..models.project`); add `.options(...)` to the `select(Episode)` query in
       `generate_podcast`: `joinedload(Episode.tts_config)`, `joinedload(Episode.template)`,
       `joinedload(Episode.project).joinedload(Project.default_tts_config)`,
@@ -104,30 +104,32 @@ podcastfy 0.4.1 `generate_podcast()`. `create_episode` does **not** persist
       (Relationships are lazy by default → would raise in the async context.)
 
 ### Step 2 — Resolve effective config + forward to the task
-- [ ] `apps/api/src/routers/generation.py` — after fetching the episode resolve
+- [x] `apps/api/src/routers/generation.py` — after fetching the episode resolve
       `effective_tts = episode.tts_config or episode.project.default_tts_config` and
       `effective_template = episode.template or episode.project.default_template`.
       `tts_model = effective_tts.provider if effective_tts else None`. Build
       `conversation_config` (None if neither): start from `effective_template.config`,
-      add a `text_to_speech` key = `effective_tts.config` if a TTS config resolved. Pass
-      `tts_model`/`conversation_config` into `generate_podcast_task.delay(...)` only when
-      non-None (preserve task defaults for unconfigured episodes).
+      add a `text_to_speech` key from `_podcastfy_text_to_speech()` (translates flat
+      voice_1/voice_2 fields + model → podcastfy's nested `text_to_speech.<provider>`
+      schema). `gemini_multi` normalised to `geminimulti`. Pass `tts_model`/
+      `conversation_config` into `generate_podcast_task.delay(...)` only when non-None
+      (preserve task defaults for unconfigured episodes).
 
 ### Step 3 — Tests (in existing `apps/api/tests/test_generation_router.py`)
-- [ ] `test_generate_forwards_episode_tts_provider` — episode TTS = ElevenLabs →
+- [x] `test_generate_forwards_episode_tts_provider` — episode TTS = ElevenLabs →
       task receives `tts_model="elevenlabs"`.
-- [ ] `test_generate_falls_back_to_project_default_tts` — no episode config, project
+- [x] `test_generate_falls_back_to_project_default_tts` — no episode config, project
       `default_tts_config` = Gemini → task receives `tts_model="gemini"`.
-- [ ] `test_generate_forwards_conversation_config` — episode template set → task
+- [x] `test_generate_forwards_conversation_config` — episode template set → task
       receives `conversation_config` with the template's config + a `text_to_speech` key.
-- [ ] `test_generate_without_config_uses_task_default` — no config → `tts_model` /
+- [x] `test_generate_without_config_uses_task_default` — no config → `tts_model` /
       `conversation_config` NOT passed (task default `openai` preserved).
 
 ### Acceptance criteria
-- [ ] Resolve episode/project TTS config and pass `tts_model` (+ `conversation_config`)
+- [x] Resolve episode/project TTS config and pass `tts_model` (+ `conversation_config`)
       into `generate_podcast_task.delay(...)`.
-- [ ] Test asserting a non-OpenAI selection is honored.
-- [ ] Full api test suite green; lint clean.
+- [x] Test asserting a non-OpenAI selection is honored.
+- [x] Full api test suite green; lint clean.
 
 ### Deviations from CodeRabbit's plan
 1. **Tests in existing `test_generation_router.py`** (not a new `test_generation.py`) —

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -79,60 +79,63 @@ so issue order == work order.
 
 ---
 
-## Active work — Issue #204 (P2.1): generation calls podcastfy with invalid kwargs
+## Active work — Issue #217 (P2.3): TTS model / conversation_config never forwarded
 
 **Plan source:** comment (CodeRabbit coding plan), adapted to the codebase.
 
-**Problem:** the Celery task calls podcastfy 0.4.1 `generate_podcast()` with `file=` and
-`youtube_urls=` kwargs that don't exist in the installed signature → **every** generation
-fails with `TypeError`. Existing tests mock `generate_podcast` with a plain `MagicMock`
-(no autospec) and actually **assert** the buggy kwargs, so they were false-green.
+**Problem:** the generation router never passes the episode's `tts_model` or
+`conversation_config`, so the Celery task default (`tts_model="openai"`) is always used.
+User/episode TTS selection is silently ignored and every generation requires
+`OPENAI_API_KEY` regardless of the chosen provider.
 
-Real podcastfy 0.4.1 signature (no `file`, no `youtube_urls`):
-`(urls, url_file, transcript_file, tts_model, transcript_only, config, conversation_config, image_paths, is_local, text, llm_model_name, api_key_label, topic, longform)`
+**Verified:** `Episode.tts_config`/`Episode.template`/`Episode.project` +
+`Project.default_tts_config`/`Project.default_template` relationships all exist; the
+Celery task already accepts `tts_model`/`conversation_config` and forwards them to
+podcastfy 0.4.1 `generate_podcast()`. `create_episode` does **not** persist
+`tts_config_id`/`template_id` — those are only settable via the update path
+(`EpisodeUpdate`), so tests configure episodes/projects via PUT.
 
-### Step 1 — Fix the Celery task call (core bug)
-- [ ] `apps/api/src/tasks/podcast_generation.py` — drop `file=file_paths` and
-      `youtube_urls=youtube_urls` from the `generate_podcast(...)` call; keep only valid
-      kwargs (`urls`, `text`, `image_paths`, `tts_model`, `conversation_config`,
-      `longform`, `topic`). Remove `file_paths`/`youtube_urls` from the task signature.
+### Step 1 — Eager-load config relationships in the generate query
+- [ ] `apps/api/src/routers/generation.py` — import `joinedload` (`sqlalchemy.orm`) and
+      `Project` (`..models.project`); add `.options(...)` to the `select(Episode)` query in
+      `generate_podcast`: `joinedload(Episode.tts_config)`, `joinedload(Episode.template)`,
+      `joinedload(Episode.project).joinedload(Project.default_tts_config)`,
+      `joinedload(Episode.project).joinedload(Project.default_template)`.
+      (Relationships are lazy by default → would raise in the async context.)
 
-### Step 2 — Router: drop file_paths assembly, enforce extraction for files
-- [ ] `apps/api/src/routers/generation.py` — remove `file_paths` assembly + the
-      `file_paths=` delay arg; add validation that returns HTTP 400 if any **file**-type
-      source has `extraction_status != "complete"` (URL/YouTube/text keep their valid
-      `source_data` fallback).
+### Step 2 — Resolve effective config + forward to the task
+- [ ] `apps/api/src/routers/generation.py` — after fetching the episode resolve
+      `effective_tts = episode.tts_config or episode.project.default_tts_config` and
+      `effective_template = episode.template or episode.project.default_template`.
+      `tts_model = effective_tts.provider if effective_tts else None`. Build
+      `conversation_config` (None if neither): start from `effective_template.config`,
+      add a `text_to_speech` key = `effective_tts.config` if a TTS config resolved. Pass
+      `tts_model`/`conversation_config` into `generate_podcast_task.delay(...)` only when
+      non-None (preserve task defaults for unconfigured episodes).
 
-### Step 3 — Delete dead PodcastService
-- [ ] Delete `apps/api/src/services/podcast_service.py` (same bug, unused).
-- [ ] Delete `apps/api/tests/unit/test_podcast_service.py`.
-
-### Step 4 — Pin podcastfy
-- [ ] `apps/api/pyproject.toml`: `podcastfy>=0.4.1` → `==0.4.1`; refresh `uv.lock`
-      (already resolves to 0.4.1 — spec tightening only).
-
-### Step 5 — Tests (drift guard + fix the false-green ones)
-- [ ] Add a signature-drift guard binding the task's exact kwargs against the **real**
-      `podcastfy.client.generate_podcast` via `inspect.signature(...).bind(...)`.
-- [ ] Rewrite the 3 tests that encode the bug
-      (`test_task_passes_file_paths_to_generate_podcast`,
-      `test_task_accepts_file_paths_parameter`,
-      `test_task_no_type_error_with_router_parameter_names`); use `autospec` so bad kwargs raise.
+### Step 3 — Tests (in existing `apps/api/tests/test_generation_router.py`)
+- [ ] `test_generate_forwards_episode_tts_provider` — episode TTS = ElevenLabs →
+      task receives `tts_model="elevenlabs"`.
+- [ ] `test_generate_falls_back_to_project_default_tts` — no episode config, project
+      `default_tts_config` = Gemini → task receives `tts_model="gemini"`.
+- [ ] `test_generate_forwards_conversation_config` — episode template set → task
+      receives `conversation_config` with the template's config + a `text_to_speech` key.
+- [ ] `test_generate_without_config_uses_task_default` — no config → `tts_model` /
+      `conversation_config` NOT passed (task default `openai` preserved).
 
 ### Acceptance criteria
-- [ ] Inputs map to real signature: YouTube → `urls=`; file/PDF pre-extracted → `text=`. `file=`/`youtube_urls=`/`output_dir=`/`file_paths=` removed.
-- [ ] A test asserts call kwargs against `inspect.signature(generate_podcast)` (or autospec).
-- [ ] `podcastfy` pinned to `==0.4.1`.
-- [ ] Dead `PodcastService` + its test deleted.
+- [ ] Resolve episode/project TTS config and pass `tts_model` (+ `conversation_config`)
+      into `generate_podcast_task.delay(...)`.
+- [ ] Test asserting a non-OpenAI selection is honored.
 - [ ] Full api test suite green; lint clean.
 
 ### Deviations from CodeRabbit's plan
-1. **Existing tests encode the bug** — three tests actively assert `file=file_paths` /
-   accept `file_paths`; they must be rewritten/inverted, not merely tweaked (this is the
-   false-green root cause).
-2. **Validation scope**: reject only **file**-type sources lacking extraction; URL/YouTube/text
-   keep their legitimate `source_data` fallback (podcastfy fetches URLs and accepts raw text).
-3. **Lock file** already pins 0.4.1 → no resolution change.
+1. **Tests in existing `test_generation_router.py`** (not a new `test_generation.py`) —
+   avoids a duplicate test module and matches the established pattern.
+2. **Integration tests via the real `client` fixture + PUT endpoints** (not AsyncMock
+   unit tests) — `create_episode` ignores the config FKs, so they are only set via update;
+   this exercises real code paths.
+3. **Added a 4th test** (no-config default preserved) to lock in backward compatibility.
 
 ---
 


### PR DESCRIPTION
## Summary
Implements #217 (P2.3): the generation router never passed the episode's `tts_model` or `conversation_config`, so `generate_podcast_task` always used its default (`tts_model="openai"`). User/episode TTS selection was silently ignored and every generation required `OPENAI_API_KEY`.

- Eager-load `Episode.tts_config` / `.template` / `.project` (+ `Project.default_tts_config` / `.default_template`) on the generate query (`result.unique()` handles joinedload row duplication).
- Resolve the effective TTS config + template: episode override → project default.
- Forward `tts_model` + `conversation_config` into `generate_podcast_task.delay(...)` only when resolved (unconfigured episodes keep the task defaults).
- Normalize the app's `gemini_multi` provider to podcastfy 0.4.1's `geminimulti` (the factory rejects the underscored name, which would otherwise fail multi-speaker Gemini generation).
- Translate the stored flat TTS config into podcastfy's nested `text_to_speech.<provider>.{default_voices.{question,answer}, model}` schema (mapping `voice_1`/`voice_1_id` → `question`, `voice_2`/`voice_2_id` → `answer`) so the user's model/voice selection is actually consumed instead of landing on keys podcastfy never reads.

## Acceptance Criteria
- [x] Resolve episode/project TTS config and pass `tts_model` (and `conversation_config`) into `generate_podcast_task.delay(...)`.
- [x] Test asserting a non-OpenAI selection is honored (ElevenLabs forwarded; Gemini project-default fallback; `gemini_multi`→`geminimulti`).

## Test Plan
- [x] Unit/integration tests written first (TDD: RED → GREEN)
- [x] All tests passing (`uv run pytest` — 661 passed)
- [x] Diff coverage on new lines verified via mutation testing (Phase 7d)
- [x] Linting clean (`ruff`)
- [x] Internal code review (advisory) completed — 2 Major findings fixed
- [x] Cross-family review pass: **codex** — 2 Major findings, both fixed, re-review clean
- [x] Test mutation sanity check completed (new behaviors fail under mutation)

New tests in `apps/api/tests/test_generation_router.py`:
- `test_generate_forwards_episode_tts_provider` — ElevenLabs → `tts_model="elevenlabs"`
- `test_generate_falls_back_to_project_default_tts` — project default Gemini → `tts_model="gemini"`
- `test_generate_normalizes_gemini_multi_provider` — `gemini_multi` → `geminimulti`
- `test_generate_forwards_conversation_config` — nested `text_to_speech.<provider>` + template config
- `test_generate_without_config_uses_task_default` — no config → kwargs omitted (task default preserved)

## Known Limitations / Intentionally Deferred
- **Voice mapping assumes 2 speakers** (`question`/`answer`), matching podcastfy 0.4.1's model — multi-speaker beyond two is not represented.
- **No dispatch-time validation of provider validity** beyond the `gemini_multi` normalization. A config with an otherwise-unknown provider would still reach podcastfy; surfacing an HTTP 400 early is a possible follow-up.
- **Web-side TTS config correctness** (empty ElevenLabs voice IDs, missing voice-ID inputs, non-empty value validation) is tracked separately in #221 (P5.1), which is explicitly scheduled after this issue.
- `create_episode` does not persist `tts_config_id`/`template_id` (only the update path does) — unchanged here; tests configure via the PUT endpoints accordingly.

## Implementation Notes
- Tests were added to the existing `test_generation_router.py` (not a new file) to match the established integration-test pattern, using the real `client` fixture + PUT endpoints since `create_episode` ignores the config FKs.
- mypy reports pre-existing SQLAlchemy `Column[str]` typing noise (209 errors across 40 files, baseline); CI/pre-commit gate on `ruff` + `pytest`, both green.

Closes #217