### PR TITLE
fix(infra): bind API to loopback, deploy non-root, reconcile port (#209)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -183,14 +183,21 @@ jobs:
               pm2 delete podcaststudiohub-api
             fi
 
-            echo "Starting API service on port ${API_PORT:-8001}..."
+            # Port must match the nginx upstream (deployment/nginx/podcastfy.conf:8001).
+            # Guard against a stray API_PORT reintroducing the 8000/8001 drift.
+            API_EFFECTIVE_PORT="${API_PORT:-8001}"
+            if [ "\$API_EFFECTIVE_PORT" != "8001" ]; then
+              echo "API_PORT=\$API_EFFECTIVE_PORT must be 8001 to match the nginx upstream" >&2
+              exit 1
+            fi
+            echo "Starting API service on port \$API_EFFECTIVE_PORT..."
             EMAIL_ENABLED=false \
             REQUIRE_EMAIL_VERIFICATION=false \
             RATE_LIMIT_ENABLED=false \
             pm2 start uv \
               --name podcaststudiohub-api \
               --cwd $SERVER_PATH/api \
-              -- run uvicorn src.main:app --host 127.0.0.1 --port ${API_PORT:-8001}
+              -- run uvicorn src.main:app --host 127.0.0.1 --port "\$API_EFFECTIVE_PORT"
 
             pm2 save
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -183,14 +183,14 @@ jobs:
               pm2 delete podcaststudiohub-api
             fi
 
-            echo "Starting API service on port ${API_PORT:-8000}..."
+            echo "Starting API service on port ${API_PORT:-8001}..."
             EMAIL_ENABLED=false \
             REQUIRE_EMAIL_VERIFICATION=false \
             RATE_LIMIT_ENABLED=false \
             pm2 start uv \
               --name podcaststudiohub-api \
               --cwd $SERVER_PATH/api \
-              -- run uvicorn src.main:app --host 0.0.0.0 --port ${API_PORT:-8000}
+              -- run uvicorn src.main:app --host 127.0.0.1 --port ${API_PORT:-8001}
 
             pm2 save
 
@@ -248,12 +248,12 @@ jobs:
           # Restart frontend service (delete and recreate to ensure fresh start)
           ssh -i ~/.ssh/deploy_key $SSH_USER@$SSH_HOST << EOF
             cd $SERVER_PATH/frontend
-            
+
             if pm2 describe podcaststudiohub-frontend > /dev/null 2>&1; then
               echo "Stopping existing frontend service..."
               pm2 delete podcaststudiohub-frontend
             fi
-            
+
             echo "Starting frontend service on port ${FRONTEND_PORT:-3000}..."
             PORT=${FRONTEND_PORT:-3000} \
             NEXT_PUBLIC_API_URL='$API_URL' \
@@ -263,9 +263,9 @@ jobs:
               --name podcaststudiohub-frontend \
               --cwd $SERVER_PATH/frontend \
               -- start
-            
+
             pm2 save
-            
+
             echo "Frontend deployment complete"
           EOF
 
@@ -277,7 +277,7 @@ jobs:
         run: |
           ssh -i ~/.ssh/deploy_key $SSH_USER@$SSH_HOST << EOF
             cd $SERVER_PATH/api
-            
+
             if pm2 describe podcaststudiohub-celery > /dev/null 2>&1; then
               echo "Stopping existing Celery service..."
               pm2 delete podcaststudiohub-celery

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -8,6 +8,14 @@
 # The podcastfy_app role is created by migration 003_force_rls.py.
 DATABASE_URL=postgresql+asyncpg://podcastfy_app:podcastfy_app_password@localhost:5432/podcastfy
 
+# API Server Binding (issue #209)
+# Bind loopback only — nginx reverse-proxies to 127.0.0.1 in prod. Never 0.0.0.0.
+# In prod, API_PORT must match the nginx upstream (deployment/nginx/podcastfy.conf -> 8001).
+API_HOST=127.0.0.1
+API_PORT=8001
+# DEBUG enables uvicorn auto-reload — keep it False in production.
+DEBUG=False
+
 # Redis Configuration (for Celery)
 REDIS_URL=redis://localhost:6379/0
 

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -14,7 +14,9 @@ class Settings(BaseSettings):
     APP_NAME: str = "Podcastfy API"
     APP_VERSION: str = "0.1.0"
     DEBUG: bool = False
-    API_HOST: str = "0.0.0.0"
+    # Bind loopback only: nginx reverse-proxies to 127.0.0.1 in prod and local
+    # dev reaches it over localhost. Never default to 0.0.0.0 (issue #209).
+    API_HOST: str = "127.0.0.1"
     API_PORT: int = 8000
 
     # Database

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -4,6 +4,30 @@
 
 This application deploys to **47.88.89.175** at `/opt/podcaststudiohub/` using **PM2** for process management.
 
+## Host Hardening (non-root + firewall) — issue #209
+
+Services run under a **dedicated non-root service account** (`podcastfy`), the API
+binds **127.0.0.1 only** (nginx reverse-proxies to it), and a host firewall blocks
+direct external access. Provision this once on the VPS:
+
+```bash
+ssh root@47.88.89.175
+cd /opt/podcaststudiohub && bash deployment/scripts/harden-host.sh
+```
+
+`harden-host.sh` (idempotent):
+1. Creates the `podcastfy` system account and an `~/.ssh` dir for the deploy key.
+2. Stops any root-owned PM2 services (releasing ports 8001/3003) and installs a
+   boot-time PM2 resurrect unit for the `podcastfy` account so services survive reboots.
+3. Chowns `/opt/podcaststudiohub` to that account.
+4. Configures `ufw`: default-deny inbound, allow only OpenSSH / 80 / 443.
+
+After running it, **add the deploy public key** to
+`/home/podcastfy/.ssh/authorized_keys` and **set the GitHub `SERVER_USER` deploy
+secret to `podcastfy`** so PM2 processes start under the non-root account on the
+next deploy. The API binds loopback (`API_HOST=127.0.0.1`, port `8001` matching the
+nginx upstream) and runs with `DEBUG=False` (uvicorn auto-reload stays off in prod).
+
 ## Deployment Methods
 
 ### 1. Automated Deployment (Recommended)
@@ -77,7 +101,7 @@ find . -type f -name '*.pyc' -delete 2>/dev/null || true
 # Restart API
 pm2 delete podcaststudiohub-api 2>/dev/null || true
 pm2 start uv --name podcaststudiohub-api --cwd /opt/podcaststudiohub/api \
-  -- run uvicorn src.main:app --host 0.0.0.0 --port 8001
+  -- run uvicorn src.main:app --host 127.0.0.1 --port 8001
 pm2 save
 EOF
 ```
@@ -215,7 +239,8 @@ Configure in **Settings** → **Environments** → **development**:
 
 **Secrets:**
 - `SSH_PRIVATE_KEY`: SSH key for deployment
-- `SERVER_USER`: `root`
+- `SERVER_USER`: `podcastfy` (the dedicated non-root service account created by
+  `harden-host.sh` — see **Host Hardening** above; do **not** deploy as root)
 - `NEXTAUTH_SECRET`: Generated with `openssl rand -base64 32`
 
 ### Server Environment Files
@@ -398,7 +423,7 @@ pm2 save --force
 
 # Restart API
 pm2 start uv --name podcaststudiohub-api --cwd /opt/podcaststudiohub/api \
-  -- run uvicorn src.main:app --host 0.0.0.0 --port 8001
+  -- run uvicorn src.main:app --host 127.0.0.1 --port 8001
 
 # Restart Frontend
 cd /opt/podcaststudiohub/frontend

--- a/deployment/scripts/harden-host.sh
+++ b/deployment/scripts/harden-host.sh
@@ -54,7 +54,8 @@ if command -v pm2 >/dev/null 2>&1; then
 	# ...and install one for the service account instead, so its API/frontend/
 	# worker come back after a reboot (the deploy's `pm2 save` writes the dump
 	# this unit resurrects). Without this, services stay down until a redeploy.
-	pm2 startup systemd -u "$SERVICE_USER" --hp "/home/$SERVICE_USER" >/dev/null 2>&1 || true
+	# NOT suppressed: a failed startup unit silently breaks reboot persistence.
+	pm2 startup systemd -u "$SERVICE_USER" --hp "/home/$SERVICE_USER"
 fi
 
 # ── 3. App tree ownership ──────────────────────────────────────────────────
@@ -73,6 +74,9 @@ if ! command -v ufw >/dev/null 2>&1; then
 fi
 
 echo "Configuring firewall (default-deny inbound, allow SSH + HTTP/S)..."
+# Reset first so any pre-existing allow rule (e.g. a directly-exposed 8000/8001
+# from before this hardening) is cleared — otherwise it survives and stays open.
+ufw --force reset
 # Allow SSH FIRST and by port (22/tcp), not the "OpenSSH" app profile: the
 # profile only exists if openssh-server registered it, and a missing profile
 # under `set -e` would abort after default-deny — locking us out of the box.

--- a/deployment/scripts/harden-host.sh
+++ b/deployment/scripts/harden-host.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Host hardening for the Podcastfy Studio VPS (issue #209).
+#
+# Creates a dedicated non-root service account that owns the app tree and runs
+# the PM2 processes, and configures a host firewall that only exposes SSH and
+# the nginx HTTP(S) ports. The API itself binds 127.0.0.1, so the firewall is
+# defense-in-depth against any service that drifts back to a public bind.
+#
+# Idempotent: safe to re-run. Run once as root on the VPS:
+#
+#   ssh root@<server>
+#   cd /opt/podcaststudiohub && bash deployment/scripts/harden-host.sh
+#
+# After running, point the GitHub `SERVER_USER` deploy secret at $SERVICE_USER
+# and re-run the deploy workflow so PM2 processes start under the new account.
+
+set -euo pipefail
+
+SERVICE_USER="${SERVICE_USER:-podcastfy}"
+APP_ROOT="${APP_ROOT:-/opt/podcaststudiohub}"
+
+if [[ "$(id -u)" -ne 0 ]]; then
+	echo "harden-host.sh must run as root (it creates a user and edits the firewall)." >&2
+	exit 1
+fi
+
+# ── 1. Dedicated non-root service account ──────────────────────────────────
+if id "$SERVICE_USER" >/dev/null 2>&1; then
+	echo "Service account '$SERVICE_USER' already exists."
+else
+	echo "Creating service account '$SERVICE_USER'..."
+	# System account, no login shell beyond what PM2/ssh-deploy needs.
+	useradd --system --create-home --shell /bin/bash "$SERVICE_USER"
+fi
+
+# The deploy uses rsync+ssh, so the account needs an SSH dir for its key.
+install -d -m 700 -o "$SERVICE_USER" -g "$SERVICE_USER" "/home/$SERVICE_USER/.ssh"
+echo "Add the deploy public key to /home/$SERVICE_USER/.ssh/authorized_keys (chmod 600)."
+
+# ── 2. Retire root-owned PM2 processes ─────────────────────────────────────
+# PM2 is per-user: services first launched as root live in root's PM2 daemon
+# and keep holding ports 8001/3003. The new $SERVICE_USER deploy can't see or
+# stop them, so its uvicorn/next starts would fail on occupied ports. Stop and
+# remove root's copies here (idempotent — no-op once they're gone).
+if command -v pm2 >/dev/null 2>&1; then
+	echo "Stopping any root-owned PM2 services (migrating to $SERVICE_USER)..."
+	for svc in podcaststudiohub-api podcaststudiohub-frontend podcaststudiohub-celery; do
+		pm2 delete "$svc" >/dev/null 2>&1 || true
+	done
+	pm2 save --force >/dev/null 2>&1 || true
+	# Drop root's PM2 startup unit so it doesn't resurrect them on reboot...
+	pm2 unstartup >/dev/null 2>&1 || true
+	# ...and install one for the service account instead, so its API/frontend/
+	# worker come back after a reboot (the deploy's `pm2 save` writes the dump
+	# this unit resurrects). Without this, services stay down until a redeploy.
+	pm2 startup systemd -u "$SERVICE_USER" --hp "/home/$SERVICE_USER" >/dev/null 2>&1 || true
+fi
+
+# ── 3. App tree ownership ──────────────────────────────────────────────────
+if [[ -d "$APP_ROOT" ]]; then
+	echo "Chowning $APP_ROOT to $SERVICE_USER..."
+	chown -R "$SERVICE_USER:$SERVICE_USER" "$APP_ROOT"
+else
+	echo "App root $APP_ROOT does not exist yet; creating it owned by $SERVICE_USER."
+	install -d -o "$SERVICE_USER" -g "$SERVICE_USER" "$APP_ROOT"
+fi
+
+# ── 4. Host firewall (ufw) ─────────────────────────────────────────────────
+if ! command -v ufw >/dev/null 2>&1; then
+	echo "Installing ufw..."
+	apt-get update -qq && apt-get install -y -qq ufw
+fi
+
+echo "Configuring firewall (default-deny inbound, allow SSH + HTTP/S)..."
+# Allow SSH FIRST and by port (22/tcp), not the "OpenSSH" app profile: the
+# profile only exists if openssh-server registered it, and a missing profile
+# under `set -e` would abort after default-deny — locking us out of the box.
+ufw allow 22/tcp
+ufw allow 80/tcp
+ufw allow 443/tcp
+ufw default deny incoming
+ufw default allow outgoing
+# Non-interactive enable (no-op if already active).
+ufw --force enable
+ufw status verbose
+
+echo
+echo "Host hardening complete."
+echo "Next: set the GitHub 'SERVER_USER' deploy secret to '$SERVICE_USER' and redeploy."

--- a/deployment/tests/test_deploy_hardening.py
+++ b/deployment/tests/test_deploy_hardening.py
@@ -49,11 +49,15 @@ def test_config_default_host_is_loopback():
 def test_workflow_deploy_port_matches_nginx_upstream():
 	port = _nginx_upstream_port()
 	text = WORKFLOW.read_text()
-	# The uvicorn launch must fall back to the nginx upstream port, not 8000.
-	assert f"--port ${{API_PORT:-{port}}}" in text, (
+	# The deploy port must fall back to the nginx upstream port, not 8000.
+	assert f"${{API_PORT:-{port}}}" in text, (
 		f"deploy port fallback must match nginx upstream ({port})"
 	)
 	assert "${API_PORT:-8000}" not in text, "stale 8000 port fallback drifts from nginx upstream"
+	# A stray API_PORT override must be rejected, not silently reintroduce the drift.
+	assert f'!= "{port}"' in text and "exit 1" in text, (
+		"deploy must hard-fail if the effective API port != nginx upstream"
+	)
 
 
 # ── AC3: DEBUG / reload off in prod ────────────────────────────────────────

--- a/deployment/tests/test_deploy_hardening.py
+++ b/deployment/tests/test_deploy_hardening.py
@@ -1,0 +1,104 @@
+"""Tests for deployment hardening (issue #209).
+
+The API must never be exposed publicly: it binds the loopback interface only
+(nginx already proxies to 127.0.0.1:8001), the deploy port must match the nginx
+upstream, services run as a dedicated non-root account, and a host firewall
+blocks direct external access. These tests pin that contract so a regression
+(re-binding 0.0.0.0, a port drift, or a root deploy) fails CI.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-dev.yml"
+CONFIG = REPO_ROOT / "apps" / "api" / "src" / "config.py"
+NGINX_CONF = REPO_ROOT / "deployment" / "nginx" / "podcastfy.conf"
+HARDEN_SCRIPT = REPO_ROOT / "deployment" / "scripts" / "harden-host.sh"
+
+
+def _nginx_upstream_port() -> str:
+	m = re.search(r"upstream\s+podcastfy_api\s*\{[^}]*?127\.0\.0\.1:(\d+)", NGINX_CONF.read_text())
+	assert m, "could not find the FastAPI upstream port in the nginx config"
+	return m.group(1)
+
+
+# ── AC2: API binds loopback, not 0.0.0.0 ───────────────────────────────────
+
+
+def test_workflow_uvicorn_binds_loopback():
+	text = WORKFLOW.read_text()
+	uvicorn_lines = [ln for ln in text.splitlines() if "uvicorn src.main:app" in ln]
+	assert uvicorn_lines, "deploy workflow no longer starts uvicorn — update this test"
+	for ln in uvicorn_lines:
+		assert "--host 127.0.0.1" in ln, f"uvicorn must bind loopback: {ln.strip()}"
+		assert "0.0.0.0" not in ln, f"uvicorn must not bind 0.0.0.0: {ln.strip()}"
+
+
+def test_config_default_host_is_loopback():
+	m = re.search(r'API_HOST:\s*str\s*=\s*"([^"]+)"', CONFIG.read_text())
+	assert m, "API_HOST default not found in config.py"
+	assert m.group(1) == "127.0.0.1", "API_HOST must default to loopback, not 0.0.0.0"
+
+
+# ── AC2: deploy port matches the nginx upstream ────────────────────────────
+
+
+def test_workflow_deploy_port_matches_nginx_upstream():
+	port = _nginx_upstream_port()
+	text = WORKFLOW.read_text()
+	# The uvicorn launch must fall back to the nginx upstream port, not 8000.
+	assert f"--port ${{API_PORT:-{port}}}" in text, (
+		f"deploy port fallback must match nginx upstream ({port})"
+	)
+	assert "${API_PORT:-8000}" not in text, "stale 8000 port fallback drifts from nginx upstream"
+
+
+# ── AC3: DEBUG / reload off in prod ────────────────────────────────────────
+
+
+def test_config_debug_defaults_off():
+	m = re.search(r"DEBUG:\s*bool\s*=\s*(\w+)", CONFIG.read_text())
+	assert m and m.group(1) == "False", "DEBUG must default to False (reload is gated on DEBUG)"
+
+
+# ── AC1 + AC3: host-hardening provisioning script ──────────────────────────
+
+
+def test_harden_script_exists_and_executable():
+	assert HARDEN_SCRIPT.is_file(), f"expected host-hardening script at {HARDEN_SCRIPT}"
+	assert HARDEN_SCRIPT.stat().st_mode & 0o111, "harden-host.sh must be executable"
+
+
+def test_harden_script_creates_nonroot_user_and_firewall():
+	text = HARDEN_SCRIPT.read_text()
+	assert "useradd" in text, "script must create a dedicated service account"
+	assert "ufw" in text, "script must configure the host firewall"
+	# Firewall must permit SSH + HTTP(S) and default-deny everything else inbound.
+	assert "ufw default deny incoming" in text, "firewall must default-deny inbound"
+	# SSH must be allowed by port (22), not the openssh-server "OpenSSH" app
+	# profile, so a missing profile can't abort the script post-default-deny.
+	for allowed in ("22/tcp", "80/tcp", "443/tcp"):
+		assert allowed in text, f"firewall must allow {allowed}"
+
+
+def test_harden_script_installs_pm2_startup_for_service_user():
+	"""Migrating PM2 off root must leave the service account's processes
+	resurrecting on reboot — otherwise services stay down after a restart."""
+	text = HARDEN_SCRIPT.read_text()
+	assert "pm2 startup" in text, "must install a boot-time PM2 unit for the service account"
+	m = re.search(r"pm2 startup[^\n]*-u\s+\"?\$\{?SERVICE_USER", text)
+	assert m, "pm2 startup must target the dedicated service account, not root"
+
+
+# ── AC1: docs no longer assume a root deploy ───────────────────────────────
+
+
+def test_readme_documents_nonroot_service_account():
+	readme = (REPO_ROOT / "deployment" / "README.md").read_text()
+	assert "harden-host.sh" in readme, "README must reference the host-hardening script"
+	assert "non-root" in readme.lower() or "service account" in readme.lower(), (
+		"README must document the dedicated non-root service account"
+	)


### PR DESCRIPTION
Closes #209.

## Problem
The API deployed as **root** with uvicorn bound to **0.0.0.0**, exposing it publicly and bypassing nginx. Any app/dependency RCE meant full host compromise. The deploy port (`8000`) also drifted from the nginx upstream (`8001`).

## Changes
| File | Change |
|------|--------|
| `apps/api/src/config.py` | `API_HOST` default `0.0.0.0` → `127.0.0.1` (secure-by-default). `DEBUG` already `False`. |
| `.github/workflows/deploy-dev.yml` | uvicorn `--host 127.0.0.1`; port fallback `8000` → `8001` (matches nginx upstream). |
| `apps/api/.env.example` | Documented loopback bind, prod port `8001`, `DEBUG=False`. |
| `deployment/scripts/harden-host.sh` *(new)* | Idempotent: create non-root `podcastfy` account, retire root's PM2 + install a boot unit for `podcastfy`, `ufw` default-deny inbound (allow only 22/80/443 **by port**). |
| `deployment/README.md` | Document non-root account, firewall, `SERVER_USER=podcastfy`. |
| `deployment/tests/test_deploy_hardening.py` *(new)* | Pins the contract (loopback bind, port==upstream, non-root + firewall + reboot persistence, DEBUG off). Runs in CI via `test.yml` → `test-deployment`. |

## Acceptance criteria
- [x] **Non-root service account** — `harden-host.sh` creates `podcastfy` (uid 999); README sets `SERVER_USER=podcastfy`.
- [x] **Bind 127.0.0.1 + reconcile port** — code default + deploy bind loopback; deploy port `8001` == nginx upstream.
- [x] **Host firewall + DEBUG/reload off** — `ufw` default-deny inbound (22/80/443 only); `DEBUG=False` (reload gated on DEBUG).

## Demo evidence (outcome, not just tests)
- **Loopback bind blocks external access**: uvicorn bound to `127.0.0.1:8001` → `curl 127.0.0.1:8001` = HTTP 200, `curl <LAN-IP>:8001` = connection refused (exit 7).
- **harden-host.sh** run in an `ubuntu:22.04` container (`--cap-add=NET_ADMIN`) → exit 0; `podcastfy` uid 999 created; `ufw` active, `default: deny (incoming)`, only 22/80/443 ALLOW IN.
- **Config defaults** (`_env_file=None`): `API_HOST='127.0.0.1'`, `DEBUG=False`.
- The demo caught and fixed a real **SSH-lockout bug** (`ufw allow OpenSSH` aborts under `set -e` if the app profile is missing — switched to `22/tcp`).

## Reviewed
`codex review` (cross-family) over two passes — all findings resolved: PM2 namespace migration + reboot-persistence fixed; stale `apps/web/package-lock.json` is a pre-existing untracked file unrelated to this issue (excluded); "tests not in CI" was a false positive (`test.yml` collects `deployment/tests/`).

## Known limitation
The GitHub **`SERVER_USER` deploy secret must be switched from `root` to `podcastfy`** by a maintainer after running `harden-host.sh` (can't be changed in code). Documented in `deployment/README.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added host hardening configuration for secure deployments with dedicated non-root service account and firewall rules.

* **Configuration Changes**
  * API now binds to localhost (127.0.0.1) instead of all network interfaces.
  * Default API port changed from 8000 to 8001.

* **Documentation**
  * Updated deployment guide with hardening procedures and new configuration details.

* **Tests**
  * Added deployment hardening verification tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->