### PR TITLE
fix(distribution): wire active targets into generation + populate episode metadata (#211)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,7 @@ podcastfy/
 # Large notebook files
 podcastfy.ipynb
 usage/examples.ipynb
+# Local demo artifacts (issue-lifecycle demo verification — never committed)
+demo.md
+demo_*.md
+demo_*_runner.py

--- a/apps/api/src/routers/generation.py
+++ b/apps/api/src/routers/generation.py
@@ -232,14 +232,44 @@ async def generate_podcast(
     # distribution stage actually fires (issue #211): the task gates distribution
     # on `enable_distribution and bool(platforms)`, so without this the subsystem
     # is unreachable. Configs stay encrypted here; the task decrypts them.
+    # Distribution requires a publicly reachable audio URL, i.e. an S3 bucket. With
+    # no bucket the workflow-chain path would schedule an invalid empty-bucket
+    # upload and fail the whole run, whereas the default finalization path degrades
+    # gracefully — so only enable distribution when a bucket is configured.
+    if use_distribution and not settings.AWS_S3_BUCKET:
+        logger.warning(
+            "Episode %s: distribution requested but AWS_S3_BUCKET is not configured "
+            "— skipping distribution.",
+            episode_id,
+        )
+        use_distribution = False
+
     if use_distribution:
         active_targets = await get_active_distribution_targets_for_project(
             db, episode.project_id
         )
         if active_targets:
-            extra_kwargs["platforms"] = {
-                target.target_type: target.config for target in active_targets
-            }
+            # platforms is keyed by platform type (the task's contract), so it
+            # holds at most one config per type. When several active targets share
+            # a type, prefer the project-scoped one over an account-level
+            # (project_id IS NULL) target, then the newest — so an explicit project
+            # target always wins over a global default and we never publish to the
+            # wrong destination. Dropped same-type duplicates are logged rather than
+            # collapsed silently (multi-target-per-type distribution is a follow-up).
+            # The query returns newest-first; a stable sort by "is account-level"
+            # keeps project-scoped targets ahead while preserving newest-first order.
+            ordered_targets = sorted(active_targets, key=lambda t: t.project_id is None)
+            platforms: dict = {}
+            for target in ordered_targets:
+                if target.target_type in platforms:
+                    logger.warning(
+                        "Episode %s: multiple active %s targets apply to project %s; "
+                        "using the preferred target and skipping target %s.",
+                        episode_id, target.target_type, episode.project_id, target.id,
+                    )
+                    continue
+                platforms[target.target_type] = target.config
+            extra_kwargs["platforms"] = platforms
         else:
             logger.info(
                 "Episode %s: distribution requested but no active targets for "

--- a/apps/api/src/routers/generation.py
+++ b/apps/api/src/routers/generation.py
@@ -18,6 +18,9 @@ from ..models.project import Project
 from ..models.content_source import ContentSource
 from ..models.user import User
 from ..dependencies import get_current_user
+from ..services.distribution_target_service import (
+    get_active_distribution_targets_for_project,
+)
 from ..tasks.podcast_generation import generate_podcast_task
 
 logger = logging.getLogger(__name__)
@@ -224,6 +227,25 @@ async def generate_podcast(
         extra_kwargs["tts_model"] = tts_model
     if conversation_config is not None:
         extra_kwargs["conversation_config"] = conversation_config
+
+    # Load active distribution targets and build the platforms mapping so the
+    # distribution stage actually fires (issue #211): the task gates distribution
+    # on `enable_distribution and bool(platforms)`, so without this the subsystem
+    # is unreachable. Configs stay encrypted here; the task decrypts them.
+    if use_distribution:
+        active_targets = await get_active_distribution_targets_for_project(
+            db, episode.project_id
+        )
+        if active_targets:
+            extra_kwargs["platforms"] = {
+                target.target_type: target.config for target in active_targets
+            }
+        else:
+            logger.info(
+                "Episode %s: distribution requested but no active targets for "
+                "project %s — skipping distribution.",
+                episode_id, episode.project_id,
+            )
 
     # Start Celery task
     task = generate_podcast_task.delay(

--- a/apps/api/src/services/distribution_target_service.py
+++ b/apps/api/src/services/distribution_target_service.py
@@ -14,7 +14,7 @@ from uuid import UUID
 
 import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, func
+from sqlalchemy import select, func, or_
 
 from ..models.distribution_target import DistributionTarget
 from ..schemas.distribution_target import (
@@ -337,28 +337,36 @@ async def get_active_distribution_targets_for_project(
 	project_id: UUID,
 ) -> list[DistributionTarget]:
 	"""
-	Get all active distribution targets scoped to a project.
+	Get the active distribution targets that apply when generating for a project.
 
 	Used by the generation flow to build the ``platforms`` mapping passed to the
 	Celery task so distribution actually fires (issue #211). RLS filters by tenant
-	automatically; here we additionally require an explicit project scope and an
-	active target.
+	automatically; on top of that this returns active targets that are either
+	scoped to this project OR account-level (``project_id IS NULL``).
+
+	Account-level targets must be included because the Spotify OAuth callback
+	creates targets without a project (``create_spotify_target`` is called with no
+	``project_id``), so a project-only filter would leave Spotify — a primary
+	supported platform — permanently unreachable.
 
 	Credentials in each target's ``config`` remain encrypted at this layer — the
 	distribution task decrypts them just before dispatch.
 
 	Args:
 		db: Database session
-		project_id: Project whose active targets should be loaded
+		project_id: Project the episode being generated belongs to
 
 	Returns:
-		List of active DistributionTarget rows for the project, newest first
-		(empty if the project has no active targets).
+		List of applicable active DistributionTarget rows, newest first (empty if
+		there are none).
 	"""
 	result = await db.execute(
 		select(DistributionTarget)
 		.where(
-			DistributionTarget.project_id == project_id,
+			or_(
+				DistributionTarget.project_id == project_id,
+				DistributionTarget.project_id.is_(None),
+			),
 			DistributionTarget.is_active.is_(True),
 		)
 		.order_by(DistributionTarget.created_at.desc())

--- a/apps/api/src/services/distribution_target_service.py
+++ b/apps/api/src/services/distribution_target_service.py
@@ -332,6 +332,40 @@ async def get_distribution_targets(
 	return list(targets), total
 
 
+async def get_active_distribution_targets_for_project(
+	db: AsyncSession,
+	project_id: UUID,
+) -> list[DistributionTarget]:
+	"""
+	Get all active distribution targets scoped to a project.
+
+	Used by the generation flow to build the ``platforms`` mapping passed to the
+	Celery task so distribution actually fires (issue #211). RLS filters by tenant
+	automatically; here we additionally require an explicit project scope and an
+	active target.
+
+	Credentials in each target's ``config`` remain encrypted at this layer — the
+	distribution task decrypts them just before dispatch.
+
+	Args:
+		db: Database session
+		project_id: Project whose active targets should be loaded
+
+	Returns:
+		List of active DistributionTarget rows for the project, newest first
+		(empty if the project has no active targets).
+	"""
+	result = await db.execute(
+		select(DistributionTarget)
+		.where(
+			DistributionTarget.project_id == project_id,
+			DistributionTarget.is_active.is_(True),
+		)
+		.order_by(DistributionTarget.created_at.desc())
+	)
+	return list(result.scalars().all())
+
+
 async def get_distribution_target_by_id(
 	db: AsyncSession,
 	target_id: UUID,

--- a/apps/api/src/services/spotify_service.py
+++ b/apps/api/src/services/spotify_service.py
@@ -108,7 +108,13 @@ class SpotifyService:
 		if duration_seconds is not None:
 			payload["duration_ms"] = int(float(duration_seconds) * 1000)
 		if metadata.get("audio_url"):
-			payload["audio_preview_url"] = metadata["audio_url"]
+			# Spotify for Podcasters primarily ingests episodes through the show's
+			# RSS feed; the catalog Web API exposes audio only as the read-only
+			# `audio_preview_url`, which is not a valid field for submitting episode
+			# audio. Send the audio under `audio_url` (the submission field) instead
+			# of the read-only preview field. Direct API publishing remains
+			# best-effort and subject to platform limitations (issue #211).
+			payload["audio_url"] = metadata["audio_url"]
 
 		logger.info(
 			"Publishing episode to Spotify show %s: %s",

--- a/apps/api/src/tasks/callbacks.py
+++ b/apps/api/src/tasks/callbacks.py
@@ -129,6 +129,9 @@ def on_composition_complete(self: Task, result: Dict[str, Any], episode_id: str)
 		episode_id,
 		updates={
 			"file_path": result.get("output_path"),
+			# Persist the composed duration to the column so distribution publishes
+			# the composed length, not the pre-composition one (issue #211).
+			"duration_seconds": result.get("duration_seconds"),
 			"generation_status": "composing",
 		},
 		progress_updates={

--- a/apps/api/src/tasks/platform_distribution.py
+++ b/apps/api/src/tasks/platform_distribution.py
@@ -60,6 +60,41 @@ def _decrypt_platform_config(config: Dict[str, Any], platform: str) -> Dict[str,
     return decrypted
 
 
+def _merge_episode_metadata(episode: Any, passed_metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Build distribution metadata from an Episode row, overlaying any passed-in values.
+
+    The workflow builder passes an empty ``episode_metadata`` because the audio's
+    ``s3_url`` is only set by the upload stage that runs *before* distribution in
+    the chain (issue #211). This reads the fresh Episode so Spotify/Apple/webhook
+    receive a real title, description and audio URL instead of blanks.
+
+    Args:
+        episode: Episode ORM row (or any object exposing the same attributes).
+        passed_metadata: Metadata forwarded by the caller; takes precedence over
+            DB-sourced values for any key it provides (with a non-None value).
+
+    Returns:
+        Merged metadata dict. DB-sourced keys with a ``None`` value are omitted so
+        downstream services fall back to their own defaults.
+    """
+    episode_meta = getattr(episode, "episode_metadata", None) or {}
+    duration = getattr(episode, "duration_seconds", None)
+    base: Dict[str, Any] = {
+        "title": episode_meta.get("title"),
+        "description": episode_meta.get("description"),
+        "duration_seconds": float(duration) if duration is not None else None,
+        "audio_url": getattr(episode, "s3_url", None),
+        "explicit": episode_meta.get("explicit", False),
+        "publish_date": episode_meta.get("publication_date"),
+    }
+    merged = {key: value for key, value in base.items() if value is not None}
+    for key, value in (passed_metadata or {}).items():
+        if value is not None:
+            merged[key] = value
+    return merged
+
+
 @celery_app.task(bind=True, name="distribute_to_platform", time_limit=300, max_retries=5)
 def distribute_to_platform_task(
     self: Task,
@@ -91,6 +126,28 @@ def distribute_to_platform_task(
                 'status': f'Starting distribution to {platform}...'
             }
         )
+
+        # Populate episode metadata from the DB. The workflow builder passes an
+        # empty dict because s3_url is only set by the upload stage that runs
+        # before this task; loading the Episode here ensures non-empty
+        # title/description/audio_url (issue #211). Any passed-in values win.
+        try:
+            from src.models.episode import Episode
+            from uuid import UUID as _UUID
+            with SyncSessionLocal() as db:
+                episode = db.get(Episode, _UUID(episode_id))
+                if episode is not None:
+                    episode_metadata = _merge_episode_metadata(episode, episode_metadata)
+                else:
+                    logger.warning(
+                        "Episode %s not found while building distribution metadata",
+                        episode_id,
+                    )
+        except Exception as e:
+            logger.warning(
+                "Could not load episode metadata for %s (%s); using passed-in metadata",
+                episode_id, e,
+            )
 
         # Decrypt any encrypted credentials in the config
         try:

--- a/apps/api/src/tasks/platform_distribution.py
+++ b/apps/api/src/tasks/platform_distribution.py
@@ -128,25 +128,37 @@ def distribute_to_platform_task(
         )
 
         # Populate episode metadata from the DB. The workflow builder passes an
-        # empty dict because s3_url is only set by the upload stage that runs
-        # before this task; loading the Episode here ensures non-empty
-        # title/description/audio_url (issue #211). Any passed-in values win.
-        try:
-            from src.models.episode import Episode
-            from uuid import UUID as _UUID
-            with SyncSessionLocal() as db:
-                episode = db.get(Episode, _UUID(episode_id))
-                if episode is not None:
-                    episode_metadata = _merge_episode_metadata(episode, episode_metadata)
-                else:
-                    logger.warning(
-                        "Episode %s not found while building distribution metadata",
-                        episode_id,
-                    )
-        except Exception as e:
+        # empty dict because the audio (and its Episode.s3_url) is only available
+        # after the upload stage that runs before this task; loading the Episode
+        # here yields non-empty title/description/audio_url (issue #211). Any
+        # passed-in values win.
+        from src.models.episode import Episode
+        from uuid import UUID as _UUID
+        with SyncSessionLocal() as db:
+            episode = db.get(Episode, _UUID(episode_id))
+            if episode is not None:
+                episode_metadata = _merge_episode_metadata(episode, episode_metadata)
+            else:
+                logger.warning(
+                    "Episode %s not found while building distribution metadata",
+                    episode_id,
+                )
+
+        # Never publish an episode whose audio was not actually uploaded. s3_url is
+        # written by on_upload_complete only on a successful upload, so its absence
+        # means the upload either failed or has not committed yet. Raising a
+        # transient error lets the retry handler below wait (the success callback
+        # races this chain task); after the retry budget is exhausted the task fails
+        # without publishing rather than pushing a non-existent audio URL to the
+        # platform (issue #211).
+        if not episode_metadata.get("audio_url"):
             logger.warning(
-                "Could not load episode metadata for %s (%s); using passed-in metadata",
-                episode_id, e,
+                "Episode %s audio not available yet (no s3_url) for %s distribution; "
+                "retrying before giving up.",
+                episode_id, platform,
+            )
+            raise RuntimeError(
+                f"Episode {episode_id} has no uploaded audio URL yet; cannot distribute."
             )
 
         # Decrypt any encrypted credentials in the config

--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -504,6 +504,10 @@ def build_generation_workflow(
 	# Stage: platform distribution (optional)
 	if enable_distribution and platforms:
 		for platform_name, platform_config in platforms.items():
+			# episode_metadata is populated inside distribute_to_platform_task
+			# from the fresh Episode row. We pass {} here because s3_url is only
+			# set by the upload stage above, so any metadata built now would have
+			# a null audio_url (issue #211).
 			dist_sig = distribute_to_platform_task.s(
 				episode_id=episode_id,
 				platform=platform_name,

--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -177,6 +177,27 @@ def generate_podcast_task(
         )
 
         if use_workflow_chain:
+            # Persist the generated file metadata before handing off to the
+            # workflow chain. The chain's callbacks only write S3 fields/status, so
+            # without this any episode generated with composition or distribution
+            # would lose file_path/transcript_path/duration_seconds/file_size_bytes
+            # that the default finalize path records (issue #211).
+            try:
+                with SyncSessionLocal() as db:
+                    episode = db.get(Episode, uuid_module.UUID(episode_id))
+                    if episode is not None:
+                        episode.file_path = audio_file_path
+                        episode.transcript_path = generation_result.get("transcript_path")
+                        episode.duration_seconds = duration_seconds
+                        episode.file_size_bytes = file_size_bytes
+                        db.commit()
+            except Exception as persist_err:
+                logger.error(
+                    "Episode %s: failed to persist generation metadata before "
+                    "workflow dispatch: %s",
+                    episode_id, persist_err,
+                )
+
             # Trigger the full workflow: S3 upload → [composition] → [distribution]
             # Isolated try/except so a broker hiccup cannot mark a successful
             # generation as "failed" or orphan the audio file.
@@ -473,23 +494,25 @@ def build_generation_workflow(
 	bucket = s3_bucket or settings.AWS_S3_BUCKET or ""
 	s3_key = f"podcasts/episode-{episode_id}.mp3"
 
-	# Stage: S3 upload
-	upload_sig = upload_to_s3_task.s(
-		file_path=audio_file_path,
-		s3_key=s3_key,
-		bucket_name=bucket,
-		content_type="audio/mpeg",
-	).set(
-		link=on_upload_complete.s(episode_id=episode_id),
-		link_error=on_workflow_failure.s(episode_id=episode_id, task_name="upload_to_s3"),
-	)
+	# Chain stages use immutable signatures (.si). In a Celery chain a mutable
+	# .s() signature has the *previous* task's return value prepended as the first
+	# positional arg; since these stages are called with keyword args (episode_id=…)
+	# that would raise "got multiple values for argument 'episode_id'" at runtime.
+	# Each stage re-reads the Episode from the DB (state is persisted by the
+	# on_*_complete callbacks), so it does not need the prior task's result.
 
-	workflow_tasks = [upload_sig]
+	workflow_tasks = []
+
+	# Composition runs BEFORE upload so the artifact uploaded to S3 — and therefore
+	# the one distributed — is the composed file, not the pre-composition audio
+	# (issue #211). Without distribution/composition reordering, enabling both would
+	# publish the uncomposed audio.
+	final_audio_path = audio_file_path
 
 	# Stage: audio composition (optional)
 	if enable_composition:
 		composed_output = output_path or f"/tmp/composed_{episode_id}.mp3"
-		composition_sig = merge_audio_snippets_task.s(
+		composition_sig = merge_audio_snippets_task.si(
 			episode_id=episode_id,
 			timeline=composition_timeline or [],
 			output_path=composed_output,
@@ -500,15 +523,28 @@ def build_generation_workflow(
 			),
 		)
 		workflow_tasks.append(composition_sig)
+		final_audio_path = composed_output
 
-	# Stage: platform distribution (optional)
+	# Stage: S3 upload of the final artifact (composed if composition ran). On
+	# success on_upload_complete persists Episode.s3_url; distribution gates on that
+	# committed s3_url, so a failed upload never results in a published episode.
+	upload_sig = upload_to_s3_task.si(
+		file_path=final_audio_path,
+		s3_key=s3_key,
+		bucket_name=bucket,
+		content_type="audio/mpeg",
+	).set(
+		link=on_upload_complete.s(episode_id=episode_id),
+		link_error=on_workflow_failure.s(episode_id=episode_id, task_name="upload_to_s3"),
+	)
+	workflow_tasks.append(upload_sig)
+
+	# Stage: platform distribution (optional). All metadata (title/description/
+	# duration/explicit/audio_url) is read from the fresh Episode row inside
+	# distribute_to_platform_task, which waits for the committed s3_url (issue #211).
 	if enable_distribution and platforms:
 		for platform_name, platform_config in platforms.items():
-			# episode_metadata is populated inside distribute_to_platform_task
-			# from the fresh Episode row. We pass {} here because s3_url is only
-			# set by the upload stage above, so any metadata built now would have
-			# a null audio_url (issue #211).
-			dist_sig = distribute_to_platform_task.s(
+			dist_sig = distribute_to_platform_task.si(
 				episode_id=episode_id,
 				platform=platform_name,
 				platform_config=platform_config,

--- a/apps/api/tests/test_celery_workflow.py
+++ b/apps/api/tests/test_celery_workflow.py
@@ -155,6 +155,58 @@ class TestFullWorkflowChain:
         assert call_kwargs["platforms"] == platforms
         mock_chain.apply_async.assert_called_once()
 
+    def test_generation_metadata_persisted_before_workflow_dispatch(self):
+        """File metadata is written to the Episode before the workflow chain runs.
+
+        The workflow callbacks only persist S3 fields, so distribution/composition
+        runs would otherwise lose file_path/transcript_path/duration_seconds/
+        file_size_bytes that the default finalize path records (issue #211).
+        """
+        import sys
+        import types
+
+        episode_id = str(uuid.uuid4())
+        platforms = {"webhook": {"url": "https://hook.example.com"}}
+
+        mock_audio_segment = MagicMock()
+        mock_audio_segment.__len__ = MagicMock(return_value=120_000)  # 120.0s
+
+        mock_client = MagicMock()
+        mock_podcastfy = types.ModuleType("podcastfy")
+        mock_podcastfy.client = mock_client
+        mock_client.generate_podcast = MagicMock(return_value="/tmp/dist_meta.mp3")
+
+        mock_episode = MagicMock()
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_episode
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        from src.tasks.podcast_generation import generate_podcast_task
+
+        with (
+            patch.dict(sys.modules, {"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
+            patch("src.tasks.podcast_generation.os.path.getsize", return_value=2000),
+            patch("src.tasks.podcast_generation.AudioSegment") as mock_audio_cls,
+            patch("src.tasks.podcast_generation.build_generation_workflow", return_value=MagicMock()),
+            patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=mock_session),
+        ):
+            mock_audio_cls.from_file.return_value = mock_audio_segment
+            result = _invoke_task(
+                generate_podcast_task,
+                episode_id=episode_id,
+                urls=["https://example.com"],
+                enable_composition=False,
+                enable_distribution=True,
+                platforms=platforms,
+            )
+
+        assert result["status"] == "success"
+        assert mock_episode.file_path == "/tmp/dist_meta.mp3"
+        assert mock_episode.duration_seconds == 120.0
+        assert mock_episode.file_size_bytes == 2000
+        mock_session.commit.assert_called_once()
+
     def test_finalize_task_used_when_no_composition_or_distribution(self):
         """Default path (no composition, no distribution) uses finalize_episode_generation_task."""
         import sys
@@ -313,6 +365,68 @@ class TestWorkflowChainStructure:
 
         task_names = [t.task for t in workflow.tasks]
         assert task_names.count("distribute_to_platform") == 3
+
+    def test_chain_stages_are_immutable_signatures(self):
+        """Composition/distribution stages must use immutable (.si) signatures.
+
+        In a Celery chain a mutable .s() signature has the previous task's return
+        value prepended as the first positional arg, which would collide with the
+        keyword episode_id and raise at runtime (issue #211). Each stage re-reads
+        the Episode from the DB, so it must ignore the prior result.
+        """
+        from src.tasks.podcast_generation import build_generation_workflow
+
+        platforms = {
+            "spotify": {"oauth_tokens": {}},
+            "webhook": {"url": "https://hook.example.com"},
+        }
+
+        with patch("src.tasks.podcast_generation.settings") as mock_settings:
+            mock_settings.AWS_S3_BUCKET = "bucket"
+            workflow = build_generation_workflow(
+                episode_id=str(uuid.uuid4()),
+                audio_file_path="/tmp/audio.mp3",
+                enable_composition=True,
+                enable_distribution=True,
+                platforms=platforms,
+            )
+
+        for task_sig in workflow.tasks:
+            if task_sig.task in ("merge_audio_snippets", "distribute_to_platform"):
+                assert task_sig.immutable is True, (
+                    f"{task_sig.task} must be an immutable (.si) chain signature"
+                )
+
+    def test_composition_uploaded_and_distributed(self):
+        """With composition enabled, upload targets the composed file and runs
+        before distribution, so the distributed artifact is the composed audio
+        (issue #211). Distribution metadata is empty — it is read from the Episode
+        at runtime.
+        """
+        from src.tasks.podcast_generation import build_generation_workflow
+
+        episode_id = str(uuid.uuid4())
+        composed = f"/tmp/composed_{episode_id}.mp3"
+        with patch("src.tasks.podcast_generation.settings") as mock_settings:
+            mock_settings.AWS_S3_BUCKET = "bucket"
+            workflow = build_generation_workflow(
+                episode_id=episode_id,
+                audio_file_path="/tmp/original.mp3",
+                enable_composition=True,
+                enable_distribution=True,
+                platforms={"webhook": {"url": "https://hook.example.com"}},
+            )
+
+        names = [t.task for t in workflow.tasks]
+        # Order: compose → upload → distribute.
+        assert names.index("merge_audio_snippets") < names.index("upload_to_s3")
+        assert names.index("upload_to_s3") < names.index("distribute_to_platform")
+
+        upload_task = next(t for t in workflow.tasks if t.task == "upload_to_s3")
+        assert upload_task.kwargs["file_path"] == composed
+
+        dist_task = next(t for t in workflow.tasks if t.task == "distribute_to_platform")
+        assert dist_task.kwargs["episode_metadata"] == {}
 
     def test_distribution_excluded_when_no_platforms(self):
         """distribute_to_platform not included when platforms is empty/None."""

--- a/apps/api/tests/test_distribution_wiring.py
+++ b/apps/api/tests/test_distribution_wiring.py
@@ -122,6 +122,30 @@ async def test_active_targets_returns_only_active_for_project(client, test_db):
 
 
 @pytest.mark.asyncio
+async def test_active_targets_includes_account_level_targets(client, test_db):
+    """Account-level targets (project_id=None, e.g. Spotify OAuth) are included.
+
+    The Spotify OAuth callback creates targets without a project, so a project-only
+    filter would make Spotify distribution unreachable (issue #211).
+    """
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    project_scoped = await _create_webhook_target(
+        client, headers, project_id, "https://hook.example.com/scoped"
+    )
+    account_level = await _create_webhook_target(
+        client, headers, None, "https://hook.example.com/account"
+    )
+
+    await set_tenant_context(test_db, account_level["tenant_id"])
+    targets = await get_active_distribution_targets_for_project(test_db, project_id)
+
+    returned_ids = {str(t.id) for t in targets}
+    assert project_scoped["id"] in returned_ids
+    assert account_level["id"] in returned_ids
+
+
+@pytest.mark.asyncio
 async def test_active_targets_excludes_other_projects(client, test_db):
     """Targets scoped to a different project are not returned."""
     headers = await _register(client)
@@ -172,6 +196,7 @@ async def test_generate_forwards_platforms_when_distribution_enabled(client):
     )
 
     with patch.object(generation_router.settings, "ENABLE_PLATFORM_DISTRIBUTION", True), \
+         patch.object(generation_router.settings, "AWS_S3_BUCKET", "test-bucket"), \
          patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
         mock_delay.return_value = MagicMock(id="task-dist")
         resp = await client.post(
@@ -186,6 +211,39 @@ async def test_generate_forwards_platforms_when_distribution_enabled(client):
     platforms = kwargs["platforms"]
     assert "webhook" in platforms
     assert platforms["webhook"]["url"] == "https://hook.example.com/publish"
+
+
+@pytest.mark.asyncio
+async def test_generate_keeps_one_target_per_type(client):
+    """Multiple active targets of the same type collapse to one platforms entry.
+
+    The platforms mapping is keyed by platform type (the task contract), so at
+    most one config per type is forwarded. This must not raise and must still
+    dispatch (the newest target wins).
+    """
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    episode_id = await _create_episode(client, headers, project_id)
+    await _create_text_source(client, episode_id, headers)
+    await _create_webhook_target(client, headers, project_id, "https://hook.example.com/one")
+    await _create_webhook_target(client, headers, project_id, "https://hook.example.com/two")
+
+    with patch.object(generation_router.settings, "ENABLE_PLATFORM_DISTRIBUTION", True), \
+         patch.object(generation_router.settings, "AWS_S3_BUCKET", "test-bucket"), \
+         patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+        mock_delay.return_value = MagicMock(id="task-dup")
+        resp = await client.post(
+            f"/generation/episodes/{episode_id}/generate?enable_distribution=true",
+            headers=headers,
+        )
+
+    assert resp.status_code == 202, resp.text
+    platforms = mock_delay.call_args.kwargs["platforms"]
+    # Exactly one webhook entry, and it is one of the two configured URLs.
+    assert list(platforms.keys()) == ["webhook"]
+    assert platforms["webhook"]["url"] in (
+        "https://hook.example.com/one", "https://hook.example.com/two"
+    )
 
 
 @pytest.mark.asyncio
@@ -207,6 +265,35 @@ async def test_generate_omits_platforms_when_no_targets(client):
     assert resp.status_code == 202, resp.text
     mock_delay.assert_called_once()
     assert "platforms" not in mock_delay.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_distribution_without_s3_bucket(client):
+    """With no S3 bucket, distribution is skipped (graceful finalization path).
+
+    Forcing the workflow chain would schedule an invalid empty-bucket upload and
+    fail an otherwise successful generation.
+    """
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    episode_id = await _create_episode(client, headers, project_id)
+    await _create_text_source(client, episode_id, headers)
+    await _create_webhook_target(client, headers, project_id, "https://hook.example.com/nob")
+
+    with patch.object(generation_router.settings, "ENABLE_PLATFORM_DISTRIBUTION", True), \
+         patch.object(generation_router.settings, "AWS_S3_BUCKET", ""), \
+         patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+        mock_delay.return_value = MagicMock(id="task-nobucket")
+        resp = await client.post(
+            f"/generation/episodes/{episode_id}/generate?enable_distribution=true",
+            headers=headers,
+        )
+
+    assert resp.status_code == 202, resp.text
+    kwargs = mock_delay.call_args.kwargs
+    assert "platforms" not in kwargs
+    # Distribution disabled because no bucket → task won't take the workflow path.
+    assert kwargs["enable_distribution"] is False
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_distribution_wiring.py
+++ b/apps/api/tests/test_distribution_wiring.py
@@ -1,0 +1,235 @@
+"""
+Integration + service tests for issue #211: platform distribution must actually
+be triggered from generation with non-empty metadata.
+
+Covers:
+- ``get_active_distribution_targets_for_project`` returns only active targets for
+  the requested project.
+- The generation router loads those targets and forwards a ``platforms`` mapping
+  to the Celery task (the task gates distribution on ``bool(platforms)``).
+"""
+
+import pytest
+from uuid import uuid4
+from unittest.mock import MagicMock, patch
+
+from httpx import AsyncClient
+
+from src.routers import generation as generation_router
+from src.database import set_tenant_context
+from src.services.distribution_target_service import (
+    get_active_distribution_targets_for_project,
+)
+
+Headers = dict[str, str]
+
+# Text long enough to clear the source validator (>=50 chars, >=10 words).
+_TEXT_BODY = (
+    "This is a sufficiently long piece of text content used by the distribution "
+    "wiring tests so that source validation accepts it as a usable podcast source."
+)
+
+
+async def _register(client: AsyncClient) -> Headers:
+    reg = await client.post("/auth/register", json={
+        "email": f"dist_{uuid4()}@example.com",
+        "password": "SecurePass123!",
+        "full_name": "Dist Tester",
+    })
+    assert reg.status_code == 201, reg.text
+    return {"Authorization": f"Bearer {reg.json()['access_token']}"}
+
+
+async def _create_project(client: AsyncClient, headers: Headers, name: str = "Dist Project") -> str:
+    proj = await client.post("/projects", headers=headers, json={
+        "name": name,
+        "podcast_metadata": {"show_title": "Show", "author": "A", "description": "D"},
+    })
+    assert proj.status_code == 201, proj.text
+    return proj.json()["id"]
+
+
+async def _create_episode(client: AsyncClient, headers: Headers, project_id: str) -> str:
+    ep = await client.post("/episodes", headers=headers, json={
+        "project_id": project_id,
+        "episode_number": 1,
+        "episode_metadata": {"title": "Ep", "description": "Episode"},
+    })
+    assert ep.status_code == 201, ep.text
+    return ep.json()["id"]
+
+
+async def _create_text_source(client: AsyncClient, episode_id: str, headers: Headers) -> None:
+    resp = await client.post(
+        f"/episodes/{episode_id}/content?auto_extract=false",
+        headers=headers,
+        json={
+            "episode_id": episode_id,
+            "source_type": "text",
+            "source_data": {"content": _TEXT_BODY},
+        },
+    )
+    assert resp.status_code == 201, resp.text
+
+
+async def _create_webhook_target(
+    client: AsyncClient, headers: Headers, project_id: str | None, url: str
+) -> dict:
+    body = {
+        "name": "Hook",
+        "url": url,
+        "method": "POST",
+        "headers": {"Authorization": "Bearer secret-token"},
+    }
+    if project_id is not None:
+        body["project_id"] = project_id
+    resp = await client.post("/distribution-targets/webhook", headers=headers, json=body)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Service: get_active_distribution_targets_for_project
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_active_targets_returns_only_active_for_project(client, test_db):
+    """Returns active targets for the project; excludes inactive ones."""
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+
+    active = await _create_webhook_target(
+        client, headers, project_id, "https://hook.example.com/active"
+    )
+    inactive = await _create_webhook_target(
+        client, headers, project_id, "https://hook.example.com/inactive"
+    )
+    # Deactivate the second target.
+    upd = await client.put(
+        f"/distribution-targets/{inactive['id']}",
+        headers=headers,
+        json={"is_active": False},
+    )
+    assert upd.status_code == 200, upd.text
+
+    await set_tenant_context(test_db, active["tenant_id"])
+    targets = await get_active_distribution_targets_for_project(test_db, project_id)
+
+    returned_ids = {str(t.id) for t in targets}
+    assert active["id"] in returned_ids
+    assert inactive["id"] not in returned_ids
+    assert all(t.is_active for t in targets)
+
+
+@pytest.mark.asyncio
+async def test_active_targets_excludes_other_projects(client, test_db):
+    """Targets scoped to a different project are not returned."""
+    headers = await _register(client)
+    project_a = await _create_project(client, headers, "A")
+    project_b = await _create_project(client, headers, "B")
+
+    target_a = await _create_webhook_target(
+        client, headers, project_a, "https://hook.example.com/a"
+    )
+    await _create_webhook_target(client, headers, project_b, "https://hook.example.com/b")
+
+    await set_tenant_context(test_db, target_a["tenant_id"])
+    targets = await get_active_distribution_targets_for_project(test_db, project_a)
+
+    assert {str(t.id) for t in targets} == {target_a["id"]}
+
+
+@pytest.mark.asyncio
+async def test_active_targets_empty_when_none(client, test_db):
+    """A project with no targets yields an empty list."""
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    # Seed an unrelated target so a tenant context exists and the table is non-empty.
+    other = await _create_webhook_target(
+        client, headers, await _create_project(client, headers, "Other"),
+        "https://hook.example.com/other",
+    )
+
+    await set_tenant_context(test_db, other["tenant_id"])
+    targets = await get_active_distribution_targets_for_project(test_db, project_id)
+
+    assert targets == []
+
+
+# ---------------------------------------------------------------------------
+# Router: platforms mapping forwarded to the Celery task
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_generate_forwards_platforms_when_distribution_enabled(client):
+    """An active target + enable_distribution=true forwards a platforms mapping."""
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    episode_id = await _create_episode(client, headers, project_id)
+    await _create_text_source(client, episode_id, headers)
+    await _create_webhook_target(
+        client, headers, project_id, "https://hook.example.com/publish"
+    )
+
+    with patch.object(generation_router.settings, "ENABLE_PLATFORM_DISTRIBUTION", True), \
+         patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+        mock_delay.return_value = MagicMock(id="task-dist")
+        resp = await client.post(
+            f"/generation/episodes/{episode_id}/generate?enable_distribution=true",
+            headers=headers,
+        )
+
+    assert resp.status_code == 202, resp.text
+    mock_delay.assert_called_once()
+    kwargs = mock_delay.call_args.kwargs
+    assert kwargs["enable_distribution"] is True
+    platforms = kwargs["platforms"]
+    assert "webhook" in platforms
+    assert platforms["webhook"]["url"] == "https://hook.example.com/publish"
+
+
+@pytest.mark.asyncio
+async def test_generate_omits_platforms_when_no_targets(client):
+    """Distribution enabled but no targets configured → no platforms kwarg."""
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    episode_id = await _create_episode(client, headers, project_id)
+    await _create_text_source(client, episode_id, headers)
+
+    with patch.object(generation_router.settings, "ENABLE_PLATFORM_DISTRIBUTION", True), \
+         patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+        mock_delay.return_value = MagicMock(id="task-nodist")
+        resp = await client.post(
+            f"/generation/episodes/{episode_id}/generate?enable_distribution=true",
+            headers=headers,
+        )
+
+    assert resp.status_code == 202, resp.text
+    mock_delay.assert_called_once()
+    assert "platforms" not in mock_delay.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_generate_omits_platforms_when_distribution_disabled(client):
+    """An active target is ignored when distribution is not requested."""
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    episode_id = await _create_episode(client, headers, project_id)
+    await _create_text_source(client, episode_id, headers)
+    await _create_webhook_target(
+        client, headers, project_id, "https://hook.example.com/ignored"
+    )
+
+    with patch.object(generation_router.settings, "ENABLE_PLATFORM_DISTRIBUTION", True), \
+         patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+        mock_delay.return_value = MagicMock(id="task-off")
+        # enable_distribution defaults to false here.
+        resp = await client.post(
+            f"/generation/episodes/{episode_id}/generate",
+            headers=headers,
+        )
+
+    assert resp.status_code == 202, resp.text
+    mock_delay.assert_called_once()
+    assert "platforms" not in mock_delay.call_args.kwargs
+    assert mock_delay.call_args.kwargs["enable_distribution"] is False

--- a/apps/api/tests/unit/test_platform_distribution_metadata.py
+++ b/apps/api/tests/unit/test_platform_distribution_metadata.py
@@ -132,40 +132,45 @@ class TestDistributeTaskPopulatesMetadata:
 		assert captured["metadata"]["description"] == "A great episode"
 		assert captured["metadata"]["audio_url"].endswith(".mp3")
 
-	def test_task_falls_back_to_passed_metadata_when_db_unavailable(self):
-		"""A DB failure must not abort distribution — passed-in metadata is used."""
+	def test_task_does_not_publish_without_uploaded_audio(self):
+		"""No s3_url (upload failed or not committed) must never publish.
+
+		The task retries until its budget is exhausted, then fails — it must not
+		call the platform service with a non-existent audio URL (issue #211).
+		"""
 		from src.tasks.platform_distribution import distribute_to_platform_task
 
-		captured = {}
+		# Episode exists but has no s3_url yet (e.g. upload not committed / failed).
+		episode = _episode(s3_url=None)
+		session = MagicMock()
+		session.get.return_value = episode
+		session.__enter__ = MagicMock(return_value=session)
+		session.__exit__ = MagicMock(return_value=False)
 
-		def _fake_webhook(episode_id, config, metadata, task):
-			captured["metadata"] = metadata
-			return {
-				"status": "success",
-				"platform": "webhook",
-				"platform_episode_id": None,
-				"platform_url": config.get("url"),
-				"error": None,
-			}
+		webhook = MagicMock()
 
 		with patch(
-			"src.tasks.platform_distribution.SyncSessionLocal",
-			side_effect=RuntimeError("db down"),
+			"src.tasks.platform_distribution.SyncSessionLocal", return_value=session,
 		), patch(
 			"src.tasks.platform_distribution._decrypt_platform_config",
 			side_effect=lambda cfg, plat: cfg,
 		), patch(
-			"src.tasks.platform_distribution._distribute_via_webhook",
-			side_effect=_fake_webhook,
-		):
-			distribute_to_platform_task.request.update(id="test-task-2")
-			with patch.object(distribute_to_platform_task, "update_state", MagicMock()):
-				result = distribute_to_platform_task.run(
-					episode_id="00000000-0000-0000-0000-000000000002",
-					platform="webhook",
-					platform_config={"url": "https://hook.example.com/x"},
-					episode_metadata={"title": "Passed In"},
-				)
+			"src.tasks.platform_distribution._distribute_via_webhook", webhook,
+		), patch.object(
+			distribute_to_platform_task, "update_state", MagicMock(),
+		), patch.object(
+			distribute_to_platform_task, "retry",
+			side_effect=distribute_to_platform_task.MaxRetriesExceededError(),
+		) as mock_retry:
+			distribute_to_platform_task.request.update(id="test-task-2", retries=5)
+			result = distribute_to_platform_task.run(
+				episode_id="00000000-0000-0000-0000-000000000002",
+				platform="webhook",
+				platform_config={"url": "https://hook.example.com/x"},
+				episode_metadata={},
+			)
 
-		assert result["status"] == "success"
-		assert captured["metadata"] == {"title": "Passed In"}
+		# Missing audio → retried (then exhausted → failed); never published.
+		mock_retry.assert_called()
+		assert result["status"] == "failed"
+		webhook.assert_not_called()

--- a/apps/api/tests/unit/test_platform_distribution_metadata.py
+++ b/apps/api/tests/unit/test_platform_distribution_metadata.py
@@ -1,0 +1,171 @@
+"""
+Unit tests for issue #211 distribution-metadata population.
+
+The workflow builder passes an empty ``episode_metadata`` because the audio's
+``s3_url`` is only set by the upload stage that runs before distribution. The
+distribution task therefore loads the Episode and builds real metadata; these
+tests cover the merge helper and the task's population behaviour with the DB and
+platform services mocked.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _episode(**overrides):
+	"""Build an Episode-like object with sensible defaults."""
+	data = {
+		"episode_metadata": {
+			"title": "My Episode",
+			"description": "A great episode",
+			"explicit": True,
+			"publication_date": "2026-01-15",
+		},
+		"duration_seconds": 123.0,
+		"s3_url": "https://bucket.s3.amazonaws.com/podcasts/episode-1.mp3",
+	}
+	data.update(overrides)
+	return SimpleNamespace(**data)
+
+
+class TestMergeEpisodeMetadata:
+	"""Tests for ``_merge_episode_metadata``."""
+
+	def test_builds_metadata_from_db_fields(self):
+		from src.tasks.platform_distribution import _merge_episode_metadata
+
+		merged = _merge_episode_metadata(_episode(), {})
+
+		assert merged["title"] == "My Episode"
+		assert merged["description"] == "A great episode"
+		assert merged["audio_url"] == (
+			"https://bucket.s3.amazonaws.com/podcasts/episode-1.mp3"
+		)
+		assert merged["duration_seconds"] == 123.0
+		assert merged["explicit"] is True
+		assert merged["publish_date"] == "2026-01-15"
+
+	def test_passed_in_values_take_precedence(self):
+		from src.tasks.platform_distribution import _merge_episode_metadata
+
+		merged = _merge_episode_metadata(
+			_episode(),
+			{"title": "Override", "audio_url": "https://cdn.example.com/a.mp3"},
+		)
+
+		assert merged["title"] == "Override"
+		assert merged["audio_url"] == "https://cdn.example.com/a.mp3"
+		# Non-overridden DB values are retained.
+		assert merged["description"] == "A great episode"
+
+	def test_omits_none_db_values(self):
+		from src.tasks.platform_distribution import _merge_episode_metadata
+
+		episode = _episode(
+			episode_metadata={"title": "T"}, duration_seconds=None, s3_url=None
+		)
+		merged = _merge_episode_metadata(episode, {})
+
+		assert merged["title"] == "T"
+		assert "audio_url" not in merged
+		assert "duration_seconds" not in merged
+		# explicit defaults to False (a real value, so it is kept).
+		assert merged["explicit"] is False
+
+	def test_handles_empty_episode_metadata(self):
+		from src.tasks.platform_distribution import _merge_episode_metadata
+
+		episode = _episode(episode_metadata=None)
+		merged = _merge_episode_metadata(episode, {})
+
+		assert "title" not in merged
+		assert merged["audio_url"].endswith(".mp3")
+
+
+class TestDistributeTaskPopulatesMetadata:
+	"""The task loads the Episode and forwards real metadata to the platform."""
+
+	def test_task_populates_metadata_from_episode(self):
+		from src.tasks.platform_distribution import distribute_to_platform_task
+
+		episode = _episode()
+
+		# Mock the sync DB session so db.get(Episode, ...) returns our episode.
+		mock_session = MagicMock()
+		mock_session.get.return_value = episode
+		mock_session.__enter__ = MagicMock(return_value=mock_session)
+		mock_session.__exit__ = MagicMock(return_value=False)
+
+		captured = {}
+
+		def _fake_spotify(episode_id, config, metadata, task):
+			captured["metadata"] = metadata
+			return {
+				"status": "success",
+				"platform": "spotify",
+				"platform_episode_id": "sp_1",
+				"platform_url": "https://open.spotify.com/episode/sp_1",
+				"error": None,
+			}
+
+		with patch(
+			"src.tasks.platform_distribution.SyncSessionLocal",
+			return_value=mock_session,
+		), patch(
+			"src.tasks.platform_distribution._decrypt_platform_config",
+			side_effect=lambda cfg, plat: cfg,
+		), patch(
+			"src.tasks.platform_distribution._distribute_to_spotify",
+			side_effect=_fake_spotify,
+		):
+			distribute_to_platform_task.request.update(id="test-task")
+			with patch.object(distribute_to_platform_task, "update_state", MagicMock()):
+				result = distribute_to_platform_task.run(
+					episode_id="00000000-0000-0000-0000-000000000001",
+					platform="spotify",
+					platform_config={"show_id": "show1", "oauth_tokens": {}},
+					episode_metadata={},  # workflow passes empty — task must populate
+				)
+
+		assert result["status"] == "success"
+		# The platform received non-empty metadata sourced from the Episode row.
+		assert captured["metadata"]["title"] == "My Episode"
+		assert captured["metadata"]["description"] == "A great episode"
+		assert captured["metadata"]["audio_url"].endswith(".mp3")
+
+	def test_task_falls_back_to_passed_metadata_when_db_unavailable(self):
+		"""A DB failure must not abort distribution — passed-in metadata is used."""
+		from src.tasks.platform_distribution import distribute_to_platform_task
+
+		captured = {}
+
+		def _fake_webhook(episode_id, config, metadata, task):
+			captured["metadata"] = metadata
+			return {
+				"status": "success",
+				"platform": "webhook",
+				"platform_episode_id": None,
+				"platform_url": config.get("url"),
+				"error": None,
+			}
+
+		with patch(
+			"src.tasks.platform_distribution.SyncSessionLocal",
+			side_effect=RuntimeError("db down"),
+		), patch(
+			"src.tasks.platform_distribution._decrypt_platform_config",
+			side_effect=lambda cfg, plat: cfg,
+		), patch(
+			"src.tasks.platform_distribution._distribute_via_webhook",
+			side_effect=_fake_webhook,
+		):
+			distribute_to_platform_task.request.update(id="test-task-2")
+			with patch.object(distribute_to_platform_task, "update_state", MagicMock()):
+				result = distribute_to_platform_task.run(
+					episode_id="00000000-0000-0000-0000-000000000002",
+					platform="webhook",
+					platform_config={"url": "https://hook.example.com/x"},
+					episode_metadata={"title": "Passed In"},
+				)
+
+		assert result["status"] == "success"
+		assert captured["metadata"] == {"title": "Passed In"}

--- a/apps/api/tests/unit/test_task_retry.py
+++ b/apps/api/tests/unit/test_task_retry.py
@@ -42,6 +42,24 @@ def _make_client_error(code: str, message: str = "AWS error") -> ClientError:
 	return ClientError({"Error": {"Code": code, "Message": message}}, "Operation")
 
 
+def _uploaded_episode_session():
+	"""A mock sync session whose Episode has a committed s3_url.
+
+	distribute_to_platform_task loads the Episode and refuses to publish without an
+	uploaded audio URL (issue #211), so distribution retry tests must present an
+	episode that has already been uploaded to reach the platform-dispatch path.
+	"""
+	episode = MagicMock()
+	episode.episode_metadata = {"title": "Ep", "description": "d"}
+	episode.duration_seconds = 60.0
+	episode.s3_url = "https://bucket.s3.amazonaws.com/podcasts/episode-x.mp3"
+	session = MagicMock()
+	session.get.return_value = episode
+	session.__enter__ = MagicMock(return_value=session)
+	session.__exit__ = MagicMock(return_value=False)
+	return session
+
+
 # ============================================================================
 # upload_to_s3_task retry tests
 # ============================================================================
@@ -300,6 +318,7 @@ class TestDistributeToPlatformTaskRetry:
 		from src.tasks.platform_distribution import distribute_to_platform_task
 
 		with (
+			patch("src.tasks.platform_distribution.SyncSessionLocal", return_value=_uploaded_episode_session()),
 			patch("src.tasks.platform_distribution._decrypt_platform_config") as mock_decrypt,
 			patch("src.tasks.platform_distribution._distribute_to_spotify") as mock_spotify,
 			patch.object(distribute_to_platform_task, "update_state"),
@@ -314,7 +333,7 @@ class TestDistributeToPlatformTaskRetry:
 			distribute_to_platform_task.request.update(retries=0)
 
 			result = distribute_to_platform_task.run(
-				episode_id="ep-dist-01",
+				episode_id="11111111-1111-1111-1111-111111111101",
 				platform="spotify",
 				platform_config={},
 				episode_metadata={},
@@ -328,6 +347,7 @@ class TestDistributeToPlatformTaskRetry:
 		from src.tasks.platform_distribution import distribute_to_platform_task
 
 		with (
+			patch("src.tasks.platform_distribution.SyncSessionLocal", return_value=_uploaded_episode_session()),
 			patch("src.tasks.platform_distribution._decrypt_platform_config") as mock_decrypt,
 			patch.object(distribute_to_platform_task, "update_state"),
 			patch.object(distribute_to_platform_task, "retry") as mock_retry,
@@ -336,7 +356,7 @@ class TestDistributeToPlatformTaskRetry:
 			distribute_to_platform_task.request.update(retries=0)
 
 			result = distribute_to_platform_task.run(
-				episode_id="ep-dist-02",
+				episode_id="11111111-1111-1111-1111-111111111102",
 				platform="unsupported_platform",
 				platform_config={},
 				episode_metadata={},
@@ -350,6 +370,7 @@ class TestDistributeToPlatformTaskRetry:
 		from src.tasks.platform_distribution import distribute_to_platform_task
 
 		with (
+			patch("src.tasks.platform_distribution.SyncSessionLocal", return_value=_uploaded_episode_session()),
 			patch("src.tasks.platform_distribution._decrypt_platform_config") as mock_decrypt,
 			patch("src.tasks.platform_distribution._distribute_to_spotify") as mock_spotify,
 			patch.object(distribute_to_platform_task, "update_state"),
@@ -364,7 +385,7 @@ class TestDistributeToPlatformTaskRetry:
 			distribute_to_platform_task.request.update(retries=0)
 
 			distribute_to_platform_task.run(
-				episode_id="ep-dist-03",
+				episode_id="11111111-1111-1111-1111-111111111103",
 				platform="spotify",
 				platform_config={},
 				episode_metadata={},

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -181,6 +181,66 @@ longer passes raw `s3_key` to the engine.
 
 ---
 
+## Active work — Issue #211 (P2.6): distribution unreachable + publishes empty metadata
+
+**Plan source:** comment (CodeRabbit coding plan), adapted to verified current code.
+
+**Problem (verified):**
+1. `routers/generation.py:229-236` dispatches `generate_podcast_task.delay(...)` without
+   `platforms=`; task default `platforms=None`. Distribution gate
+   `enable_distribution and bool(platforms)` (podcast_generation.py:175-177) is never true →
+   distribution always skipped. No code loads active DistributionTarget rows.
+2. `build_generation_workflow` hardcodes `episode_metadata={}` (podcast_generation.py:511) →
+   Spotify/Apple/webhook would publish blank title/description and no audio_url.
+3. `spotify_service.publish_episode` maps audio to read-only `audio_preview_url`
+   (spotify_service.py:111).
+
+**Verified:** task already declares (unused) `platforms` param; `distribute_to_platform_task`
+already decrypts `config` via `_decrypt_platform_config` (so router passes raw encrypted
+config); `on_upload_complete` (callbacks.py:75) sets `Episode.s3_url` as the first chain
+stage → metadata must be populated *in the task* (post-upload), not at workflow-build time;
+sync DB access pattern is `with SyncSessionLocal() as db: db.get(Episode, UUID(id))`.
+
+### Step 1 — Service: active-targets query (`services/distribution_target_service.py`)
+- [ ] `get_active_distribution_targets_for_project(db, project_id)` (async): filter
+      `project_id` + `is_active == True`, newest-first; return `list[DistributionTarget]`
+      (raw encrypted `config`; decryption stays in the task).
+- [ ] Unit tests (async test_db): only-active; project filter; excludes inactive; empty when none.
+
+### Step 2 — Router: build + pass platforms dict (`routers/generation.py`)
+- [ ] When `use_distribution`, load active targets for `episode.project_id`, build
+      `platforms = {t.target_type: t.config for t in targets}`, pass `platforms=platforms`
+      to `.delay()` only when non-empty.
+- [ ] Integration test: active target + `enable_distribution=true` → `delay` called with
+      `platforms` = `{target_type: config}`.
+
+### Step 3 — Task: populate metadata at distribution time (`tasks/platform_distribution.py`)
+- [ ] Load Episode via `SyncSessionLocal`; merge DB metadata under any passed-in (passed-in
+      wins): title/description/explicit/publish_date ← `episode.episode_metadata`;
+      duration_seconds ← `episode.duration_seconds`; audio_url ← `episode.s3_url`.
+- [ ] Extract pure helper `_merge_episode_metadata(episode, passed)` for direct unit testing.
+- [ ] `build_generation_workflow` keeps `episode_metadata={}` + comment explaining the task
+      self-populates from the fresh row (avoids stale pre-upload s3_url).
+- [ ] Tests: helper merge + precedence; task populates non-empty title/description/audio_url.
+
+### Step 4 — Spotify mapping + docs (`services/spotify_service.py`)
+- [ ] Replace `audio_preview_url` with `audio_url` in payload; comment noting Spotify for
+      Podcasters primarily ingests via RSS and direct API publishing has platform limitations.
+
+### Acceptance criteria
+- [ ] Active targets loaded; `platforms` dict built; `platforms=` passed to `.delay()`.
+- [ ] `episode_metadata` populated (title/description/duration/explicit/audio_url) from Episode + S3 URL.
+- [ ] Spotify/Apple mechanism documented; `audio_preview_url` mapping fixed.
+- [ ] E2E test asserts distribution dispatch with non-empty metadata when a target is configured.
+
+### Known limitations (carry to PR)
+- Account-level targets (`project_id IS NULL`) are not auto-distributed; only project-scoped
+  active targets are loaded (matches AC wording).
+- Spotify/Apple direct-publish stays best-effort (design-choice option 1: fix mapping +
+  document); no new Podcasters/Connect API integration.
+
+---
+
 ## Ops changes already made this session
 - README server IP removed (commit `bf9e606`).
 - gitleaks pre-commit secret scanner added.


### PR DESCRIPTION
## Summary

Fixes #211 — the platform-distribution subsystem (Spotify/Apple/webhook) was fully built but **unreachable** from generation, and even if reached would have published blank, audio-less episodes.

Root causes:
1. `routers/generation.py` dispatched `generate_podcast_task.delay(...)` without `platforms=`, so the task's `enable_distribution and bool(platforms)` gate was never satisfied → distribution always skipped.
2. `build_generation_workflow` hardcoded `episode_metadata={}` → Spotify/Apple/webhook would publish empty title/description and no audio_url.
3. `spotify_service.publish_episode` mapped audio to the read-only `audio_preview_url` field.

## Changes

**Core wiring**
- New `get_active_distribution_targets_for_project(db, project_id)` service query (active, project-scoped **or** account-level targets; configs stay encrypted).
- Router loads active targets and forwards `platforms={target_type: config}` to the task. Prefers project-scoped over account-level targets for the same type; skips distribution when no targets or no `AWS_S3_BUCKET`.
- `distribute_to_platform_task` loads the Episode and builds real metadata (title/description/duration/explicit/audio_url), merging any passed-in values.
- Spotify payload now sends audio under `audio_url` (not the read-only `audio_preview_url`), with a comment documenting that Spotify for Podcasters primarily ingests via RSS and direct publishing is best-effort.

**Correctness hardening (from cross-family `codex` review — 7 rounds)**
- Immutable (`.si`) Celery chain signatures (a mutable `.s()` would prepend the prior task's result and crash distribution with a duplicate `episode_id`).
- Workflow reordered to **compose → upload → distribute**, uploading the *final* artifact, so distribution publishes the composed audio (not the pre-composition file); `on_composition_complete` now persists the composed duration.
- Distribution refuses to publish without a committed `s3_url` (written by `on_upload_complete` only on a successful upload) and retries until it appears — fixing both the upload→distribute callback race and the "publish non-existent audio after a failed upload" footgun.
- Generation metadata (`file_path`/`transcript_path`/`duration_seconds`/`file_size_bytes`) is persisted before the workflow dispatch so distribution-enabled runs match the finalize path.

## Acceptance criteria (all verified by demo — see `apps/api/demo_211.md`)
- [x] Load active targets, build the platforms dict, pass `platforms=` to `.delay()`.
- [x] Populate `episode_metadata` (title/description/duration/explicit/audio_url) from Episode + S3 URL.
- [x] Spotify/Apple mechanism documented; `audio_preview_url` mapping fixed.
- [x] E2E tests assert distribution dispatch with non-empty metadata when a target is configured.

## Tests
- New: `tests/test_distribution_wiring.py` (service query + router forwarding + dedup + no-bucket skip), `tests/unit/test_platform_distribution_metadata.py` (metadata merge + guard).
- Updated: `test_celery_workflow.py` (immutable signatures, compose→upload→distribute, metadata persistence), `test_task_retry.py` (distribution retry tests seed an uploaded episode).
- Full unit suite (667) + distribution/generation/celery integration green; `ruff` clean on all changed files.

## Demo (outcome evidence)
API-only feature → Showboat-style runner exercising real code paths. All 3 ACs demonstrated with captured runtime values (platforms dict forwarded, non-empty metadata delivered, Spotify payload uses `audio_url`). See `apps/api/demo_211.md`.

## Known limitations / follow-ups
- `platforms` is keyed by platform type → one config per type; multiple same-type targets log+skip the extras (multi-target-per-type is a follow-up).
- Direct Spotify/Apple publish stays best-effort (design-choice option 1: fix mapping + document RSS ingest); no new Podcasters/Connect publishing API.
- The pre-existing integration-suite flakiness (order-dependent settings/env bleed in `test_content`/`test_audio_snippets`) is unrelated to this PR — it reproduces on clean `main` (762 passed/1 flaky) and this branch adds exactly the new tests (768/1).

## Review note
`codex`'s final-round "RLS tenant context" flag is a **false positive**: Celery sync tasks use the `podcastfy` DB role (`rolsuper`/`rolbypassrls` = true), so RLS does not apply — verified empirically (episodes visible without tenant context). This matches every existing sync task (`_update_episode`, `finalize_episode_generation_task`); the RLS-forced `podcastfy_app` role is used only by the test suite's async API path.
