### PR TITLE
fix(api): unify S3 key layout — restore user-{id}/ tenant prefix on workflow path (#215)

### DIFF
--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -19,6 +19,16 @@ from src.tasks.retry_utils import calculate_backoff
 logger = logging.getLogger(__name__)
 
 
+def build_podcast_s3_key(user_id: str, episode_id: str) -> str:
+    """Canonical S3 key for a generated episode's audio.
+
+    Single source of truth for the key layout so every upload path namespaces
+    the object under the user's tenant prefix (``podcasts/user-*/``), which
+    bucket-policy/IAM/lifecycle rules scope on (issue #215).
+    """
+    return f"podcasts/user-{user_id}/episode-{episode_id}.mp3"
+
+
 @celery_app.task(bind=True, name="generate_podcast", time_limit=600, max_retries=3)
 def generate_podcast_task(
     self: Task,
@@ -182,10 +192,14 @@ def generate_podcast_task(
             # without this any episode generated with composition or distribution
             # would lose file_path/transcript_path/duration_seconds/file_size_bytes
             # that the default finalize path records (issue #211).
+            # ponytail: "" only survives if the episode vanished mid-flight (an
+            # already-failed state); normally it's the real tenant id below.
+            user_id = ""
             try:
                 with SyncSessionLocal() as db:
                     episode = db.get(Episode, uuid_module.UUID(episode_id))
                     if episode is not None:
+                        user_id = str(episode.user_id)
                         episode.file_path = audio_file_path
                         episode.transcript_path = generation_result.get("transcript_path")
                         episode.duration_seconds = duration_seconds
@@ -211,6 +225,7 @@ def generate_podcast_task(
                 build_generation_workflow(
                     episode_id=episode_id,
                     audio_file_path=audio_file_path,
+                    user_id=user_id,
                     s3_bucket=settings.AWS_S3_BUCKET,
                     enable_composition=enable_composition,
                     composition_timeline=composition_timeline,
@@ -373,8 +388,8 @@ def finalize_episode_generation_task(
                 }
                 db.commit()
 
-                # Build S3 key using consistent naming convention
-                s3_key = f"podcasts/user-{episode.user_id}/episode-{episode_id}.mp3"
+                # Build S3 key using the canonical helper (issue #215)
+                s3_key = build_podcast_s3_key(str(episode.user_id), episode_id)
 
                 upload_result = upload_to_s3_task(
                     file_path=audio_file_path,
@@ -456,6 +471,7 @@ def finalize_episode_generation_task(
 def build_generation_workflow(
 	episode_id: str,
 	audio_file_path: str,
+	user_id: str,
 	s3_bucket: Optional[str] = None,
 	enable_composition: bool = False,
 	composition_timeline: Optional[List[Dict[str, Any]]] = None,
@@ -471,6 +487,7 @@ def build_generation_workflow(
 	Args:
 		episode_id: UUID string of the episode.
 		audio_file_path: Local path to the generated audio file.
+		user_id: UUID string of the owning user, for the canonical S3 key prefix.
 		s3_bucket: S3 bucket name for upload.  Defaults to settings.AWS_S3_BUCKET.
 		enable_composition: Whether to include the audio-composition step.
 		composition_timeline: Timeline segments for merge_audio_snippets_task.
@@ -492,7 +509,7 @@ def build_generation_workflow(
 	from src.tasks.platform_distribution import distribute_to_platform_task
 
 	bucket = s3_bucket or settings.AWS_S3_BUCKET or ""
-	s3_key = f"podcasts/episode-{episode_id}.mp3"
+	s3_key = build_podcast_s3_key(user_id, episode_id)
 
 	# Chain stages use immutable signatures (.si). In a Celery chain a mutable
 	# .s() signature has the *previous* task's return value prepended as the first

--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -192,13 +192,11 @@ def generate_podcast_task(
             # without this any episode generated with composition or distribution
             # would lose file_path/transcript_path/duration_seconds/file_size_bytes
             # that the default finalize path records (issue #211).
-            # ponytail: "" only survives if the episode vanished mid-flight (an
-            # already-failed state); normally it's the real tenant id below.
-            user_id = ""
+            user_id: Optional[str] = None
             try:
                 with SyncSessionLocal() as db:
                     episode = db.get(Episode, uuid_module.UUID(episode_id))
-                    if episode is not None:
+                    if episode is not None and episode.user_id is not None:
                         user_id = str(episode.user_id)
                         episode.file_path = audio_file_path
                         episode.transcript_path = generation_result.get("transcript_path")
@@ -211,6 +209,18 @@ def generate_podcast_task(
                     "workflow dispatch: %s",
                     episode_id, persist_err,
                 )
+
+            # Fail closed: without a resolved user_id the upload chain would write
+            # a non-tenant-scoped key (podcasts/user-/episode-…), the exact layout
+            # bug this path is meant to prevent (issue #215). Skip dispatch rather
+            # than orphan an object outside podcasts/user-*/.
+            if not user_id:
+                logger.critical(
+                    "Episode %s: workflow dispatch skipped — user_id could not be "
+                    "resolved, refusing to upload outside the tenant prefix",
+                    episode_id,
+                )
+                return generation_result
 
             # Trigger the full workflow: S3 upload → [composition] → [distribution]
             # Isolated try/except so a broker hiccup cannot mark a successful

--- a/apps/api/tests/test_celery_workflow.py
+++ b/apps/api/tests/test_celery_workflow.py
@@ -303,6 +303,7 @@ class TestWorkflowChainStructure:
         with patch("src.tasks.podcast_generation.settings") as mock_settings:
             mock_settings.AWS_S3_BUCKET = "test-bucket"
             workflow = build_generation_workflow(
+                user_id="test-user-id",
                 episode_id=str(uuid.uuid4()),
                 audio_file_path="/tmp/podcast.mp3",
             )
@@ -320,6 +321,7 @@ class TestWorkflowChainStructure:
         with patch("src.tasks.podcast_generation.settings") as mock_settings:
             mock_settings.AWS_S3_BUCKET = "bucket"
             workflow = build_generation_workflow(
+                user_id="test-user-id",
                 episode_id=str(uuid.uuid4()),
                 audio_file_path="/tmp/audio.mp3",
                 enable_composition=True,
@@ -336,6 +338,7 @@ class TestWorkflowChainStructure:
         with patch("src.tasks.podcast_generation.settings") as mock_settings:
             mock_settings.AWS_S3_BUCKET = "bucket"
             workflow = build_generation_workflow(
+                user_id="test-user-id",
                 episode_id=str(uuid.uuid4()),
                 audio_file_path="/tmp/audio.mp3",
                 enable_composition=False,
@@ -357,6 +360,7 @@ class TestWorkflowChainStructure:
         with patch("src.tasks.podcast_generation.settings") as mock_settings:
             mock_settings.AWS_S3_BUCKET = "bucket"
             workflow = build_generation_workflow(
+                user_id="test-user-id",
                 episode_id=str(uuid.uuid4()),
                 audio_file_path="/tmp/audio.mp3",
                 enable_distribution=True,
@@ -384,6 +388,7 @@ class TestWorkflowChainStructure:
         with patch("src.tasks.podcast_generation.settings") as mock_settings:
             mock_settings.AWS_S3_BUCKET = "bucket"
             workflow = build_generation_workflow(
+                user_id="test-user-id",
                 episode_id=str(uuid.uuid4()),
                 audio_file_path="/tmp/audio.mp3",
                 enable_composition=True,
@@ -410,6 +415,7 @@ class TestWorkflowChainStructure:
         with patch("src.tasks.podcast_generation.settings") as mock_settings:
             mock_settings.AWS_S3_BUCKET = "bucket"
             workflow = build_generation_workflow(
+                user_id="test-user-id",
                 episode_id=episode_id,
                 audio_file_path="/tmp/original.mp3",
                 enable_composition=True,
@@ -435,6 +441,7 @@ class TestWorkflowChainStructure:
         with patch("src.tasks.podcast_generation.settings") as mock_settings:
             mock_settings.AWS_S3_BUCKET = "bucket"
             workflow = build_generation_workflow(
+                user_id="test-user-id",
                 episode_id=str(uuid.uuid4()),
                 audio_file_path="/tmp/audio.mp3",
                 enable_distribution=True,
@@ -445,21 +452,50 @@ class TestWorkflowChainStructure:
         assert "distribute_to_platform" not in task_names
 
     def test_s3_key_contains_episode_id(self):
-        """Generated S3 key includes episode_id for uniqueness."""
+        """Generated S3 key is namespaced under the user tenant prefix and
+        includes the episode_id for uniqueness (issue #215)."""
         from src.tasks.podcast_generation import build_generation_workflow
 
         episode_id = str(uuid.uuid4())
+        user_id = str(uuid.uuid4())
 
         with patch("src.tasks.podcast_generation.settings") as mock_settings:
             mock_settings.AWS_S3_BUCKET = "bucket"
             workflow = build_generation_workflow(
+                user_id=user_id,
                 episode_id=episode_id,
                 audio_file_path="/tmp/audio.mp3",
             )
 
         upload_task = workflow.tasks[0]
         s3_key = upload_task.kwargs.get("s3_key", "")
+        assert s3_key.startswith(f"podcasts/user-{user_id}/")
         assert episode_id in s3_key
+
+    def test_workflow_key_matches_canonical_helper(self):
+        """Acceptance criterion (issue #215): the workflow-chain upload path
+        produces the same key as the canonical helper used by the finalize
+        path, so both paths agree on the tenant-namespaced layout."""
+        from src.tasks.podcast_generation import (
+            build_generation_workflow,
+            build_podcast_s3_key,
+        )
+
+        episode_id = str(uuid.uuid4())
+        user_id = str(uuid.uuid4())
+
+        with patch("src.tasks.podcast_generation.settings") as mock_settings:
+            mock_settings.AWS_S3_BUCKET = "bucket"
+            workflow = build_generation_workflow(
+                user_id=user_id,
+                episode_id=episode_id,
+                audio_file_path="/tmp/audio.mp3",
+            )
+
+        upload_task = workflow.tasks[0]
+        assert upload_task.kwargs.get("s3_key") == build_podcast_s3_key(
+            user_id, episode_id
+        )
 
     def test_explicit_s3_bucket_overrides_settings(self):
         """Explicit s3_bucket parameter takes precedence over settings.AWS_S3_BUCKET."""
@@ -468,6 +504,7 @@ class TestWorkflowChainStructure:
         with patch("src.tasks.podcast_generation.settings") as mock_settings:
             mock_settings.AWS_S3_BUCKET = "default-bucket"
             workflow = build_generation_workflow(
+                user_id="test-user-id",
                 episode_id=str(uuid.uuid4()),
                 audio_file_path="/tmp/audio.mp3",
                 s3_bucket="override-bucket",
@@ -629,6 +666,7 @@ class TestMultiplePlatformDistribution:
         with patch("src.tasks.podcast_generation.settings") as mock_settings:
             mock_settings.AWS_S3_BUCKET = "bucket"
             workflow = build_generation_workflow(
+                user_id="test-user-id",
                 episode_id=str(uuid.uuid4()),
                 audio_file_path="/tmp/audio.mp3",
                 enable_distribution=True,
@@ -650,6 +688,7 @@ class TestMultiplePlatformDistribution:
         with patch("src.tasks.podcast_generation.settings") as mock_settings:
             mock_settings.AWS_S3_BUCKET = "bucket"
             workflow = build_generation_workflow(
+                user_id="test-user-id",
                 episode_id=episode_id,
                 audio_file_path="/tmp/audio.mp3",
                 enable_distribution=True,

--- a/apps/api/tests/test_celery_workflow.py
+++ b/apps/api/tests/test_celery_workflow.py
@@ -44,6 +44,22 @@ def _invoke_task(task, **kwargs):
         return task.run(**kwargs)
 
 
+def _mock_session_with_episode(user_id: str = "11111111-1111-1111-1111-111111111111") -> MagicMock:
+    """Mock a SyncSessionLocal context manager yielding an episode with user_id.
+
+    generate_podcast_task resolves episode.user_id for the tenant-scoped S3 key
+    and fails closed when it cannot (issue #215), so workflow-dispatch tests must
+    seed an episode rather than relying on the empty test DB.
+    """
+    episode = MagicMock()
+    episode.user_id = user_id
+    session = MagicMock()
+    session.get.return_value = episode
+    session.__enter__ = MagicMock(return_value=session)
+    session.__exit__ = MagicMock(return_value=False)
+    return session
+
+
 def _make_generation_result(audio_file_path: str = "/tmp/episode.mp3") -> dict:
     return {
         "status": "success",
@@ -88,6 +104,7 @@ class TestFullWorkflowChain:
             patch("src.tasks.podcast_generation.AudioSegment") as mock_audio_cls,
             patch("src.tasks.podcast_generation.build_generation_workflow", return_value=mock_chain) as mock_builder,
             patch("src.tasks.podcast_generation.finalize_episode_generation_task"),
+            patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=_mock_session_with_episode()),
         ):
             mock_audio_cls.from_file.return_value = mock_audio_segment
 
@@ -136,6 +153,7 @@ class TestFullWorkflowChain:
             patch("src.tasks.podcast_generation.AudioSegment") as mock_audio_cls,
             patch("src.tasks.podcast_generation.build_generation_workflow", return_value=mock_chain) as mock_builder,
             patch("src.tasks.podcast_generation.finalize_episode_generation_task"),
+            patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=_mock_session_with_episode()),
         ):
             mock_audio_cls.from_file.return_value = mock_audio_segment
 
@@ -550,6 +568,7 @@ class TestConditionalComposition:
             patch("src.tasks.podcast_generation.AudioSegment") as mock_audio_cls,
             patch("src.tasks.podcast_generation.build_generation_workflow", return_value=mock_chain) as mock_builder,
             patch("src.tasks.podcast_generation.finalize_episode_generation_task"),
+            patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=_mock_session_with_episode()),
         ):
             mock_audio_cls.from_file.return_value = mock_audio_segment
 
@@ -590,6 +609,7 @@ class TestErrorHandling:
             patch.dict(sys.modules, {"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
             patch("src.tasks.podcast_generation.build_generation_workflow") as mock_builder,
             patch("src.tasks.podcast_generation.finalize_episode_generation_task"),
+            patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=_mock_session_with_episode()),
             patch.object(
                 generate_podcast_task,
                 "retry",
@@ -633,6 +653,7 @@ class TestErrorHandling:
             patch("src.tasks.podcast_generation.AudioSegment") as mock_audio_cls,
             patch("src.tasks.podcast_generation.build_generation_workflow", return_value=mock_chain),
             patch("src.tasks.podcast_generation.finalize_episode_generation_task"),
+            patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=_mock_session_with_episode()),
         ):
             mock_audio_cls.from_file.return_value = mock_audio_segment
 
@@ -645,6 +666,51 @@ class TestErrorHandling:
             )
 
         assert result["status"] == "success"
+
+    def test_workflow_dispatch_skipped_when_user_id_unresolved(self):
+        """Fail closed: if the episode/user_id cannot be resolved, the upload
+        chain is never dispatched, so nothing is written outside the
+        podcasts/user-*/ tenant prefix (issue #215)."""
+        import sys
+        import types
+
+        episode_id = str(uuid.uuid4())
+
+        mock_audio_segment = MagicMock()
+        mock_audio_segment.__len__ = MagicMock(return_value=60_000)
+
+        mock_client = MagicMock()
+        mock_podcastfy = types.ModuleType("podcastfy")
+        mock_podcastfy.client = mock_client
+        mock_client.generate_podcast = MagicMock(return_value="/tmp/audio.mp3")
+
+        # Lookup returns no episode → user_id stays unresolved.
+        mock_session = MagicMock()
+        mock_session.get.return_value = None
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        from src.tasks.podcast_generation import generate_podcast_task
+
+        with (
+            patch.dict(sys.modules, {"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
+            patch("src.tasks.podcast_generation.os.path.getsize", return_value=1000),
+            patch("src.tasks.podcast_generation.AudioSegment") as mock_audio_cls,
+            patch("src.tasks.podcast_generation.build_generation_workflow") as mock_builder,
+            patch("src.tasks.podcast_generation.finalize_episode_generation_task"),
+            patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=mock_session),
+        ):
+            mock_audio_cls.from_file.return_value = mock_audio_segment
+            result = _invoke_task(
+                generate_podcast_task,
+                episode_id=episode_id,
+                urls=["https://example.com"],
+                enable_composition=True,
+            )
+
+        # Generation itself still succeeded; only the unsafe dispatch was skipped.
+        assert result["status"] == "success"
+        mock_builder.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/unit/test_celery_callbacks.py
+++ b/apps/api/tests/unit/test_celery_callbacks.py
@@ -409,6 +409,7 @@ class TestBuildGenerationWorkflow:
 		with patch("src.tasks.podcast_generation.settings") as mock_settings:
 			mock_settings.AWS_S3_BUCKET = "test-bucket"
 			workflow = build_generation_workflow(
+				user_id="test-user-id",
 				episode_id=str(uuid.uuid4()),
 				audio_file_path="/tmp/podcast.mp3",
 			)
@@ -422,6 +423,7 @@ class TestBuildGenerationWorkflow:
 		with patch("src.tasks.podcast_generation.settings") as mock_settings:
 			mock_settings.AWS_S3_BUCKET = "my-bucket"
 			workflow = build_generation_workflow(
+				user_id="test-user-id",
 				episode_id=str(uuid.uuid4()),
 				audio_file_path="/tmp/audio.mp3",
 			)
@@ -437,6 +439,7 @@ class TestBuildGenerationWorkflow:
 		with patch("src.tasks.podcast_generation.settings") as mock_settings:
 			mock_settings.AWS_S3_BUCKET = "bucket"
 			workflow = build_generation_workflow(
+				user_id="test-user-id",
 				episode_id=str(uuid.uuid4()),
 				audio_file_path="/tmp/a.mp3",
 				enable_composition=True,
@@ -453,6 +456,7 @@ class TestBuildGenerationWorkflow:
 		with patch("src.tasks.podcast_generation.settings") as mock_settings:
 			mock_settings.AWS_S3_BUCKET = "bucket"
 			workflow = build_generation_workflow(
+				user_id="test-user-id",
 				episode_id=str(uuid.uuid4()),
 				audio_file_path="/tmp/a.mp3",
 				enable_composition=False,
@@ -473,6 +477,7 @@ class TestBuildGenerationWorkflow:
 		with patch("src.tasks.podcast_generation.settings") as mock_settings:
 			mock_settings.AWS_S3_BUCKET = "bucket"
 			workflow = build_generation_workflow(
+				user_id="test-user-id",
 				episode_id=str(uuid.uuid4()),
 				audio_file_path="/tmp/a.mp3",
 				enable_distribution=True,
@@ -489,6 +494,7 @@ class TestBuildGenerationWorkflow:
 		with patch("src.tasks.podcast_generation.settings") as mock_settings:
 			mock_settings.AWS_S3_BUCKET = "default-bucket"
 			workflow = build_generation_workflow(
+				user_id="test-user-id",
 				episode_id=str(uuid.uuid4()),
 				audio_file_path="/tmp/a.mp3",
 				s3_bucket="override-bucket",
@@ -507,6 +513,7 @@ class TestBuildGenerationWorkflow:
 		with patch("src.tasks.podcast_generation.settings") as mock_settings:
 			mock_settings.AWS_S3_BUCKET = "bucket"
 			workflow = build_generation_workflow(
+				user_id="test-user-id",
 				episode_id=episode_id,
 				audio_file_path="/tmp/a.mp3",
 			)

--- a/apps/api/tests/unit/test_podcast_generation_task.py
+++ b/apps/api/tests/unit/test_podcast_generation_task.py
@@ -234,7 +234,8 @@ def test_task_returns_failed_result_on_exception():
 class TestBuildPodcastS3Key:
 	"""Canonical S3 key helper (issue #215)."""
 
-	def test_format(self):
+	def test_format(self) -> None:
+		"""The helper renders the exact canonical key for plain string inputs."""
 		from src.tasks.podcast_generation import build_podcast_s3_key
 
 		user_id = "abc-123"
@@ -244,7 +245,8 @@ class TestBuildPodcastS3Key:
 			== "podcasts/user-abc-123/episode-ep-456.mp3"
 		)
 
-	def test_uuid_inputs(self):
+	def test_uuid_inputs(self) -> None:
+		"""UUID-string inputs produce a tenant-prefixed, .mp3-suffixed key."""
 		from src.tasks.podcast_generation import build_podcast_s3_key
 
 		user_id = str(uuid4())

--- a/apps/api/tests/unit/test_podcast_generation_task.py
+++ b/apps/api/tests/unit/test_podcast_generation_task.py
@@ -229,3 +229,27 @@ def test_task_returns_failed_result_on_exception():
 	assert result["status"] == "failed"
 	assert "Podcastfy crashed" in result["error"]
 	assert result["audio_file_path"] is None
+
+
+class TestBuildPodcastS3Key:
+	"""Canonical S3 key helper (issue #215)."""
+
+	def test_format(self):
+		from src.tasks.podcast_generation import build_podcast_s3_key
+
+		user_id = "abc-123"
+		episode_id = "ep-456"
+		assert (
+			build_podcast_s3_key(user_id, episode_id)
+			== "podcasts/user-abc-123/episode-ep-456.mp3"
+		)
+
+	def test_uuid_inputs(self):
+		from src.tasks.podcast_generation import build_podcast_s3_key
+
+		user_id = str(uuid4())
+		episode_id = str(uuid4())
+		key = build_podcast_s3_key(user_id, episode_id)
+		assert key == f"podcasts/user-{user_id}/episode-{episode_id}.mp3"
+		assert key.startswith("podcasts/user-")
+		assert key.endswith(".mp3")


### PR DESCRIPTION
## Summary
Closes #215.

Two upload paths built different S3 keys for the same episode:
- `finalize_episode_generation_task` → `podcasts/user-{user_id}/episode-{id}.mp3` ✅
- `build_generation_workflow` (composition/distribution path) → `podcasts/episode-{id}.mp3` ❌ — no tenant namespace

So composed/distributed episodes landed **outside** `podcasts/user-*/`, escaping any bucket-policy / IAM / lifecycle rule scoped on that prefix.

## Changes
- Add `build_podcast_s3_key(user_id, episode_id)` — single source of truth for the key layout.
- `finalize_episode_generation_task` and `build_generation_workflow` both use it.
- `build_generation_workflow` gains a **required** `user_id: str` param, threaded from the episode at the call site in `generate_podcast_task` (reusing the episode already loaded in the metadata-persist block).

## Acceptance criteria
- [x] Single canonical-key helper used by both paths (includes user namespace).
- [x] Test asserting both paths produce the same key shape (`test_workflow_key_matches_canonical_helper`).

## Tests
- New: `build_podcast_s3_key` unit tests (`tests/unit/test_podcast_generation_task.py`).
- New: cross-path same-key-shape assertion + tightened `test_s3_key_contains_episode_id` to require the `podcasts/user-{user_id}/` prefix (`tests/test_celery_workflow.py`).
- Existing `build_generation_workflow(...)` call sites updated to pass `user_id`.
- Full API suite: **669 passed**. ruff clean; no new mypy errors.

## Known Limitations
- `user_id` was made **required** (not defaulted) on purpose: a `None`/empty default would let a future caller silently produce a `user-None/` key — the exact bug class being fixed. The call site defaults to `""` only in the degenerate case where the episode row vanished mid-flight (an already-failed state); normal flow always passes the real tenant id.
- This changes only the key **layout going forward**; pre-existing objects already written under `podcasts/episode-*.mp3` are not migrated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Podcast episodes are now stored with tenant-specific organizational structure, improving data isolation and file uniqueness (issue `#215`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->