### PR TITLE
fix(api): retry inline S3 upload, fix upload callback status, fresh SSE session (#220)

### DIFF
--- a/apps/api/src/database.py
+++ b/apps/api/src/database.py
@@ -125,6 +125,19 @@ async def get_db(request: Request) -> AsyncGenerator[AsyncSession, None]:
         yield session
 
 
+def get_streaming_session_factory():
+    """Session factory for work that outlives the request scope (e.g. SSE).
+
+    Returns ``AsyncSessionLocal`` so callers can open a fresh, short-lived
+    session per iteration instead of holding the request-scoped session for the
+    life of a long stream (issue #220). Exposed as a FastAPI dependency so tests
+    can override it to bind to the test engine — otherwise the SSE generator
+    would open connections on the module-global engine, leaking asyncpg pools
+    across pytest's per-test event loops.
+    """
+    return AsyncSessionLocal
+
+
 async def set_tenant_context(db: AsyncSession, tenant_id: str) -> None:
     """
     Manually set the tenant_id in PostgreSQL session for Row-Level Security.

--- a/apps/api/src/database.py
+++ b/apps/api/src/database.py
@@ -125,7 +125,7 @@ async def get_db(request: Request) -> AsyncGenerator[AsyncSession, None]:
         yield session
 
 
-def get_streaming_session_factory():
+def get_streaming_session_factory() -> async_sessionmaker[AsyncSession]:
     """Session factory for work that outlives the request scope (e.g. SSE).
 
     Returns ``AsyncSessionLocal`` so callers can open a fresh, short-lived

--- a/apps/api/src/routers/generation.py
+++ b/apps/api/src/routers/generation.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
 from ..config import settings
-from ..database import get_db
+from ..database import get_db, AsyncSessionLocal
 from ..models.episode import Episode
 from ..models.project import Project
 from ..models.content_source import ContentSource
@@ -334,27 +334,43 @@ async def get_generation_progress_stream(
     if not episode:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Episode not found")
 
+    # Capture the id only: the request-scoped `db` session must not be reused
+    # inside the long-lived generator. Each poll opens its own short-lived
+    # session so a client disconnect can never leave a session checked out of
+    # the pool (issue #220).
+    stream_episode_id = episode.id
+
     async def event_generator():
         """Generate SSE events with progress updates"""
-        while True:
-            # Refresh episode to get latest progress
-            await db.refresh(episode)
+        try:
+            while True:
+                # Fresh short-lived session per poll — released by __aexit__.
+                async with AsyncSessionLocal() as session:
+                    current = await session.get(Episode, stream_episode_id)
 
-            progress_data = {
-                "episode_id": str(episode.id),
-                "status": episode.generation_status,
-                "progress": episode.generation_progress,
-            }
+                if current is None:
+                    break
 
-            # Send SSE event
-            yield f"data: {json.dumps(progress_data)}\n\n"
+                progress_data = {
+                    "episode_id": str(current.id),
+                    "status": current.generation_status,
+                    "progress": current.generation_progress,
+                }
 
-            # Check if generation is complete or failed
-            if episode.generation_status in ["complete", "failed"]:
-                break
+                # Send SSE event
+                yield f"data: {json.dumps(progress_data)}\n\n"
 
-            # Wait before next update (poll every 2 seconds)
-            await asyncio.sleep(2)
+                # Check if generation is complete or failed
+                if current.generation_status in ["complete", "failed"]:
+                    break
+
+                # Wait before next update (poll every 2 seconds)
+                await asyncio.sleep(2)
+        except asyncio.CancelledError:
+            # Raised when the client disconnects; per-iteration sessions are
+            # already released, so just log and let the cancellation propagate.
+            logger.info("SSE progress stream cancelled for episode %s", stream_episode_id)
+            raise
 
     return StreamingResponse(
         event_generator(),

--- a/apps/api/src/routers/generation.py
+++ b/apps/api/src/routers/generation.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
 from ..config import settings
-from ..database import get_db, AsyncSessionLocal
+from ..database import get_db, get_streaming_session_factory
 from ..models.episode import Episode
 from ..models.project import Project
 from ..models.content_source import ContentSource
@@ -309,6 +309,7 @@ async def get_generation_progress_stream(
     episode_id: UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    session_factory=Depends(get_streaming_session_factory),
 ):
     """
     Server-Sent Events (SSE) endpoint for real-time generation progress
@@ -345,7 +346,7 @@ async def get_generation_progress_stream(
         try:
             while True:
                 # Fresh short-lived session per poll — released by __aexit__.
-                async with AsyncSessionLocal() as session:
+                async with session_factory() as session:
                     current = await session.get(Episode, stream_episode_id)
 
                 if current is None:

--- a/apps/api/src/routers/generation.py
+++ b/apps/api/src/routers/generation.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
@@ -309,7 +309,7 @@ async def get_generation_progress_stream(
     episode_id: UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-    session_factory=Depends(get_streaming_session_factory),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_streaming_session_factory),
 ):
     """
     Server-Sent Events (SSE) endpoint for real-time generation progress

--- a/apps/api/src/routers/generation.py
+++ b/apps/api/src/routers/generation.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
 from ..config import settings
-from ..database import get_db, get_streaming_session_factory
+from ..database import get_db, get_streaming_session_factory, set_tenant_context
 from ..models.episode import Episode
 from ..models.project import Project
 from ..models.content_source import ContentSource
@@ -335,11 +335,12 @@ async def get_generation_progress_stream(
     if not episode:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Episode not found")
 
-    # Capture the id only: the request-scoped `db` session must not be reused
-    # inside the long-lived generator. Each poll opens its own short-lived
-    # session so a client disconnect can never leave a session checked out of
-    # the pool (issue #220).
+    # Capture id + tenant only: the request-scoped `db` session must not be
+    # reused inside the long-lived generator. Each poll opens its own
+    # short-lived session so a client disconnect can never leave a session
+    # checked out of the pool (issue #220).
     stream_episode_id = episode.id
+    stream_tenant_id = str(current_user.tenant_id)
 
     async def event_generator():
         """Generate SSE events with progress updates"""
@@ -347,6 +348,10 @@ async def get_generation_progress_stream(
             while True:
                 # Fresh short-lived session per poll — released by __aexit__.
                 async with session_factory() as session:
+                    # Re-apply tenant context: unlike the request session, a
+                    # fresh session has no app.tenant_id set, so FORCE ROW LEVEL
+                    # SECURITY would hide the episode without this (issue #220).
+                    await set_tenant_context(session, stream_tenant_id)
                     current = await session.get(Episode, stream_episode_id)
 
                 if current is None:

--- a/apps/api/src/tasks/callbacks.py
+++ b/apps/api/src/tasks/callbacks.py
@@ -89,10 +89,12 @@ def on_upload_complete(self: Task, result: Dict[str, Any], episode_id: str) -> N
 
 	updated = _update_episode(
 		episode_id,
+		# Do NOT set generation_status here: upload has already completed, so
+		# "uploading" would briefly regress the status. The workflow chain's
+		# next task (or on_workflow_complete) owns status progression (issue #220).
 		updates={
 			"s3_url": result.get("s3_url"),
 			"s3_key": result.get("s3_key"),
-			"generation_status": "uploading",
 		},
 		progress_updates={
 			"upload": "complete",

--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -3,6 +3,7 @@ Celery tasks for podcast generation
 Wraps the existing podcastfy CLI functionality
 """
 import os
+import time
 import uuid as uuid_module
 import logging
 from celery import Task, chain
@@ -27,6 +28,55 @@ def build_podcast_s3_key(user_id: str, episode_id: str) -> str:
     bucket-policy/IAM/lifecycle rules scope on (issue #215).
     """
     return f"podcasts/user-{user_id}/episode-{episode_id}.mp3"
+
+
+def _upload_to_s3_with_retries(
+    file_path: str,
+    s3_key: str,
+    bucket_name: str,
+    content_type: str = "audio/mpeg",
+    max_attempts: int = 3,
+) -> Dict[str, Any]:
+    """Upload to S3 with explicit retries + exponential backoff.
+
+    ``finalize_episode_generation_task`` calls ``upload_to_s3_task`` synchronously
+    (as a plain function, not via Celery), so the task's own ``self.retry`` is
+    bypassed — a transient S3 error would propagate raw on the first try
+    (issue #220). This wrapper restores retry behaviour for the inline path: it
+    retries on a raised exception OR a returned ``{"status": "failed"}`` result,
+    sleeping ``calculate_backoff()`` seconds between attempts. Returns the final
+    upload result dict (success or failed) without raising.
+    """
+    last_error = "S3 upload failed"
+    for attempt in range(max_attempts):
+        try:
+            result = upload_to_s3_task(
+                file_path=file_path,
+                s3_key=s3_key,
+                bucket_name=bucket_name,
+                content_type=content_type,
+            )
+            if result.get("status") == "success":
+                return result
+            last_error = result.get("error") or last_error
+            logger.warning(
+                f"S3 upload attempt {attempt + 1}/{max_attempts} failed: {last_error}"
+            )
+        except Exception as exc:
+            last_error = str(exc)
+            logger.warning(
+                f"S3 upload attempt {attempt + 1}/{max_attempts} raised: {exc}"
+            )
+        if attempt < max_attempts - 1:
+            time.sleep(calculate_backoff(attempt))
+
+    return {
+        "status": "failed",
+        "s3_key": None,
+        "s3_url": None,
+        "file_size_bytes": 0,
+        "error": last_error,
+    }
 
 
 @celery_app.task(bind=True, name="generate_podcast", time_limit=600, max_retries=3)
@@ -401,7 +451,7 @@ def finalize_episode_generation_task(
                 # Build S3 key using the canonical helper (issue #215)
                 s3_key = build_podcast_s3_key(str(episode.user_id), episode_id)
 
-                upload_result = upload_to_s3_task(
+                upload_result = _upload_to_s3_with_retries(
                     file_path=audio_file_path,
                     s3_key=s3_key,
                     bucket_name=settings.AWS_S3_BUCKET,

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -105,10 +105,15 @@ async def client(test_db):
     # (b) never opens connections on the module-global engine, which would leak
     # asyncpg pools across pytest's per-test event loops (issue #220).
     class _TestSessionCM:
-        async def __aenter__(self):
+        async def __aenter__(self) -> AsyncSession:
             return test_db
 
-        async def __aexit__(self, *exc):
+        async def __aexit__(
+            self,
+            exc_type: "type[BaseException] | None",
+            exc_val: "BaseException | None",
+            exc_tb: object,
+        ) -> bool:
             return False
 
     app.dependency_overrides[get_streaming_session_factory] = lambda: (lambda: _TestSessionCM())

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -14,7 +14,7 @@ from sqlalchemy.pool import NullPool
 os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
 
 from src.main import app
-from src.database import get_db
+from src.database import get_db, get_streaming_session_factory
 
 
 # Test database URL (use PostgreSQL test database)
@@ -99,6 +99,19 @@ async def client(test_db):
             raise
 
     app.dependency_overrides[get_db] = override_get_db
+
+    # The SSE generator opens a session per poll via get_streaming_session_factory.
+    # Bind it to the test session so it (a) sees the test's uncommitted data and
+    # (b) never opens connections on the module-global engine, which would leak
+    # asyncpg pools across pytest's per-test event loops (issue #220).
+    class _TestSessionCM:
+        async def __aenter__(self):
+            return test_db
+
+        async def __aexit__(self, *exc):
+            return False
+
+    app.dependency_overrides[get_streaming_session_factory] = lambda: (lambda: _TestSessionCM())
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:

--- a/apps/api/tests/test_s3_upload.py
+++ b/apps/api/tests/test_s3_upload.py
@@ -295,13 +295,17 @@ class TestFinalizeEpisodeGenerationTask:
         with (
             patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=mock_db),
             patch("src.tasks.podcast_generation.settings") as mock_settings,
-            patch("src.tasks.podcast_generation.upload_to_s3_task", return_value=mock_upload_result),
+            patch("src.tasks.podcast_generation.upload_to_s3_task", return_value=mock_upload_result) as mock_upload,
+            patch("src.tasks.podcast_generation.time.sleep") as mock_sleep,
         ):
             mock_settings.AWS_S3_BUCKET = "missing-bucket"
             result = self._invoke_finalize(episode_id, generation_result, mock_db)
 
         assert result["status"] == "failed"
         assert episode.generation_status == "failed"
+        # Inline upload now retries (issue #220): exhausts 3 attempts before failing.
+        assert mock_upload.call_count == 3
+        assert mock_sleep.call_count == 2
 
     def test_marks_failed_when_generation_failed(self):
         """If generate_podcast_task returned failure, episode is marked failed."""

--- a/apps/api/tests/test_sse_auth.py
+++ b/apps/api/tests/test_sse_auth.py
@@ -206,21 +206,21 @@ class _FakeSession:
 
     opened = 0
 
-    def __init__(self, episode):
+    def __init__(self, episode: SimpleNamespace) -> None:
         self._episode = episode
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "_FakeSession":
         type(self).opened += 1
         return self
 
-    async def __aexit__(self, *exc):
+    async def __aexit__(self, *exc: object) -> bool:
         return False
 
-    async def execute(self, *args, **kwargs):
+    async def execute(self, *args: object, **kwargs: object) -> None:
         # Absorb the SET LOCAL app.tenant_id call the generator issues.
         return None
 
-    async def get(self, model, pk):
+    async def get(self, model: object, pk: object) -> SimpleNamespace:
         return self._episode
 
 

--- a/apps/api/tests/test_sse_auth.py
+++ b/apps/api/tests/test_sse_auth.py
@@ -93,6 +93,12 @@ async def test_progress_stream_with_header_token(client, episode_with_user, test
     )
     assert response.status_code == 200
     assert "text/event-stream" in response.headers.get("content-type", "")
+    # The per-poll fresh session must re-apply tenant context; otherwise FORCE
+    # ROW LEVEL SECURITY (podcastfy_app role) hides the episode and the stream
+    # emits nothing. Assert the streamed event carries the episode's status (#220).
+    payload = json.loads(response.text.split("data: ", 1)[1].split("\n\n", 1)[0])
+    assert payload["episode_id"] == episode_id
+    assert payload["status"] == "complete"
 
 
 @pytest.mark.asyncio
@@ -209,6 +215,10 @@ class _FakeSession:
 
     async def __aexit__(self, *exc):
         return False
+
+    async def execute(self, *args, **kwargs):
+        # Absorb the SET LOCAL app.tenant_id call the generator issues.
+        return None
 
     async def get(self, model, pk):
         return self._episode

--- a/apps/api/tests/test_sse_auth.py
+++ b/apps/api/tests/test_sse_auth.py
@@ -11,7 +11,6 @@ history, and Referer headers.
 import json
 import pytest
 from types import SimpleNamespace
-from unittest.mock import patch
 from uuid import uuid4, UUID as PyUUID
 from datetime import timedelta
 from sqlalchemy import update
@@ -194,17 +193,18 @@ async def test_progress_stream_tenant_isolation(client, episode_with_user):
 class _FakeSession:
     """Async-context-manager session whose .get() returns a preset episode.
 
-    Stands in for AsyncSessionLocal() so the SSE generator can be exercised
-    without touching the request-scoped DB session it must NOT reuse (#220).
+    Stands in for a per-poll streaming session so the SSE generator can be
+    exercised without touching the request-scoped session it must NOT reuse,
+    and without opening real connections (issue #220).
     """
 
-    instances = 0
+    opened = 0
 
     def __init__(self, episode):
         self._episode = episode
 
     async def __aenter__(self):
-        type(self).instances += 1
+        type(self).opened += 1
         return self
 
     async def __aexit__(self, *exc):
@@ -215,9 +215,13 @@ class _FakeSession:
 
 
 @pytest.mark.asyncio
-async def test_progress_stream_uses_fresh_session_per_poll(client, episode_with_user, test_db):
-    """The SSE generator polls a fresh AsyncSessionLocal() rather than reusing
-    the request-scoped session, preventing pool leaks on disconnect (#220)."""
+async def test_progress_stream_uses_fresh_session_per_poll(client, episode_with_user):
+    """The SSE generator opens a fresh streaming session per poll (via the
+    injectable factory) instead of reusing the request-scoped session,
+    preventing pool leaks on disconnect (#220)."""
+    from src.main import app
+    from src.database import get_streaming_session_factory
+
     episode_id, token, headers = episode_with_user
 
     fake_episode = SimpleNamespace(
@@ -225,20 +229,22 @@ async def test_progress_stream_uses_fresh_session_per_poll(client, episode_with_
         generation_status="complete",  # terminal → stream emits once and stops
         generation_progress={"stage": "complete", "progress": 100},
     )
-    _FakeSession.instances = 0
+    _FakeSession.opened = 0
 
-    with patch(
-        "src.routers.generation.AsyncSessionLocal",
-        lambda: _FakeSession(fake_episode),
-    ):
-        response = await client.get(
-            f"/generation/episodes/{episode_id}/progress",
-            headers=headers,
-        )
+    # Override the streaming factory for this test; the per-test override added
+    # in conftest is replaced here and cleared by the client fixture teardown.
+    app.dependency_overrides[get_streaming_session_factory] = (
+        lambda: (lambda: _FakeSession(fake_episode))
+    )
+
+    response = await client.get(
+        f"/generation/episodes/{episode_id}/progress",
+        headers=headers,
+    )
 
     assert response.status_code == 200
-    # A fresh session was opened by the generator (not the request session).
-    assert _FakeSession.instances >= 1
+    # A fresh streaming session was opened by the generator (not the request one).
+    assert _FakeSession.opened >= 1
     # The streamed event reflects the data fetched via that fresh session.
     payload = json.loads(response.text.split("data: ", 1)[1].split("\n\n", 1)[0])
     assert payload["status"] == "complete"

--- a/apps/api/tests/test_sse_auth.py
+++ b/apps/api/tests/test_sse_auth.py
@@ -8,7 +8,10 @@ header server-side (issue #212). The legacy ``?token=<jwt>`` query-parameter aut
 path has been removed because tokens in URLs leak into proxy/access logs, browser
 history, and Referer headers.
 """
+import json
 import pytest
+from types import SimpleNamespace
+from unittest.mock import patch
 from uuid import uuid4, UUID as PyUUID
 from datetime import timedelta
 from sqlalchemy import update
@@ -182,6 +185,63 @@ async def test_progress_stream_tenant_isolation(client, episode_with_user):
         headers={"Authorization": f"Bearer {other_token}"}
     )
     assert response.status_code == 404
+
+
+# =============================================================================
+# Tests: SSE per-iteration session (issue #220)
+# =============================================================================
+
+class _FakeSession:
+    """Async-context-manager session whose .get() returns a preset episode.
+
+    Stands in for AsyncSessionLocal() so the SSE generator can be exercised
+    without touching the request-scoped DB session it must NOT reuse (#220).
+    """
+
+    instances = 0
+
+    def __init__(self, episode):
+        self._episode = episode
+
+    async def __aenter__(self):
+        type(self).instances += 1
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, model, pk):
+        return self._episode
+
+
+@pytest.mark.asyncio
+async def test_progress_stream_uses_fresh_session_per_poll(client, episode_with_user, test_db):
+    """The SSE generator polls a fresh AsyncSessionLocal() rather than reusing
+    the request-scoped session, preventing pool leaks on disconnect (#220)."""
+    episode_id, token, headers = episode_with_user
+
+    fake_episode = SimpleNamespace(
+        id=PyUUID(episode_id),
+        generation_status="complete",  # terminal → stream emits once and stops
+        generation_progress={"stage": "complete", "progress": 100},
+    )
+    _FakeSession.instances = 0
+
+    with patch(
+        "src.routers.generation.AsyncSessionLocal",
+        lambda: _FakeSession(fake_episode),
+    ):
+        response = await client.get(
+            f"/generation/episodes/{episode_id}/progress",
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    # A fresh session was opened by the generator (not the request session).
+    assert _FakeSession.instances >= 1
+    # The streamed event reflects the data fetched via that fresh session.
+    payload = json.loads(response.text.split("data: ", 1)[1].split("\n\n", 1)[0])
+    assert payload["status"] == "complete"
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/unit/test_celery_callbacks.py
+++ b/apps/api/tests/unit/test_celery_callbacks.py
@@ -76,7 +76,9 @@ class TestOnUploadComplete:
 
 		assert episode.s3_url == result["s3_url"]
 		assert episode.s3_key == result["s3_key"]
-		assert episode.generation_status == "uploading"
+		# Upload is already done; callback must NOT regress status back to
+		# "uploading" (issue #220). It leaves status untouched for the chain.
+		assert episode.generation_status == "generating"
 		mock_session.commit.assert_called_once()
 
 	def test_skips_update_when_upload_failed(self):

--- a/apps/api/tests/unit/test_podcast_generation_task.py
+++ b/apps/api/tests/unit/test_podcast_generation_task.py
@@ -263,6 +263,7 @@ class TestUploadToS3WithRetries:
 	explicit wrapper instead of propagating on the first try."""
 
 	def test_returns_success_first_try(self) -> None:
+		"""A first-try success returns immediately without retrying or sleeping."""
 		from src.tasks import podcast_generation as pg
 
 		ok = {"status": "success", "s3_url": "u", "s3_key": "k", "error": None}
@@ -274,6 +275,7 @@ class TestUploadToS3WithRetries:
 		slept.assert_not_called()
 
 	def test_retries_failed_status_then_succeeds(self) -> None:
+		"""A returned status!=success is retried; a later success is returned."""
 		from src.tasks import podcast_generation as pg
 
 		fail = {"status": "failed", "error": "throttled"}
@@ -286,6 +288,7 @@ class TestUploadToS3WithRetries:
 		assert slept.call_count == 1
 
 	def test_retries_on_exception_then_succeeds(self) -> None:
+		"""A raised transient error is retried; a later success is returned."""
 		from src.tasks import podcast_generation as pg
 
 		ok = {"status": "success", "s3_url": "u", "s3_key": "k", "error": None}
@@ -298,6 +301,7 @@ class TestUploadToS3WithRetries:
 		assert slept.call_count == 1
 
 	def test_returns_failed_after_exhausting_attempts(self) -> None:
+		"""Repeated failed-status results exhaust attempts and return failed."""
 		from src.tasks import podcast_generation as pg
 
 		fail = {"status": "failed", "error": "still throttled"}
@@ -310,12 +314,14 @@ class TestUploadToS3WithRetries:
 		assert slept.call_count == 2  # no sleep after the final attempt
 
 	def test_exhausts_attempts_on_repeated_exception(self) -> None:
+		"""Repeated raised errors exhaust attempts and return a failed dict."""
 		from src.tasks import podcast_generation as pg
 
 		with patch.object(
 			pg, "upload_to_s3_task", side_effect=ConnectionError("down")
-		) as up, patch.object(pg.time, "sleep"):
+		) as up, patch.object(pg.time, "sleep") as slept:
 			result = pg._upload_to_s3_with_retries("f", "k", "b", max_attempts=3)
 		assert result["status"] == "failed"
 		assert "down" in result["error"]
 		assert up.call_count == 3
+		assert slept.call_count == 2  # backoff between attempts, none after the last

--- a/apps/api/tests/unit/test_podcast_generation_task.py
+++ b/apps/api/tests/unit/test_podcast_generation_task.py
@@ -255,3 +255,67 @@ class TestBuildPodcastS3Key:
 		assert key == f"podcasts/user-{user_id}/episode-{episode_id}.mp3"
 		assert key.startswith("podcasts/user-")
 		assert key.endswith(".mp3")
+
+
+class TestUploadToS3WithRetries:
+	"""Issue #220: the inline S3 upload in finalize_episode_generation_task
+	bypasses Celery's retry, so a transient failure must be retried by the
+	explicit wrapper instead of propagating on the first try."""
+
+	def test_returns_success_first_try(self) -> None:
+		from src.tasks import podcast_generation as pg
+
+		ok = {"status": "success", "s3_url": "u", "s3_key": "k", "error": None}
+		with patch.object(pg, "upload_to_s3_task", return_value=ok) as up, \
+			patch.object(pg.time, "sleep") as slept:
+			result = pg._upload_to_s3_with_retries("f", "k", "b")
+		assert result["status"] == "success"
+		assert up.call_count == 1
+		slept.assert_not_called()
+
+	def test_retries_failed_status_then_succeeds(self) -> None:
+		from src.tasks import podcast_generation as pg
+
+		fail = {"status": "failed", "error": "throttled"}
+		ok = {"status": "success", "s3_url": "u", "s3_key": "k", "error": None}
+		with patch.object(pg, "upload_to_s3_task", side_effect=[fail, ok]) as up, \
+			patch.object(pg.time, "sleep") as slept:
+			result = pg._upload_to_s3_with_retries("f", "k", "b")
+		assert result["status"] == "success"
+		assert up.call_count == 2
+		assert slept.call_count == 1
+
+	def test_retries_on_exception_then_succeeds(self) -> None:
+		from src.tasks import podcast_generation as pg
+
+		ok = {"status": "success", "s3_url": "u", "s3_key": "k", "error": None}
+		with patch.object(
+			pg, "upload_to_s3_task", side_effect=[ConnectionError("net"), ok]
+		) as up, patch.object(pg.time, "sleep") as slept:
+			result = pg._upload_to_s3_with_retries("f", "k", "b")
+		assert result["status"] == "success"
+		assert up.call_count == 2
+		assert slept.call_count == 1
+
+	def test_returns_failed_after_exhausting_attempts(self) -> None:
+		from src.tasks import podcast_generation as pg
+
+		fail = {"status": "failed", "error": "still throttled"}
+		with patch.object(pg, "upload_to_s3_task", return_value=fail) as up, \
+			patch.object(pg.time, "sleep") as slept:
+			result = pg._upload_to_s3_with_retries("f", "k", "b", max_attempts=3)
+		assert result["status"] == "failed"
+		assert result["error"] == "still throttled"
+		assert up.call_count == 3
+		assert slept.call_count == 2  # no sleep after the final attempt
+
+	def test_exhausts_attempts_on_repeated_exception(self) -> None:
+		from src.tasks import podcast_generation as pg
+
+		with patch.object(
+			pg, "upload_to_s3_task", side_effect=ConnectionError("down")
+		) as up, patch.object(pg.time, "sleep"):
+			result = pg._upload_to_s3_with_retries("f", "k", "b", max_attempts=3)
+		assert result["status"] == "failed"
+		assert "down" in result["error"]
+		assert up.call_count == 3

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,43 +1,30 @@
-# Issue #224 — Harden agentic/CI workflows
+# Issue #220 — Celery/SSE reliability fixes (apps/api)
 
-Security hardening of GitHub Actions workflows. Plan source: issue body (acceptance criteria).
+Plan source: CodeRabbit comment (adapted to current code). Branch: `fix/220-celery-sse-reliability`
 
-## Steps
+## Fix 1 — Inline S3 upload bypasses retries (`tasks/podcast_generation.py` ~404)
+- `upload_to_s3_task(...)` is called as a plain function inside `finalize_episode_generation_task`.
+  Called directly, its `self.retry` raises immediately → upload's own retry never runs.
+- Wrap the inline call in an explicit retry loop: up to 3 attempts, `calculate_backoff` + `time.sleep`
+  between tries. Retry on transient exception AND on a returned `status != "success"`.
+- On exhaustion: mark episode `failed` + return failed dict (matches existing upload-failure branch;
+  avoids double-retry against the finalize task's own outer `self.retry`).
+- Add `import time`.
 
-### 1. Stop interpolating untrusted input into `run:` shells
-- **rm-loop.yml** (line ~146): issue `title` is interpolated into a `run:` shell → shell injection.
-  Move `title` (and the dispatch input `force_issue`) into step-level `env:` and reference `"$TITLE"` / `"$FORCE_ISSUE"`.
-- **playwright-tests.yml** (line ~88): `github.event.inputs.test_suite` (choice input, arbitrary via API) interpolated into a `run:` glob.
-  Move to `env:` and reference `"$TEST_SUITE"` (keep the surrounding `*` globs unquoted).
+## Fix 2 — Wrong status in `on_upload_complete` (`tasks/callbacks.py:95`)
+- Remove `"generation_status": "uploading"` from the `_update_episode` updates dict.
+- Keep `s3_url`, `s3_key`, and progress updates.
+- Update test `test_updates_episode_s3_url_on_success` (asserts status == "uploading").
 
-### 2. Pin third-party actions to full commit SHAs
-- `anthropics/claude-code-action@v1` → `@51705da45eecce209d4700538bf8377d5b5fc695` across 6 workflows
-  (rm-loop, rm-review, rm-docs, rm-refine, rm-research, claude).
-- Each pin gets a `# vX.Y` comment so Dependabot can track it.
-- First-party `actions/*` (checkout, setup-node, etc.) left on tags — not flagged, Dependabot covers them.
-- `draft-pdf.yml` (the other flagged pins: `openjournals-draft-action@master`,
-  `create-pull-request@v5`) was **deleted** instead — dead leftover from the
-  upstream JOSS-paper fork (no `paper/` dir; failing on main since Nov 2025).
-
-### 3. Add Dependabot for github-actions
-- New `.github/dependabot.yml` with the `github-actions` ecosystem (weekly).
-
-### 4. Protect the deploy secret (deploy-dev.yml)
-- `chmod 600` the `.env.production` file after writing `NEXTAUTH_SECRET` into it.
-- Remove `NEXTAUTH_SECRET` from the PM2 command line (argv → visible via `ps`); Next.js reads it from `.env.production` at runtime.
-
-### 5. (Judgment call) Human approval before auto-merge to main
-- rm-review.yml `auto-merge` job currently merges every tier once CI + verification pass.
-- Add `environment: auto-merge-approval` to that job so a required-reviewer rule can gate it.
-- Takes effect only once reviewers are configured on that environment in repo settings (no-op otherwise).
-
-## Acceptance criteria
-- [ ] Untrusted issue title / dispatch inputs passed via `env:`, referenced as `"$VAR"`; no `${{ }}` interpolation into `run:`.
-- [ ] Third-party actions pinned to full SHAs (no `@master`); Dependabot enabled for github-actions.
-- [ ] Deploy secret written to a chmod-600 env file; not passed on argv.
-- [ ] Auto-merge to main can require human approval (environment gate).
+## Fix 3 — SSE leaks DB session (`routers/generation.py:337-357`)
+- `event_generator` loops `await db.refresh(episode)` on the request-scoped session; on client
+  disconnect the session can be left non-idle.
+- Capture `episode_id` before the generator; per iteration open `async with AsyncSessionLocal()`
+  and `session.get(Episode, episode_id)`.
+- Wrap loop to catch `asyncio.CancelledError` (disconnect) + log; `finally` for cleanup.
+- Add `AsyncSessionLocal` import.
 
 ## Verification
-- `actionlint` on changed workflows (syntax + shellcheck of `run:` blocks).
-- grep assertion: no untrusted `${{ }}` left inside `run:` blocks of the touched workflows.
-- No test framework exists for workflow YAML — verification is actionlint + targeted grep + demo gate.
+- `uv run pytest tests/unit/test_celery_callbacks.py tests/unit/test_podcast_generation_task.py tests/test_sse_auth.py`
+- New tests: upload-retry-then-fail path; on_upload_complete no longer sets status; SSE uses fresh session.
+- Demo (Phase 11), CI gate (Phase 12), then PR + merge.


### PR DESCRIPTION
## Summary
Fixes three Celery/SSE reliability defects in `apps/api` (issue #220).

### 1. Inline S3 upload bypassed retries (`tasks/podcast_generation.py`)
`finalize_episode_generation_task` called `upload_to_s3_task(...)` as a plain
function. Called directly, the Celery task's own `self.retry` raises immediately
(`called_directly`), so transient S3 errors propagated raw on the first try.
Wrapped the inline call in `_upload_to_s3_with_retries`: up to 3 attempts with
`calculate_backoff` between tries, retrying on a raised transient error **or** a
returned `status != "success"`. On exhaustion the existing branch marks the
episode `failed`.

### 2. Wrong status in `on_upload_complete` (`tasks/callbacks.py`)
The callback set `generation_status="uploading"` *after* upload had already
completed, briefly regressing the status. Removed it — the workflow chain's next
task (or `on_workflow_complete`) owns status progression. `s3_url`/`s3_key`/
progress updates are kept.

### 3. SSE leaked the request DB session (`routers/generation.py`)
`event_generator` looped `await db.refresh(episode)` on the request-scoped
`AsyncSession`; on client disconnect the session could be left non-idle in the
pool. Now opens a fresh `AsyncSessionLocal()` per poll, fetches by id, and
handles `asyncio.CancelledError` (disconnect) explicitly.

## Tests
- `_upload_to_s3_with_retries`: success-first-try, retry-on-failed-status,
  retry-on-exception, exhaustion (failed-status & repeated-exception).
- `on_upload_complete` no longer regresses status.
- SSE generator uses a fresh session per poll and emits the polled status.
- Updated `test_marks_failed_when_s3_upload_fails` to assert the new retry count.
- Full backend suite green locally (Postgres 16).

## Known Limitations
- The inline upload retry sleeps `calculate_backoff` (5s, 10s) on the worker
  thread between attempts — consistent with the chosen synchronous-execution
  design (CodeRabbit plan, option 2). Bounded to 2 sleeps max.
- Non-retryable S3 errors (e.g. `NoSuchBucket`) are still retried up to 3× by
  the wrapper before failing; `upload_to_s3_task` raises these, and the wrapper
  treats all exceptions as transient for simplicity. Cost is ~15s worst case.

Closes #220
