### PR TITLE
fix(generation): functional PDF upload + S3-backed extraction (#210)

### DIFF
--- a/apps/api/src/routers/content.py
+++ b/apps/api/src/routers/content.py
@@ -9,10 +9,10 @@ Note: Content sources are nested under episodes at /episodes/{episode_id}/conten
 """
 
 import logging
-from fastapi import APIRouter, Depends, HTTPException, status, Query
+from fastapi import APIRouter, Depends, File, Form, HTTPException, status, Query, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 from uuid import UUID
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from ..database import get_db
 from ..middleware.auth import get_current_user
@@ -25,6 +25,7 @@ from ..schemas.content import (
 )
 from ..services.content_service import (
     add_content_source,
+    upload_pdf_content,
     get_content_sources,
     get_content_source_by_id,
     update_content_source,
@@ -125,6 +126,70 @@ async def create_content_source(
             )
         except Exception as e:
             # Broker unavailable — log but don't fail creation
+            logger.warning(
+                f"Could not queue extraction task for {content_source.id}: {e}"
+            )
+
+    return content_source
+
+
+@router.post(
+    "/episodes/{episode_id}/content/upload",
+    response_model=ContentSourceResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def upload_pdf_content_source(
+    episode_id: UUID,
+    file: UploadFile = File(..., description="PDF file (application/pdf, max 50MB)"),
+    description: Optional[str] = Form(None, max_length=500, description="Optional description"),
+    auto_extract: bool = Form(True, description="Trigger extraction immediately after upload"),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Upload a PDF file as a content source for an episode.
+
+    Accepts multipart/form-data with a PDF file plus optional metadata. Stores
+    the file in S3, creates a 'pdf' content source recording its ``s3_key`` and
+    ``filename``, and (when ``auto_extract`` is true) queues a background
+    extraction task so the content is ready for generation.
+
+    Args:
+        episode_id: UUID of the parent episode.
+        file: Uploaded PDF file.
+        description: Optional description.
+        auto_extract: Whether to automatically trigger extraction (default True).
+        current_user: Authenticated user (from JWT token).
+        db: Database session.
+
+    Returns:
+        Created content source with all fields.
+
+    Raises:
+        HTTPException: 404 if episode not found, 413 if file too large,
+            422 if the file is not a valid PDF.
+    """
+    content_source = await upload_pdf_content(
+        db=db,
+        tenant_id=current_user.tenant_id,
+        episode_id=episode_id,
+        file=file,
+        description=description,
+    )
+
+    # Auto-trigger extraction if requested (mirrors create_content_source)
+    if auto_extract:
+        try:
+            from ..tasks.content_extraction import extract_content_task
+            extract_content_task.delay(
+                content_source_id=str(content_source.id),
+                source_type=content_source.source_type,
+            )
+            logger.info(
+                f"Triggered extraction task for uploaded PDF content source {content_source.id}"
+            )
+        except Exception as e:
+            # Broker unavailable — log but don't fail the upload
             logger.warning(
                 f"Could not queue extraction task for {content_source.id}: {e}"
             )

--- a/apps/api/src/services/content_extraction_service.py
+++ b/apps/api/src/services/content_extraction_service.py
@@ -13,6 +13,8 @@ maintain async compatibility with the FastAPI application.
 
 import asyncio
 import logging
+import os
+import tempfile
 from typing import Optional
 from urllib.parse import urljoin
 from uuid import UUID
@@ -25,10 +27,12 @@ from requests.exceptions import RequestException, Timeout, HTTPError
 from podcastfy.content_parser.website_extractor import WebsiteExtractor
 from podcastfy.content_parser.pdf_extractor import PDFExtractor
 
+from ..config import settings
 from ..models import ContentSource
 from ..schemas.content import ContentSourceUpdate
 from ..utils.ssrf import SSRFValidationError, validate_public_url
 from .content_service import get_content_source_by_id, update_content_source
+from .storage_service import StorageService
 
 
 logger = logging.getLogger(__name__)
@@ -230,9 +234,9 @@ class ContentExtractionService:
 		"""
 		Extract content from a PDF source.
 
-		Retrieves content source, validates it's a PDF type, locates the PDF file
-		(local filesystem or S3), extracts content using Podcastfy's PDFExtractor,
-		and updates the database with results or error details.
+		Retrieves content source, validates it's a PDF type, downloads the PDF from
+		S3 (via StorageService) to a temp file, extracts content using Podcastfy's
+		PDFExtractor, and updates the database with results or error details.
 
 		Args:
 			db: Database session
@@ -266,19 +270,34 @@ class ContentExtractionService:
 			await self._update_extraction_failed(db, content_source, error_msg)
 			return ExtractionResult(success=False, error_message=error_msg)
 
-		# Construct file path (local filesystem for now)
-		# TODO: Add S3 support in future iteration
-		file_path = f"data/uploads/{filename}"
+		# The PDF lives in S3 under s3_key (written by the upload endpoint). Without
+		# a configured bucket there is nothing to download from, so fail clearly
+		# rather than reading a non-existent local path.
+		bucket = getattr(settings, "AWS_S3_BUCKET", None)
+		if not bucket:
+			error_msg = "File storage not configured; cannot retrieve PDF for extraction"
+			logger.error(f"Content source {content_source_id}: {error_msg}")
+			await self._update_extraction_failed(db, content_source, error_msg)
+			return ExtractionResult(success=False, error_message=error_msg)
 
 		# Update status to 'extracting'
 		await self._update_extraction_status(db, content_source, 'extracting')
 
+		# Download the PDF from S3 to a temp file, extract, then always clean up.
+		storage = StorageService(bucket_name=bucket, region_name=settings.AWS_REGION)
+		temp_path: Optional[str] = None
 		try:
-			# Extract content using Podcastfy (async wrapper)
-			logger.info(f"Extracting content from PDF: {file_path}")
+			with tempfile.NamedTemporaryFile(suffix='.pdf', delete=False) as tmp:
+				temp_path = tmp.name
+
+			logger.info(f"Downloading PDF {filename} from S3 key {s3_key}")
+			await storage.download_file(s3_key, temp_path)
+
+			# Extract content using Podcastfy (sync extractor in a worker thread)
+			logger.info(f"Extracting content from PDF: {filename}")
 			extracted_text = await asyncio.to_thread(
 				self.pdf_extractor.extract_content,
-				file_path
+				temp_path
 			)
 
 			# Update with success
@@ -290,17 +309,25 @@ class ContentExtractionService:
 			return ExtractionResult(success=True, content=extracted_text)
 
 		except FileNotFoundError:
-			error_msg = f"PDF file not found: {file_path}"
+			error_msg = f"PDF file not found in storage (s3_key: {s3_key})"
 			logger.error(f"File error extracting {filename}: {error_msg}")
 			await self._update_extraction_failed(db, content_source, error_msg)
 			return ExtractionResult(success=False, error_message=error_msg)
 
 		except Exception as e:
-			# Handle PDF extraction errors (corrupted file, extraction failure)
+			# Handle download failures and PDF extraction errors (corrupted file, etc.)
 			error_msg = f"Error extracting PDF content: {str(e)}"
 			logger.exception(f"Error extracting {filename}: {error_msg}")
 			await self._update_extraction_failed(db, content_source, error_msg)
 			return ExtractionResult(success=False, error_message=error_msg)
+
+		finally:
+			# Always remove the downloaded temp file, even on failure.
+			if temp_path and os.path.exists(temp_path):
+				try:
+					os.unlink(temp_path)
+				except OSError:
+					logger.warning(f"Failed to remove temp PDF file: {temp_path}")
 
 	async def extract_from_text(
 		self,

--- a/apps/api/src/services/content_service.py
+++ b/apps/api/src/services/content_service.py
@@ -5,14 +5,22 @@ Provides CRUD operations for content sources with episode validation, pagination
 and extraction status management. RLS ensures tenant isolation.
 """
 
+import os
+import tempfile
+import uuid
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func
 from uuid import UUID
 from typing import Optional
-from fastapi import HTTPException, status
+from fastapi import HTTPException, UploadFile, status
 
 from ..models import ContentSource, Episode
 from ..schemas.content import ContentSourceCreate, ContentSourceUpdate
+from ..utils.validators import (
+    MAX_PDF_SIZE_BYTES,
+    sanitize_filename,
+    validate_pdf_format,
+)
 
 
 async def add_content_source(
@@ -55,6 +63,144 @@ async def add_content_source(
         extraction_status="pending",  # Initial status
         extracted_content=None,
         error_message=None
+    )
+    db.add(content_source)
+    await db.commit()
+    return content_source
+
+
+async def _upload_pdf_to_s3(file_path: str, s3_key: str) -> Optional[str]:
+    """
+    Upload a PDF to S3 and return its URL.
+
+    Returns None when S3 is not configured (development mode), mirroring the
+    audio-snippet upload helper. Kept at module scope so tests can patch it.
+
+    Args:
+        file_path: Local temp file path to upload.
+        s3_key: Destination S3 object key.
+
+    Returns:
+        S3 URL string, or None if S3 is not configured.
+    """
+    from ..config import settings
+    from ..services.storage_service import StorageService
+
+    bucket = getattr(settings, "AWS_S3_BUCKET", None)
+    if not bucket:
+        # S3 not configured — development mode, skip upload.
+        return None
+
+    storage = StorageService(bucket_name=bucket, region_name=settings.AWS_REGION)
+    return await storage.upload_file(
+        file_path=file_path,
+        s3_key=s3_key,
+        content_type="application/pdf",
+        public=False,
+    )
+
+
+async def upload_pdf_content(
+    db: AsyncSession,
+    tenant_id: UUID,
+    episode_id: UUID,
+    file: UploadFile,
+    description: Optional[str] = None,
+) -> ContentSource:
+    """
+    Upload a PDF file to S3 and create a 'pdf' content source for an episode.
+
+    Validates the episode exists, the file is a PDF, and the size is within
+    limits, then stores the file in S3 under
+    ``content/{tenant_id}/{episode_id}/{uuid}_{filename}`` and records a
+    ContentSource with ``source_data={s3_key, filename, mime_type}`` and an
+    initial ``extraction_status='pending'``.
+
+    Args:
+        db: Database session.
+        tenant_id: Tenant ID for isolation.
+        episode_id: Episode the PDF belongs to.
+        file: Uploaded PDF file.
+        description: Optional description (currently unused metadata).
+
+    Returns:
+        Created ContentSource instance.
+
+    Raises:
+        HTTPException: 404 if episode not found, 413 if too large,
+            422 if invalid format / storage failure.
+    """
+    # Verify episode exists (RLS ensures it's in the correct tenant)
+    episode = await db.get(Episode, episode_id)
+    if episode is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Episode not found",
+        )
+
+    # Validate PDF format before reading the whole file
+    filename = file.filename or ""
+    try:
+        validate_pdf_format(filename, file.content_type)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(e),
+        )
+
+    # Read contents and enforce size limits
+    file_bytes = await file.read()
+    file_size = len(file_bytes)
+    if file_size == 0:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Uploaded PDF is empty",
+        )
+    if file_size > MAX_PDF_SIZE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=(
+                f"File too large ({file_size} bytes). "
+                f"Maximum allowed size is {MAX_PDF_SIZE_BYTES // (1024 * 1024)} MB"
+            ),
+        )
+
+    # Build a tenant/episode-scoped S3 key with a sanitized filename
+    safe_name = sanitize_filename(filename) or "document.pdf"
+    s3_key = f"content/{tenant_id}/{episode_id}/{uuid.uuid4()}_{safe_name}"
+
+    # Write to a temp file and upload to S3, cleaning up afterwards
+    temp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            tmp.write(file_bytes)
+            temp_path = tmp.name
+
+        await _upload_pdf_to_s3(temp_path, s3_key)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Failed to store PDF: {str(e)}",
+        )
+    finally:
+        if temp_path and os.path.exists(temp_path):
+            os.unlink(temp_path)
+
+    content_source = ContentSource(
+        episode_id=episode_id,
+        tenant_id=tenant_id,
+        source_type="pdf",
+        source_data={
+            "s3_key": s3_key,
+            "filename": filename,
+            "mime_type": "application/pdf",
+        },
+        extraction_status="pending",
+        extracted_content=None,
+        error_message=None,
     )
     db.add(content_source)
     await db.commit()

--- a/apps/api/src/services/content_service.py
+++ b/apps/api/src/services/content_service.py
@@ -69,27 +69,34 @@ async def add_content_source(
     return content_source
 
 
-async def _upload_pdf_to_s3(file_path: str, s3_key: str) -> Optional[str]:
+async def _upload_pdf_to_s3(file_path: str, s3_key: str) -> str:
     """
     Upload a PDF to S3 and return its URL.
 
-    Returns None when S3 is not configured (development mode), mirroring the
-    audio-snippet upload helper. Kept at module scope so tests can patch it.
+    Kept at module scope so tests can patch it. Raises 503 when S3 is not
+    configured, since a PDF that is not stored cannot later be extracted.
 
     Args:
         file_path: Local temp file path to upload.
         s3_key: Destination S3 object key.
 
     Returns:
-        S3 URL string, or None if S3 is not configured.
+        S3 URL string.
+
+    Raises:
+        HTTPException: 503 if S3 storage is not configured.
     """
     from ..config import settings
     from ..services.storage_service import StorageService
 
     bucket = getattr(settings, "AWS_S3_BUCKET", None)
     if not bucket:
-        # S3 not configured — development mode, skip upload.
-        return None
+        # Without S3 the PDF cannot be persisted anywhere extraction can read it,
+        # so reject the upload rather than recording an unretrievable s3_key.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="File storage is not configured; PDF uploads are unavailable.",
+        )
 
     storage = StorageService(bucket_name=bucket, region_name=settings.AWS_REGION)
     return await storage.upload_file(
@@ -163,6 +170,14 @@ async def upload_pdf_content(
                 f"File too large ({file_size} bytes). "
                 f"Maximum allowed size is {MAX_PDF_SIZE_BYTES // (1024 * 1024)} MB"
             ),
+        )
+
+    # Verify the bytes are actually a PDF (magic header) so non-PDF content is
+    # rejected synchronously with 422 rather than failing later during extraction.
+    if not file_bytes.startswith(b"%PDF-"):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Uploaded file is not a valid PDF (missing %PDF- header).",
         )
 
     # Build a tenant/episode-scoped S3 key with a sanitized filename

--- a/apps/api/src/services/storage_service.py
+++ b/apps/api/src/services/storage_service.py
@@ -1,5 +1,6 @@
 """Storage service for S3 operations"""
 
+import asyncio
 from typing import Optional
 import boto3
 from botocore.exceptions import ClientError
@@ -67,7 +68,10 @@ class StorageService:
             extra_args["ACL"] = "public-read"
 
         try:
-            self.s3_client.upload_file(
+            # boto3 is synchronous; run it off the event loop so concurrent
+            # requests/tasks are not blocked during the upload.
+            await asyncio.to_thread(
+                self.s3_client.upload_file,
                 Filename=file_path,
                 Bucket=self.bucket_name,
                 Key=s3_key,
@@ -93,7 +97,10 @@ class StorageService:
             Local file path
         """
         try:
-            self.s3_client.download_file(
+            # boto3 is synchronous; run it off the event loop so concurrent
+            # requests/tasks are not blocked during the download.
+            await asyncio.to_thread(
+                self.s3_client.download_file,
                 Bucket=self.bucket_name,
                 Key=s3_key,
                 Filename=local_path,

--- a/apps/api/src/utils/validators.py
+++ b/apps/api/src/utils/validators.py
@@ -2,8 +2,54 @@
 Input validation utilities
 """
 import re
+from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
+
+
+# PDF upload constraints (mirrors the 50 MB ceiling used for audio snippets).
+MAX_PDF_SIZE_BYTES = 50 * 1024 * 1024  # 50 MB
+
+# Content types accepted for a PDF upload. ``application/octet-stream`` is
+# allowed because some browsers/clients send it for binary uploads even when the
+# file is a valid PDF; the ``.pdf`` extension check below is the primary guard.
+ALLOWED_PDF_CONTENT_TYPES = frozenset(
+    {"application/pdf", "application/x-pdf", "application/octet-stream"}
+)
+
+
+def validate_pdf_format(filename: str, content_type: Optional[str] = None) -> str:
+    """
+    Validate that an uploaded file is a PDF.
+
+    Checks the filename extension is ``.pdf`` (case-insensitive) and, when a
+    content type is supplied, that it is an accepted PDF MIME type. Lenient on a
+    generic ``application/octet-stream`` content type as long as the extension is
+    ``.pdf`` (mirrors the audio-snippet validator's tolerance for generic types).
+
+    Args:
+        filename: Original filename of the uploaded file.
+        content_type: MIME type reported by the upload (optional).
+
+    Returns:
+        The normalized extension ``"pdf"``.
+
+    Raises:
+        ValueError: If the extension is not ``.pdf`` or the content type is a
+            recognized non-PDF type.
+    """
+    ext = Path(filename or "").suffix.lstrip(".").lower()
+    if ext != "pdf":
+        raise ValueError(
+            f"Unsupported file format '.{ext}'. Only PDF files (.pdf) are allowed."
+        )
+
+    if content_type and content_type.lower() not in ALLOWED_PDF_CONTENT_TYPES:
+        raise ValueError(
+            f"Invalid content type '{content_type}'. Expected 'application/pdf'."
+        )
+
+    return ext
 
 
 def validate_email(email: str) -> bool:

--- a/apps/api/tests/test_content.py
+++ b/apps/api/tests/test_content.py
@@ -1235,6 +1235,24 @@ async def test_upload_pdf_rejects_wrong_content_type(client, episode_and_auth):
 
 
 @pytest.mark.asyncio
+async def test_upload_pdf_rejects_non_pdf_bytes(client, episode_and_auth):
+    """A .pdf/application/pdf upload whose bytes are not a PDF is rejected with 422."""
+    episode_id, headers = episode_and_auth
+
+    with patch(
+        "src.services.content_service._upload_pdf_to_s3", new_callable=AsyncMock
+    ):
+        response = await client.post(
+            f"/episodes/{episode_id}/content/upload",
+            headers=headers,
+            files={"file": ("document.pdf", io.BytesIO(b"not a real pdf"), "application/pdf")},
+        )
+
+    assert response.status_code == 422
+    assert "pdf" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
 async def test_upload_pdf_rejects_oversize(client, episode_and_auth):
     """A PDF larger than the 50MB limit is rejected with 413."""
     episode_id, headers = episode_and_auth
@@ -1252,6 +1270,24 @@ async def test_upload_pdf_rejects_oversize(client, episode_and_auth):
 
     assert response.status_code == 413
     assert "too large" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_upload_pdf_storage_not_configured(client, episode_and_auth):
+    """When S3 is not configured, the upload is rejected with 503 (not a dead record)."""
+    episode_id, headers = episode_and_auth
+
+    from src.config import settings as app_settings
+
+    with patch.object(app_settings, "AWS_S3_BUCKET", None):
+        response = await client.post(
+            f"/episodes/{episode_id}/content/upload",
+            headers=headers,
+            files=_pdf_upload_files(),
+        )
+
+    assert response.status_code == 503
+    assert "storage" in response.json()["detail"].lower()
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_content.py
+++ b/apps/api/tests/test_content.py
@@ -13,6 +13,7 @@ Tests cover:
 - Tenant isolation (skipped with justification)
 """
 
+import io
 import pytest
 from uuid import uuid4
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1126,3 +1127,145 @@ async def test_validation_error_response_format(client, episode_and_auth):
     assert "detail" in body
     assert isinstance(body["detail"], str)
     assert len(body["detail"]) > 10  # Non-trivial message
+
+
+# ============================================================================
+# PDF UPLOAD ENDPOINT TESTS (#210)
+# ============================================================================
+
+def _pdf_upload_files(filename: str = "document.pdf", content_type: str = "application/pdf",
+                      size_bytes: int = 2048):
+    """Build a multipart 'files' payload for the PDF upload endpoint."""
+    # Minimal PDF-ish bytes padded to the requested size.
+    payload = b"%PDF-1.4\n" + b"0" * max(0, size_bytes - 9)
+    return {"file": (filename, io.BytesIO(payload), content_type)}
+
+
+@pytest.mark.asyncio
+async def test_upload_pdf_success(client, episode_and_auth):
+    """Uploading a valid PDF stores it and creates a 'pdf' content source."""
+    episode_id, headers = episode_and_auth
+
+    with patch(
+        "src.services.content_service._upload_pdf_to_s3", new_callable=AsyncMock
+    ) as mock_s3, patch(
+        "src.tasks.content_extraction.extract_content_task"
+    ) as mock_task:
+        mock_s3.return_value = "https://bucket.s3.amazonaws.com/content/key.pdf"
+        response = await client.post(
+            f"/episodes/{episode_id}/content/upload",
+            headers=headers,
+            files=_pdf_upload_files(),
+            data={"description": "A test document", "auto_extract": "true"},
+        )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["source_type"] == "pdf"
+    assert data["extraction_status"] == "pending"
+    # Record carries the S3 key + original filename + mime type
+    assert data["source_data"]["filename"] == "document.pdf"
+    assert data["source_data"]["mime_type"] == "application/pdf"
+    assert data["source_data"]["s3_key"].startswith("content/")
+    assert data["source_data"]["s3_key"].endswith("_document.pdf")
+    # S3 upload was invoked with the same key recorded on the source
+    mock_s3.assert_awaited_once()
+    assert mock_s3.call_args[0][1] == data["source_data"]["s3_key"]
+    # auto_extract=True dispatches the extraction task
+    mock_task.delay.assert_called_once()
+    assert mock_task.delay.call_args.kwargs["source_type"] == "pdf"
+
+
+@pytest.mark.asyncio
+async def test_upload_pdf_no_auto_extract(client, episode_and_auth):
+    """auto_extract=false uploads without dispatching extraction."""
+    episode_id, headers = episode_and_auth
+
+    with patch(
+        "src.services.content_service._upload_pdf_to_s3", new_callable=AsyncMock
+    ) as mock_s3, patch(
+        "src.tasks.content_extraction.extract_content_task"
+    ) as mock_task:
+        mock_s3.return_value = None  # dev mode (no S3)
+        response = await client.post(
+            f"/episodes/{episode_id}/content/upload",
+            headers=headers,
+            files=_pdf_upload_files(),
+            data={"auto_extract": "false"},
+        )
+
+    assert response.status_code == 201
+    mock_task.delay.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_pdf_rejects_wrong_extension(client, episode_and_auth):
+    """A non-.pdf filename is rejected with 422."""
+    episode_id, headers = episode_and_auth
+
+    with patch(
+        "src.services.content_service._upload_pdf_to_s3", new_callable=AsyncMock
+    ):
+        response = await client.post(
+            f"/episodes/{episode_id}/content/upload",
+            headers=headers,
+            files=_pdf_upload_files(filename="notes.txt", content_type="text/plain"),
+        )
+
+    assert response.status_code == 422
+    assert ".pdf" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_upload_pdf_rejects_wrong_content_type(client, episode_and_auth):
+    """A .pdf filename with a clearly non-PDF content type is rejected with 422."""
+    episode_id, headers = episode_and_auth
+
+    with patch(
+        "src.services.content_service._upload_pdf_to_s3", new_callable=AsyncMock
+    ):
+        response = await client.post(
+            f"/episodes/{episode_id}/content/upload",
+            headers=headers,
+            files=_pdf_upload_files(filename="document.pdf", content_type="image/png"),
+        )
+
+    assert response.status_code == 422
+    assert "content type" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_upload_pdf_rejects_oversize(client, episode_and_auth):
+    """A PDF larger than the 50MB limit is rejected with 413."""
+    episode_id, headers = episode_and_auth
+
+    from src.utils.validators import MAX_PDF_SIZE_BYTES
+
+    with patch(
+        "src.services.content_service._upload_pdf_to_s3", new_callable=AsyncMock
+    ):
+        response = await client.post(
+            f"/episodes/{episode_id}/content/upload",
+            headers=headers,
+            files=_pdf_upload_files(size_bytes=MAX_PDF_SIZE_BYTES + 1024),
+        )
+
+    assert response.status_code == 413
+    assert "too large" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_upload_pdf_episode_not_found(client, authenticated_headers):
+    """Uploading to a non-existent episode returns 404."""
+    missing_episode = uuid4()
+
+    with patch(
+        "src.services.content_service._upload_pdf_to_s3", new_callable=AsyncMock
+    ):
+        response = await client.post(
+            f"/episodes/{missing_episode}/content/upload",
+            headers=authenticated_headers,
+            files=_pdf_upload_files(),
+        )
+
+    assert response.status_code == 404

--- a/apps/api/tests/test_content_extraction.py
+++ b/apps/api/tests/test_content_extraction.py
@@ -12,6 +12,7 @@ Tests cover:
 Podcastfy modules are mocked to avoid external dependencies.
 """
 
+import os
 import pytest
 from unittest.mock import Mock, patch, AsyncMock
 from uuid import uuid4
@@ -23,6 +24,18 @@ from src.services.content_extraction_service import (
 )
 from src.models import ContentSource
 from src.utils.ssrf import SSRFValidationError
+
+
+# ============================================================================
+# HELPERS
+# ============================================================================
+
+def _cleanup_leaked_temp(mock_unlink):
+	"""Remove the real temp file that a patched ``os.unlink`` spy spared."""
+	if mock_unlink.call_args:
+		path = mock_unlink.call_args[0][0]
+		if path and os.path.exists(path):
+			os.unlink(path)
 
 
 # ============================================================================
@@ -353,13 +366,18 @@ async def test_extract_from_pdf_success(
 	mock_db,
 	pdf_content_source
 ):
-	"""Test successful PDF content extraction."""
+	"""Test successful PDF content extraction: downloads from S3, extracts, cleans up."""
 	extracted_text = "This is the extracted content from the PDF document."
 
 	with patch('src.services.content_extraction_service.get_content_source_by_id') as mock_get, \
 		 patch('src.services.content_extraction_service.update_content_source') as mock_update, \
+		 patch('src.services.content_extraction_service.settings.AWS_S3_BUCKET', 'test-bucket'), \
+		 patch('src.services.content_extraction_service.StorageService') as mock_storage_cls, \
+		 patch('src.services.content_extraction_service.os.unlink') as mock_unlink, \
 		 patch.object(extraction_service.pdf_extractor, 'extract_content', return_value=extracted_text):
 
+		mock_storage = mock_storage_cls.return_value
+		mock_storage.download_file = AsyncMock(return_value="/tmp/downloaded.pdf")
 		mock_get.return_value = pdf_content_source
 
 		result = await extraction_service.extract_from_pdf(mock_db, pdf_content_source.id)
@@ -368,6 +386,19 @@ async def test_extract_from_pdf_success(
 		assert result.content == extracted_text
 		assert result.error_message is None
 		assert result.word_count == len(extracted_text.split())
+
+		# Verify the PDF was downloaded from S3 with the stored s3_key
+		mock_storage.download_file.assert_awaited_once()
+		download_args = mock_storage.download_file.call_args[0]
+		assert download_args[0] == pdf_content_source.source_data['s3_key']
+
+		# The downloaded temp path is what gets extracted (not a data/uploads path)
+		extract_path = extraction_service.pdf_extractor.extract_content.call_args[0][0]
+		assert extract_path == download_args[1]
+
+		# Temp file is always cleaned up
+		mock_unlink.assert_called_once()
+		_cleanup_leaked_temp(mock_unlink)
 
 		# Verify database updates
 		assert mock_update.call_count == 2  # extracting, then complete
@@ -384,13 +415,18 @@ async def test_extract_from_pdf_file_not_found(
 	mock_db,
 	pdf_content_source
 ):
-	"""Test PDF extraction with file not found error."""
+	"""Test PDF extraction when the extractor raises FileNotFoundError."""
 	file_error = FileNotFoundError("File not found")
 
 	with patch('src.services.content_extraction_service.get_content_source_by_id') as mock_get, \
 		 patch('src.services.content_extraction_service.update_content_source') as mock_update, \
+		 patch('src.services.content_extraction_service.settings.AWS_S3_BUCKET', 'test-bucket'), \
+		 patch('src.services.content_extraction_service.StorageService') as mock_storage_cls, \
+		 patch('src.services.content_extraction_service.os.unlink') as mock_unlink, \
 		 patch.object(extraction_service.pdf_extractor, 'extract_content', side_effect=file_error):
 
+		mock_storage = mock_storage_cls.return_value
+		mock_storage.download_file = AsyncMock(return_value="/tmp/downloaded.pdf")
 		mock_get.return_value = pdf_content_source
 
 		result = await extraction_service.extract_from_pdf(mock_db, pdf_content_source.id)
@@ -398,7 +434,13 @@ async def test_extract_from_pdf_file_not_found(
 		assert result.success is False
 		assert result.content is None
 		assert "not found" in result.error_message.lower()
-		assert "data/uploads/document.pdf" in result.error_message
+		# Error references the S3 key, not the old hard-coded local path
+		assert pdf_content_source.source_data['s3_key'] in result.error_message
+		assert "data/uploads" not in result.error_message
+
+		# Temp file still cleaned up on failure
+		mock_unlink.assert_called_once()
+		_cleanup_leaked_temp(mock_unlink)
 
 		# Verify failure status update
 		final_call = mock_update.call_args_list[-1]
@@ -416,8 +458,13 @@ async def test_extract_from_pdf_corrupted_file(
 
 	with patch('src.services.content_extraction_service.get_content_source_by_id') as mock_get, \
 		 patch('src.services.content_extraction_service.update_content_source') as mock_update, \
+		 patch('src.services.content_extraction_service.settings.AWS_S3_BUCKET', 'test-bucket'), \
+		 patch('src.services.content_extraction_service.StorageService') as mock_storage_cls, \
+		 patch('src.services.content_extraction_service.os.unlink') as mock_unlink, \
 		 patch.object(extraction_service.pdf_extractor, 'extract_content', side_effect=extraction_error):
 
+		mock_storage = mock_storage_cls.return_value
+		mock_storage.download_file = AsyncMock(return_value="/tmp/downloaded.pdf")
 		mock_get.return_value = pdf_content_source
 
 		result = await extraction_service.extract_from_pdf(mock_db, pdf_content_source.id)
@@ -425,7 +472,64 @@ async def test_extract_from_pdf_corrupted_file(
 		assert result.success is False
 		assert "corrupted file" in result.error_message.lower()
 
+		mock_unlink.assert_called_once()
+		_cleanup_leaked_temp(mock_unlink)
+
 		# Verify failure status update
+		final_call = mock_update.call_args_list[-1]
+		assert final_call[0][2].extraction_status == 'failed'
+
+
+@pytest.mark.asyncio
+async def test_extract_from_pdf_storage_not_configured(
+	extraction_service,
+	mock_db,
+	pdf_content_source
+):
+	"""PDF extraction fails clearly when S3 is not configured (no dead local path)."""
+	with patch('src.services.content_extraction_service.get_content_source_by_id') as mock_get, \
+		 patch('src.services.content_extraction_service.update_content_source') as mock_update, \
+		 patch('src.services.content_extraction_service.settings.AWS_S3_BUCKET', None):
+
+		mock_get.return_value = pdf_content_source
+
+		result = await extraction_service.extract_from_pdf(mock_db, pdf_content_source.id)
+
+		assert result.success is False
+		assert "not configured" in result.error_message.lower()
+
+		# Only the failure update — extraction never started
+		assert mock_update.call_count == 1
+		assert mock_update.call_args[0][2].extraction_status == 'failed'
+
+
+@pytest.mark.asyncio
+async def test_extract_from_pdf_download_failure(
+	extraction_service,
+	mock_db,
+	pdf_content_source
+):
+	"""PDF extraction fails (and cleans up) when the S3 download errors."""
+	with patch('src.services.content_extraction_service.get_content_source_by_id') as mock_get, \
+		 patch('src.services.content_extraction_service.update_content_source') as mock_update, \
+		 patch('src.services.content_extraction_service.settings.AWS_S3_BUCKET', 'test-bucket'), \
+		 patch('src.services.content_extraction_service.StorageService') as mock_storage_cls, \
+		 patch('src.services.content_extraction_service.os.unlink') as mock_unlink:
+
+		mock_storage = mock_storage_cls.return_value
+		mock_storage.download_file = AsyncMock(
+			side_effect=Exception("Failed to download file from S3: NoSuchKey")
+		)
+		mock_get.return_value = pdf_content_source
+
+		result = await extraction_service.extract_from_pdf(mock_db, pdf_content_source.id)
+
+		assert result.success is False
+		assert "error extracting pdf content" in result.error_message.lower()
+
+		mock_unlink.assert_called_once()
+		_cleanup_leaked_temp(mock_unlink)
+
 		final_call = mock_update.call_args_list[-1]
 		assert final_call[0][2].extraction_status == 'failed'
 

--- a/apps/api/tests/test_pdf_pipeline_integration.py
+++ b/apps/api/tests/test_pdf_pipeline_integration.py
@@ -1,0 +1,117 @@
+"""
+End-to-end integration test for the PDF pipeline (issue #210).
+
+Exercises the full upload → extract → generate flow with S3 and the Podcastfy
+engine mocked, proving that:
+- A PDF upload stores the file (S3) and records s3_key/filename on a 'pdf' source.
+- Extraction downloads the PDF from S3 by its s3_key and populates
+  extracted_content, transitioning pending → extracting → complete.
+- Generation then resolves the source to extracted text (never a raw s3_key),
+  dispatching the engine with text_content rather than rejecting the file source.
+"""
+
+import io
+import pytest
+from uuid import UUID, uuid4
+from unittest.mock import AsyncMock, patch
+
+from src.services.content_extraction_service import ContentExtractionService
+
+
+def _pdf_files(filename: str = "whitepaper.pdf"):
+    payload = b"%PDF-1.4\n" + b"0" * 2048
+    return {"file": (filename, io.BytesIO(payload), "application/pdf")}
+
+
+@pytest.fixture
+async def episode_and_auth(client):
+    """Create a user, project, and episode; return (episode_id, headers)."""
+    reg = await client.post("/auth/register", json={
+        "email": f"test_{uuid4()}@example.com",
+        "password": "SecurePass123!",
+        "full_name": "Test User",
+    })
+    assert reg.status_code == 201
+    headers = {"Authorization": f"Bearer {reg.json()['access_token']}"}
+
+    proj = await client.post("/projects", headers=headers, json={
+        "name": "PDF Project",
+        "podcast_metadata": {
+            "show_title": "Show", "author": "Author", "description": "Desc",
+        },
+    })
+    assert proj.status_code == 201
+    project_id = proj.json()["id"]
+
+    ep = await client.post("/episodes", headers=headers, json={
+        "project_id": project_id,
+        "episode_number": 1,
+        "episode_metadata": {"title": "Ep", "description": "Desc"},
+    })
+    assert ep.status_code == 201
+    return ep.json()["id"], headers
+
+
+@pytest.mark.asyncio
+async def test_pdf_upload_extract_generate_pipeline(client, test_db, episode_and_auth):
+    episode_id, headers = episode_and_auth
+
+    # ---- 1. Upload the PDF (no auto-extract; we drive extraction explicitly) ----
+    with patch(
+        "src.services.content_service._upload_pdf_to_s3", new_callable=AsyncMock
+    ) as mock_upload:
+        mock_upload.return_value = "https://bucket.s3.amazonaws.com/content/x.pdf"
+        upload = await client.post(
+            f"/episodes/{episode_id}/content/upload",
+            headers=headers,
+            files=_pdf_files(),
+            data={"auto_extract": "false"},
+        )
+
+    assert upload.status_code == 201
+    source = upload.json()
+    content_id = source["id"]
+    s3_key = source["source_data"]["s3_key"]
+    assert source["extraction_status"] == "pending"
+    assert s3_key  # recorded for extraction to resolve
+
+    # ---- 2. Extract: downloads from S3 by s3_key, populates extracted_content ----
+    extracted_text = "Extracted whitepaper body. " * 20
+    service = ContentExtractionService()
+
+    with patch(
+        "src.services.content_extraction_service.settings.AWS_S3_BUCKET", "test-bucket"
+    ), patch(
+        "src.services.content_extraction_service.StorageService"
+    ) as mock_storage_cls, patch.object(
+        service.pdf_extractor, "extract_content", return_value=extracted_text
+    ):
+        mock_storage = mock_storage_cls.return_value
+        mock_storage.download_file = AsyncMock(return_value="/tmp/x.pdf")
+
+        result = await service.extract_from_pdf(test_db, UUID(content_id))
+
+    assert result.success is True
+    # The s3_key (not a local data/uploads path) is what was downloaded
+    assert mock_storage.download_file.call_args[0][0] == s3_key
+
+    # Status transitioned to complete and extracted_content is populated
+    status_resp = await client.get(
+        f"/content/{content_id}/extraction-status", headers=headers
+    )
+    assert status_resp.status_code == 200
+    assert status_resp.json()["extraction_status"] == "complete"
+
+    # ---- 3. Generate: source resolves to text, engine gets text_content ----
+    with patch("src.routers.generation.generate_podcast_task") as mock_task:
+        mock_task.delay.return_value.id = "celery-task-123"
+        gen = await client.post(
+            f"/generation/episodes/{episode_id}/generate", headers=headers
+        )
+
+    assert gen.status_code == 202
+    mock_task.delay.assert_called_once()
+    kwargs = mock_task.delay.call_args.kwargs
+    # The PDF was resolved to extracted text — not rejected as an unextracted file
+    assert kwargs["text_content"] is not None
+    assert "Extracted whitepaper body" in kwargs["text_content"]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -129,6 +129,58 @@ generate endpoint sets it to `"queued"` on dispatch. `regenerate_podcast` delega
 
 ---
 
+## Active work — Issue #210 (P2.5): PDF/file input non-functional
+
+**Plan source:** comment (CodeRabbit coding plan), adapted to the codebase.
+**Branch:** `fix/210-pdf-upload-s3-extraction`
+
+**Problem:** The `pdf` source type requires `s3_key`+`filename`, but (1) there is no upload
+endpoint to store a PDF and create the record, and (2) `extract_from_pdf` ignores `s3_key`
+and reads a hard-coded `data/uploads/{filename}` local path that nothing writes → every PDF
+extraction fails with FileNotFoundError.
+
+**Verified in codebase:** content router has no prefix (routes `/episodes/{id}/content`,
+`/content/{id}`); settings use `AWS_S3_BUCKET`/`AWS_REGION`; `StorageService.download_file`
+exists but is unused; `audio_snippet_service` is the canonical multipart→S3→record pattern
+(module-level `_upload_to_s3` helper, mocked in tests); `validators.py` already has
+`sanitize_filename`. **`generation.py` was already refactored by #214/#217** to reject
+unextracted file/pdf sources (HTTP 400) and feed the engine `extracted_content` — it no
+longer passes raw `s3_key` to the engine.
+
+### Steps
+- [ ] **1. PDF validation util** (`src/utils/validators.py`): `validate_pdf_format(filename,
+      content_type)`; `MAX_PDF_SIZE_BYTES = 50MB`.
+- [ ] **2. PDF upload service** (`src/services/content_service.py`): `upload_pdf_content(...)`
+      + module helper `_upload_pdf_to_s3` (None in dev when `AWS_S3_BUCKET` unset). S3 key
+      `content/{tenant_id}/{episode_id}/{uuid}_{sanitized}`.
+- [ ] **3. Upload endpoint** (`src/routers/content.py`): `POST /episodes/{episode_id}/content/upload`
+      (multipart `file`, `description`, `auto_extract=True`); dispatch extract task when `auto_extract`.
+- [ ] **4. Fix PDF extraction (CORE)** (`src/services/content_extraction_service.py`): remove TODO +
+      `data/uploads/`; download `s3_key` via `StorageService.download_file` to a temp `.pdf`; extract;
+      `os.unlink` in `finally`; clear error when storage unconfigured/download fails.
+- [ ] **5. StorageService async-safe** (`src/services/storage_service.py`): wrap boto3
+      `download_file`/`upload_file` in `asyncio.to_thread`.
+- [ ] **6. Tests**: `test_content.py` (upload success/wrong-ext/wrong-type/oversize/source_data);
+      `test_content_extraction.py` (mock `download_file`, assert s3_key + temp cleanup, replace old
+      `data/uploads/` assertion); new `test_pdf_pipeline_integration.py` (upload → extract → generate,
+      `pending→extracting→complete`).
+
+### Acceptance criteria
+- [ ] Multipart upload endpoint stores PDFs to S3 and records `s3_key`/`filename`.
+- [ ] Extraction downloads from S3 via `StorageService.download_file`; TODO removed.
+- [ ] `s3_key` resolved to text before the engine (via extraction → `extracted_content`).
+- [ ] Integration test: upload → extract → generate.
+
+### Deviations from CodeRabbit plan
+1. **Phase 2 Task 2 (generation router file_paths) is obsolete** — already handled by #214/#217;
+   the AC "resolve s3_key before the engine" is met via the extraction path. Re-adding raw-path
+   passing would regress that design (podcastfy 0.4.1 has no file-path kwarg), so `generation.py`
+   is left unchanged.
+2. Settings keys are `AWS_S3_BUCKET`/`AWS_REGION` (not `S3_BUCKET_NAME`).
+3. Reuse existing `sanitize_filename`; no new shared S3→temp helper needed (generation untouched).
+
+---
+
 ## Ops changes already made this session
 - README server IP removed (commit `bf9e606`).
 - gitleaks pre-commit secret scanner added.


### PR DESCRIPTION
## Summary

Closes #210. The `pdf`/`file` source type was advertised but unusable end-to-end:
there was **no upload endpoint**, and `extract_from_pdf` read a hard-coded
`data/uploads/{filename}` local path (never written) while ignoring the stored
`s3_key` — so every PDF extraction failed with `FileNotFoundError`.

## What changed

- **Upload endpoint** — `POST /episodes/{episode_id}/content/upload` (multipart):
  stores the PDF in S3 and creates a `source_type='pdf'` content source recording
  `s3_key`/`filename`/`mime_type`, optionally auto-dispatching extraction. Mirrors the
  existing `audio_snippets` upload pattern.
- **Validation** — `validate_pdf_format` + `MAX_PDF_SIZE_BYTES` (50 MB) in `utils/validators.py`;
  the service also checks the `%PDF-` magic header so non-PDF bytes are rejected synchronously (422),
  and rejects uploads with **503** when S3 is not configured (no dead, unretrievable records).
- **CORE fix** — `extract_from_pdf` now downloads the PDF from S3 via
  `StorageService.download_file` into a temp file (cleaned up in `finally`) and extracts from it.
  TODO and dead local path removed; clear failure when storage is unconfigured.
- **Async-safety** — `StorageService.upload_file`/`download_file` wrap the blocking boto3 calls
  in `asyncio.to_thread`.

## Acceptance criteria

- [x] Multipart upload endpoint stores PDFs to S3 and records `s3_key`/`filename`.
- [x] Extraction downloads from S3 via `StorageService.download_file`; TODO removed.
- [x] `s3_key` resolved to text before the engine (via the extraction path → `extracted_content`).
- [x] Integration test: upload → extract → generate (`tests/test_pdf_pipeline_integration.py`).

## Tests

- `test_content.py`: upload success / no-auto-extract / wrong-ext / wrong-content-type /
  non-PDF-bytes / oversize / storage-not-configured / episode-not-found.
- `test_content_extraction.py`: S3-download behavior, temp cleanup on success & failure,
  storage-not-configured, download failure (old `data/uploads/` assertion replaced).
- New `test_pdf_pipeline_integration.py`: full upload → extract → generate.
- Full API suite green (661 passed); `ruff` clean. Cross-family review by `codex` (2 P2 findings addressed).

## Known limitations / deviations

- **Generation router unchanged by design.** CodeRabbit's plan proposed downloading `s3_key` →
  temp and passing file paths to the engine in `generation.py`. That router was already refactored
  by #214/#217 to reject unextracted file/pdf sources (HTTP 400) and feed the engine
  `extracted_content` — podcastfy 0.4.1 has no file-path kwarg. The "resolve `s3_key` before the
  engine" criterion is met via the **extraction path** (download → extract → text); re-adding
  raw-path passing would regress that design, so the router is left as-is.
- Scope is **PDF** only (per the issue). `image` file sources remain unsupported for upload.
- Dev/local mode (no `AWS_S3_BUCKET`) intentionally rejects PDF uploads with 503.
- The `%PDF-` check is a lightweight header guard, not full structural PDF validation.