### PR TITLE
fix(api): enforce Stripe webhook signature verification (#216)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -85,3 +85,9 @@ SPOTIFY_CLIENT_ID=your-spotify-client-id-here
 SPOTIFY_CLIENT_SECRET=your-spotify-client-secret-here
 # Must be registered as a valid redirect URI in your Spotify app settings
 SPOTIFY_REDIRECT_URI=https://api.example.com/distribution-targets/spotify/callback
+
+# Stripe billing (issue #216)
+# Billing is OFF unless STRIPE_SECRET_KEY is set. When enabled, STRIPE_WEBHOOK_SECRET
+# is REQUIRED: the webhook endpoint rejects any unsigned/unverified event with 400.
+STRIPE_SECRET_KEY=your-stripe-secret-key-here
+STRIPE_WEBHOOK_SECRET=your-stripe-webhook-signing-secret-here

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -59,6 +59,10 @@ class Settings(BaseSettings):
     AWS_S3_BUCKET: Optional[str] = None
     AWS_REGION: str = "us-east-1"
 
+    # Stripe billing (both required to enable billing; see billing_service)
+    STRIPE_SECRET_KEY: Optional[str] = None
+    STRIPE_WEBHOOK_SECRET: Optional[str] = None
+
     # Celery
     CELERY_BROKER_URL: Optional[str] = None
     CELERY_RESULT_BACKEND: Optional[str] = None

--- a/apps/api/src/services/billing_service.py
+++ b/apps/api/src/services/billing_service.py
@@ -207,19 +207,33 @@ async def process_webhook(
 
 	_stripe_module.api_key = _get_stripe_key()  # type: ignore[union-attr]
 
-	if webhook_secret and sig_header:
-		try:
-			event = _stripe_module.Webhook.construct_event(  # type: ignore[union-attr]
-				payload, sig_header, webhook_secret
-			)
-		except _stripe_module.error.SignatureVerificationError:  # type: ignore[union-attr]
-			raise HTTPException(
-				status_code=status.HTTP_400_BAD_REQUEST,
-				detail="Invalid webhook signature",
-			)
-	else:
-		import json
-		event = json.loads(payload)
+	# Signature verification is mandatory when billing is enabled. There is no
+	# unsigned/unverified fallback: a missing secret or signature header is
+	# rejected outright rather than parsed, closing the bypass in issue #216.
+	if not webhook_secret:
+		logger.error(
+			"Stripe billing is enabled but STRIPE_WEBHOOK_SECRET is not configured; "
+			"rejecting webhook instead of processing it unverified"
+		)
+		raise HTTPException(
+			status_code=status.HTTP_400_BAD_REQUEST,
+			detail="Webhook secret not configured",
+		)
+	if not sig_header:
+		raise HTTPException(
+			status_code=status.HTTP_400_BAD_REQUEST,
+			detail="Missing webhook signature",
+		)
+
+	try:
+		event = _stripe_module.Webhook.construct_event(  # type: ignore[union-attr]
+			payload, sig_header, webhook_secret
+		)
+	except _stripe_module.error.SignatureVerificationError:  # type: ignore[union-attr]
+		raise HTTPException(
+			status_code=status.HTTP_400_BAD_REQUEST,
+			detail="Invalid webhook signature",
+		)
 
 	event_type = event.get("type", "")
 	data = event.get("data", {}).get("object", {})

--- a/apps/api/tests/test_billing.py
+++ b/apps/api/tests/test_billing.py
@@ -5,6 +5,8 @@ Integration tests for the /billing endpoints.
 import pytest
 from uuid import uuid4
 
+from httpx import AsyncClient
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -332,7 +334,9 @@ async def test_pricing_config_pro_tier():
 
 
 @pytest.mark.asyncio
-async def test_stripe_webhook_rejects_missing_signature_when_enabled(client, monkeypatch):
+async def test_stripe_webhook_rejects_missing_signature_when_enabled(
+	client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+):
 	"""Issue #216: with billing enabled + secret configured, a request without a
 	Stripe-Signature header is rejected with 400 — never parsed unsigned."""
 	import types

--- a/apps/api/tests/test_billing.py
+++ b/apps/api/tests/test_billing.py
@@ -329,3 +329,32 @@ async def test_pricing_config_pro_tier():
 	from src.utils.pricing import get_tier_limit
 	assert get_tier_limit("pro", "episodes_per_month") == 100
 	assert get_tier_limit("pro", "storage_gb") == 50
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_rejects_missing_signature_when_enabled(client, monkeypatch):
+	"""Issue #216: with billing enabled + secret configured, a request without a
+	Stripe-Signature header is rejected with 400 — never parsed unsigned."""
+	import types
+	import src.services.billing_service as bs
+	from src.config import settings
+
+	# Enable billing with a fake stripe module (the real one isn't installed).
+	fake = types.SimpleNamespace(
+		api_key=None,
+		Webhook=types.SimpleNamespace(construct_event=lambda *a, **k: {}),
+		error=types.SimpleNamespace(SignatureVerificationError=type("E", (Exception,), {})),
+	)
+	monkeypatch.setattr(bs, "_STRIPE_AVAILABLE", True)
+	monkeypatch.setattr(bs, "_stripe_module", fake)
+	monkeypatch.setattr(bs, "_get_stripe_key", lambda: "sk_test_fake")
+	monkeypatch.setattr(settings, "STRIPE_WEBHOOK_SECRET", "whsec_test", raising=False)
+
+	import json
+	payload = json.dumps({"type": "customer.subscription.updated", "data": {"object": {}}}).encode()
+	response = await client.post(
+		"/billing/webhooks/stripe",
+		content=payload,
+		headers={"Content-Type": "application/json"},  # no stripe-signature header
+	)
+	assert response.status_code == 400

--- a/apps/api/tests/unit/test_billing_unit.py
+++ b/apps/api/tests/unit/test_billing_unit.py
@@ -3,7 +3,11 @@ Unit tests for billing service, usage service, and pricing config.
 These tests do not require a database connection.
 """
 
+import types
+from unittest.mock import MagicMock
+
 import pytest
+from fastapi import HTTPException
 
 
 # ---------------------------------------------------------------------------
@@ -180,3 +184,85 @@ class TestBillingSchemas:
 		from src.schemas.billing import SubscriptionUpdateRequest
 		with pytest.raises(ValidationError):
 			SubscriptionUpdateRequest(action="invalid_action")
+
+
+# ---------------------------------------------------------------------------
+# Webhook signature enforcement (issue #216)
+# ---------------------------------------------------------------------------
+
+
+def _enable_stripe(monkeypatch, construct_event):
+	"""Enable Stripe in billing_service with a fake stripe module.
+
+	Returns (module, SignatureVerificationError) so callers can raise the same
+	error class the verifier catches.
+	"""
+	import src.services.billing_service as bs
+
+	class _SigError(Exception):
+		pass
+
+	fake = types.SimpleNamespace()
+	fake.Webhook = types.SimpleNamespace(construct_event=construct_event)
+	fake.error = types.SimpleNamespace(SignatureVerificationError=_SigError)
+	monkeypatch.setattr(bs, "_STRIPE_AVAILABLE", True)
+	monkeypatch.setattr(bs, "_stripe_module", fake)
+	monkeypatch.setattr(bs, "_get_stripe_key", lambda: "sk_test_fake")
+	return bs, _SigError
+
+
+class TestProcessWebhookSignature:
+	"""When Stripe is enabled, unsigned/unverified payloads must be rejected."""
+
+	@pytest.mark.asyncio
+	async def test_missing_signature_header_rejected(self, monkeypatch):
+		"""Enabled + secret configured + no Stripe-Signature header -> 400."""
+		bs, _ = _enable_stripe(monkeypatch, MagicMock())
+		with pytest.raises(HTTPException) as exc:
+			await bs.process_webhook(MagicMock(), b"{}", None, "whsec_test")
+		assert exc.value.status_code == 400
+
+	@pytest.mark.asyncio
+	async def test_missing_secret_rejected(self, monkeypatch):
+		"""Enabled but no webhook secret configured -> 400; never parse unsigned."""
+		bs, _ = _enable_stripe(monkeypatch, MagicMock())
+		with pytest.raises(HTTPException) as exc:
+			await bs.process_webhook(MagicMock(), b"{}", "sig", None)
+		assert exc.value.status_code == 400
+
+	@pytest.mark.asyncio
+	async def test_invalid_signature_rejected(self, monkeypatch):
+		"""Configured secret + invalid signature -> 400."""
+		bs, SigError = _enable_stripe(monkeypatch, MagicMock())
+		bs._stripe_module.Webhook.construct_event = MagicMock(
+			side_effect=SigError("bad signature")
+		)
+		with pytest.raises(HTTPException) as exc:
+			await bs.process_webhook(MagicMock(), b"{}", "sig", "whsec_test")
+		assert exc.value.status_code == 400
+
+	@pytest.mark.asyncio
+	async def test_valid_signature_processed(self, monkeypatch):
+		"""Configured secret + valid signature -> event processed (verified path)."""
+		event = {"type": "invoice.paid", "data": {"object": {}}}
+		bs, _ = _enable_stripe(monkeypatch, MagicMock(return_value=event))
+		result = await bs.process_webhook(MagicMock(), b"{}", "sig", "whsec_test")
+		assert result["status"] == "processed"
+		assert result["event_type"] == "invoice.paid"
+
+	@pytest.mark.asyncio
+	async def test_disabled_stripe_ignored(self, monkeypatch):
+		"""Stripe disabled -> ignored, no parsing (existing behavior preserved)."""
+		import src.services.billing_service as bs
+		monkeypatch.setattr(bs, "_get_stripe_key", lambda: None)
+		result = await bs.process_webhook(MagicMock(), b"{}", None, None)
+		assert result["status"] == "ignored"
+
+
+class TestStripeSettings:
+	"""Issue #216 AC1: secret + webhook secret must be real Settings fields."""
+
+	def test_settings_expose_stripe_fields(self):
+		from src.config import settings
+		assert hasattr(settings, "STRIPE_SECRET_KEY")
+		assert hasattr(settings, "STRIPE_WEBHOOK_SECRET")

--- a/apps/api/tests/unit/test_billing_unit.py
+++ b/apps/api/tests/unit/test_billing_unit.py
@@ -4,6 +4,7 @@ These tests do not require a database connection.
 """
 
 import types
+from typing import Any, Callable
 from unittest.mock import MagicMock
 
 import pytest
@@ -191,7 +192,9 @@ class TestBillingSchemas:
 # ---------------------------------------------------------------------------
 
 
-def _enable_stripe(monkeypatch, construct_event):
+def _enable_stripe(
+	monkeypatch: pytest.MonkeyPatch, construct_event: Callable[..., object]
+) -> "tuple[Any, type[Exception]]":
 	"""Enable Stripe in billing_service with a fake stripe module.
 
 	Returns (module, SignatureVerificationError) so callers can raise the same
@@ -215,7 +218,7 @@ class TestProcessWebhookSignature:
 	"""When Stripe is enabled, unsigned/unverified payloads must be rejected."""
 
 	@pytest.mark.asyncio
-	async def test_missing_signature_header_rejected(self, monkeypatch):
+	async def test_missing_signature_header_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
 		"""Enabled + secret configured + no Stripe-Signature header -> 400."""
 		bs, _ = _enable_stripe(monkeypatch, MagicMock())
 		with pytest.raises(HTTPException) as exc:
@@ -223,7 +226,7 @@ class TestProcessWebhookSignature:
 		assert exc.value.status_code == 400
 
 	@pytest.mark.asyncio
-	async def test_missing_secret_rejected(self, monkeypatch):
+	async def test_missing_secret_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
 		"""Enabled but no webhook secret configured -> 400; never parse unsigned."""
 		bs, _ = _enable_stripe(monkeypatch, MagicMock())
 		with pytest.raises(HTTPException) as exc:
@@ -231,7 +234,7 @@ class TestProcessWebhookSignature:
 		assert exc.value.status_code == 400
 
 	@pytest.mark.asyncio
-	async def test_invalid_signature_rejected(self, monkeypatch):
+	async def test_invalid_signature_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
 		"""Configured secret + invalid signature -> 400."""
 		bs, SigError = _enable_stripe(monkeypatch, MagicMock())
 		bs._stripe_module.Webhook.construct_event = MagicMock(
@@ -242,16 +245,19 @@ class TestProcessWebhookSignature:
 		assert exc.value.status_code == 400
 
 	@pytest.mark.asyncio
-	async def test_valid_signature_processed(self, monkeypatch):
+	async def test_valid_signature_processed(self, monkeypatch: pytest.MonkeyPatch) -> None:
 		"""Configured secret + valid signature -> event processed (verified path)."""
 		event = {"type": "invoice.paid", "data": {"object": {}}}
-		bs, _ = _enable_stripe(monkeypatch, MagicMock(return_value=event))
+		construct_event = MagicMock(return_value=event)
+		bs, _ = _enable_stripe(monkeypatch, construct_event)
 		result = await bs.process_webhook(MagicMock(), b"{}", "sig", "whsec_test")
 		assert result["status"] == "processed"
 		assert result["event_type"] == "invoice.paid"
+		# The verified path was taken: signature was actually checked.
+		construct_event.assert_called_once_with(b"{}", "sig", "whsec_test")
 
 	@pytest.mark.asyncio
-	async def test_disabled_stripe_ignored(self, monkeypatch):
+	async def test_disabled_stripe_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
 		"""Stripe disabled -> ignored, no parsing (existing behavior preserved)."""
 		import src.services.billing_service as bs
 		monkeypatch.setattr(bs, "_get_stripe_key", lambda: None)
@@ -262,7 +268,7 @@ class TestProcessWebhookSignature:
 class TestStripeSettings:
 	"""Issue #216 AC1: secret + webhook secret must be real Settings fields."""
 
-	def test_settings_expose_stripe_fields(self):
+	def test_settings_expose_stripe_fields(self) -> None:
 		from src.config import settings
 		assert hasattr(settings, "STRIPE_SECRET_KEY")
 		assert hasattr(settings, "STRIPE_WEBHOOK_SECRET")

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,30 +1,40 @@
-# Issue #220 — Celery/SSE reliability fixes (apps/api)
+# Issue #216 — Stripe webhook signature bypass (security, apps/api)
 
-Plan source: CodeRabbit comment (adapted to current code). Branch: `fix/220-celery-sse-reliability`
+Plan source: self-authored (no plan comment). Branch: `fix/216-stripe-webhook-signature`
 
-## Fix 1 — Inline S3 upload bypasses retries (`tasks/podcast_generation.py` ~404)
-- `upload_to_s3_task(...)` is called as a plain function inside `finalize_episode_generation_task`.
-  Called directly, its `self.retry` raises immediately → upload's own retry never runs.
-- Wrap the inline call in an explicit retry loop: up to 3 attempts, `calculate_backoff` + `time.sleep`
-  between tries. Retry on transient exception AND on a returned `status != "success"`.
-- On exhaustion: mark episode `failed` + return failed dict (matches existing upload-failure branch;
-  avoids double-retry against the finalize task's own outer `self.retry`).
-- Add `import time`.
+## Vulnerability
+`billing_service.process_webhook` falls back to `json.loads(payload)` and processes
+events **unsigned** when `webhook_secret`/`sig_header` are absent. Latent today only
+because `STRIPE_SECRET_KEY` isn't a Settings field (`extra="ignore"` drops it →
+`_stripe_enabled()` always False → early return). Becomes live the moment billing is
+enabled.
 
-## Fix 2 — Wrong status in `on_upload_complete` (`tasks/callbacks.py:95`)
-- Remove `"generation_status": "uploading"` from the `_update_episode` updates dict.
-- Keep `s3_url`, `s3_key`, and progress updates.
-- Update test `test_updates_episode_s3_url_on_success` (asserts status == "uploading").
+## Fix 1 — Settings fields (`config.py`, spaces indent)
+- Add `STRIPE_SECRET_KEY: Optional[str] = None` and `STRIPE_WEBHOOK_SECRET: Optional[str] = None`.
+- Makes them real, validated Settings (no longer silently dropped). Satisfies AC1.
 
-## Fix 3 — SSE leaks DB session (`routers/generation.py:337-357`)
-- `event_generator` loops `await db.refresh(episode)` on the request-scoped session; on client
-  disconnect the session can be left non-idle.
-- Capture `episode_id` before the generator; per iteration open `async with AsyncSessionLocal()`
-  and `session.get(Episode, episode_id)`.
-- Wrap loop to catch `asyncio.CancelledError` (disconnect) + log; `finally` for cleanup.
-- Add `AsyncSessionLocal` import.
+## Fix 2 — Enforce signature (`billing_service.process_webhook`, tabs indent)
+- Keep the `_stripe_enabled()` early-return (`ignored` when billing off) — existing
+  behavior/tests rely on it.
+- When enabled: **remove the `json.loads` unsigned fallback entirely.**
+  - `webhook_secret` or `sig_header` missing → raise `HTTPException(400)` (per AC2).
+  - else `construct_event(...)`; on `SignatureVerificationError` → 400 (already present).
+- Net: no code path ever parses an unsigned/unverified payload.
+
+## Fix 3 — Tests (`tests/unit/test_billing_unit.py` + `tests/test_billing.py`, tabs)
+- enabled + secret set + **missing** sig_header → 400 (AC3).
+- enabled + secret set + **invalid** signature (mock `construct_event` raises
+  `SignatureVerificationError`) → 400 (AC3).
+- enabled + secret set + valid signature → processed.
+- Settings exposes `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` (AC1).
+- Existing webhook tests (stripe disabled → 200 ignored) remain green.
+
+## Notes / decisions
+- AC says "Reject with 400 when secret/sig_header missing." A missing server-side
+  `webhook_secret` is arguably a 500 (misconfig), but I follow the AC literally → 400
+  for both missing cases. Logged distinctly for ops.
+- Scope is small (security hardening) → single agent, TDD.
 
 ## Verification
-- `uv run pytest tests/unit/test_celery_callbacks.py tests/unit/test_podcast_generation_task.py tests/test_sse_auth.py`
-- New tests: upload-retry-then-fail path; on_upload_complete no longer sets status; SSE uses fresh session.
-- Demo (Phase 11), CI gate (Phase 12), then PR + merge.
+- `uv run pytest tests/test_billing.py tests/unit/test_billing_unit.py`
+- Cross-family review (CodeRabbit), demo (Phase 11), CI gate (Phase 12), PR → merge.


### PR DESCRIPTION
## Summary
Closes #216. Fixes a latent **Stripe webhook signature bypass** in `apps/api`.

`billing_service.process_webhook` fell back to `json.loads(payload)` and processed
events **unverified** whenever `webhook_secret`/`sig_header` were absent. It was
latent only because `STRIPE_SECRET_KEY` was never a `Settings` field
(`extra="ignore"` dropped it → `_stripe_enabled()` always `False` → early return).
The bypass would become live the moment billing is enabled.

## Changes
- **`config.py`** — add `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` as real
  `Optional[str]` Settings fields (no longer silently dropped).
- **`billing_service.process_webhook`** — remove the unsigned `json.loads`
  fallback. When billing is enabled:
  - missing webhook secret → `400` (logged as a server misconfiguration)
  - missing signature header → `400`
  - invalid signature → `400` (unchanged)
  - valid signature → verified and processed

  No code path parses an unsigned/unverified payload.

## Tests
- Unit (`test_billing_unit.py`): missing-sig / missing-secret / invalid-sig → 400;
  valid sig → processed; disabled → `ignored`; Settings expose both fields.
- Integration (`test_billing.py`): enabled + configured secret + no signature
  header → HTTP 400. Existing "disabled → 200 ignored" webhook tests unchanged.
- Full backend suite green locally (1459 passed).

## Known Limitations / decisions
- Per the issue's acceptance criteria ("reject with 400 when secret/sig_header
  missing"), a missing **server-side** `webhook_secret` returns 400 even though it
  is a misconfiguration rather than a client error. It is logged distinctly via
  `logger.error` for operators. Enforcement is at the webhook boundary (not a
  startup check) to avoid breaking existing/test deployments.
