### PR TITLE
fix(api): bind team invitation acceptance to invited email; restrict roles; document RLS exclusion (#218)

### DIFF
--- a/apps/api/alembic/versions/009_add_team_collaboration_tables.py
+++ b/apps/api/alembic/versions/009_add_team_collaboration_tables.py
@@ -8,6 +8,12 @@ Creates three new tables to support team-based collaboration:
   - teams: team/organization records
   - team_members: user membership with role assignment
   - team_invitations: pending email invitations with token-based acceptance
+
+Security note: these tables are intentionally NOT row-level-security scoped.
+Unlike the tenant-scoped tables in migration 003, teams have no ``tenant_id``
+(a team is a shared, cross-user resource), so per-tenant RLS does not apply.
+Access is isolated at the application layer via RBAC — see team_service.py and
+rbac_service.assert_permission, which every team route calls.
 """
 from typing import Sequence, Union
 

--- a/apps/api/src/routers/teams.py
+++ b/apps/api/src/routers/teams.py
@@ -174,5 +174,9 @@ async def accept_invitation(
 	current_user: User = Depends(get_current_user),
 	db: AsyncSession = Depends(get_db),
 ):
-	"""Accept an invitation token and join the team."""
-	return await team_service.accept_invitation(db, token, current_user.id)
+	"""Accept an invitation token and join the team.
+
+	The invitation is bound to the invited email: a user whose email does not
+	match the invitation is rejected (403), so a forwarded token cannot be used.
+	"""
+	return await team_service.accept_invitation(db, token, current_user.id, current_user.email)

--- a/apps/api/src/schemas/team.py
+++ b/apps/api/src/schemas/team.py
@@ -83,10 +83,15 @@ class TeamMemberUpdate(BaseModel):
 
 
 class InvitationCreate(BaseModel):
-	"""Schema for sending an invitation."""
+	"""Schema for sending an invitation.
+
+	`owner` is intentionally not invitable: an invitation token can be forwarded
+	or leaked, so granting ownership through it is a privilege-escalation vector.
+	Ownership is granted directly via the owner-only update-member-role route.
+	"""
 
 	email: EmailStr
-	role: str = Field("editor", pattern="^(owner|editor|viewer|analyst)$")
+	role: str = Field("editor", pattern="^(editor|viewer|analyst)$")
 
 
 class InvitationResponse(BaseModel):

--- a/apps/api/src/services/team_service.py
+++ b/apps/api/src/services/team_service.py
@@ -1,5 +1,13 @@
 """
 Team service: business logic for team CRUD, memberships, and invitations.
+
+Security note — team tables are intentionally NOT row-level-security (RLS)
+scoped. `teams`, `team_members`, and `team_invitations` have no `tenant_id`
+column: a team is a shared, cross-user resource rather than data owned by a
+single tenant, so the per-tenant RLS policies applied in migration 003 do not
+apply to them (see migration 009). Isolation for these tables is enforced at
+the application layer via RBAC — every team route asserts membership/permission
+through `rbac_service.assert_permission`. Any new team route MUST do the same.
 """
 
 import secrets
@@ -14,6 +22,13 @@ from ..models.team import Team
 from ..models.team_member import TeamMember
 from ..models.team_invitation import TeamInvitation
 from ..schemas.team import TeamCreate, TeamUpdate, InvitationCreate
+
+# Roles that may be granted through an invitation. `owner` is excluded: an
+# invitation token is forwardable, so granting ownership through it is a
+# privilege-escalation vector (ownership is granted via update_member_role).
+# Enforced at acceptance as well as creation so tokens issued before the role
+# restriction was deployed cannot still grant a disallowed role.
+INVITABLE_ROLES = frozenset({"editor", "viewer", "analyst"})
 
 
 # ---------------------------------------------------------------------------
@@ -202,14 +217,34 @@ async def accept_invitation(
 	db: AsyncSession,
 	token: str,
 	user_id: UUID,
+	user_email: str,
 ) -> TeamMember:
-	"""Accept an invitation token and create a TeamMember record."""
+	"""Accept an invitation token and create a TeamMember record.
+
+	The accepting user's email must match the invited email exactly, otherwise a
+	forwarded/leaked token would let any user join. The match is exact (not
+	case-folded) because account emails are stored and looked up case-sensitively
+	(see auth_service): `victim@x.com` and `Victim@x.com` can be distinct
+	accounts, so a case-insensitive match here would let a case-variant account
+	accept a token addressed to another. Membership is created with the
+	invitation's role.
+	"""
 	result = await db.execute(
 		select(TeamInvitation).where(TeamInvitation.token == token)
 	)
 	invitation = result.scalar_one_or_none()
 	if invitation is None:
 		raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invitation not found")
+	if invitation.email != user_email:
+		raise HTTPException(
+			status_code=status.HTTP_403_FORBIDDEN,
+			detail="This invitation was sent to a different email address",
+		)
+	if invitation.role not in INVITABLE_ROLES:
+		raise HTTPException(
+			status_code=status.HTTP_403_FORBIDDEN,
+			detail="This invitation grants a role that can no longer be accepted",
+		)
 	if invitation.status != "pending":
 		raise HTTPException(
 			status_code=status.HTTP_400_BAD_REQUEST,

--- a/apps/api/tests/test_teams.py
+++ b/apps/api/tests/test_teams.py
@@ -7,6 +7,9 @@ Requires a running PostgreSQL instance with migrations applied.
 import pytest
 from uuid import uuid4
 
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -274,7 +277,7 @@ async def test_invalid_invitation_token_returns_404(client):
 
 
 @pytest.mark.asyncio
-async def test_accept_invitation_wrong_email_rejected(client):
+async def test_accept_invitation_wrong_email_rejected(client: AsyncClient) -> None:
 	"""A user whose email differs from the invited email cannot accept (403)."""
 	owner_headers = await register_and_login(client)
 	invited_email = f"invited_{uuid4()}@example.com"
@@ -296,7 +299,7 @@ async def test_accept_invitation_wrong_email_rejected(client):
 
 
 @pytest.mark.asyncio
-async def test_accept_invitation_case_variant_account_rejected(client):
+async def test_accept_invitation_case_variant_account_rejected(client: AsyncClient) -> None:
 	"""A case-variant account cannot accept a token addressed to another email.
 
 	Account emails are case-sensitive (auth_service), so victim@ and VICTIM@ are
@@ -324,7 +327,7 @@ async def test_accept_invitation_case_variant_account_rejected(client):
 
 
 @pytest.mark.asyncio
-async def test_cannot_invite_as_owner(client):
+async def test_cannot_invite_as_owner(client: AsyncClient) -> None:
 	"""Ownership is not grantable via invitation (schema rejects role=owner)."""
 	owner_headers = await register_and_login(client)
 	create_resp = await client.post("/teams", headers=owner_headers, json={"name": "No Owner Invite"})
@@ -339,7 +342,10 @@ async def test_cannot_invite_as_owner(client):
 
 
 @pytest.mark.asyncio
-async def test_legacy_owner_invitation_rejected_on_accept(client, test_db):
+async def test_legacy_owner_invitation_rejected_on_accept(
+	client: AsyncClient,
+	test_db: AsyncSession,
+) -> None:
 	"""A pre-existing owner invitation (issued before role restriction) cannot
 	be accepted — the role guard is enforced at acceptance, not just creation."""
 	from datetime import datetime, timedelta
@@ -382,7 +388,7 @@ async def test_legacy_owner_invitation_rejected_on_accept(client, test_db):
 # One case per route. Parametrized (not looped in a single test) because the
 # test-db fixture rolls its savepoint back on the first permission-denied
 # response, which would erase the registered users for any later request.
-NON_MEMBER_ROUTES = [
+NON_MEMBER_ROUTES: list[tuple[str, str, dict[str, str] | None]] = [
 	("get", "/teams/{team_id}", None),
 	("patch", "/teams/{team_id}", {"name": "Hijack"}),
 	("delete", "/teams/{team_id}", None),
@@ -396,7 +402,12 @@ NON_MEMBER_ROUTES = [
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("method,url_tmpl,body", NON_MEMBER_ROUTES)
-async def test_non_member_blocked_on_team_route(client, method, url_tmpl, body):
+async def test_non_member_blocked_on_team_route(
+	client: AsyncClient,
+	method: str,
+	url_tmpl: str,
+	body: dict[str, str] | None,
+) -> None:
 	"""A non-member receives 403 on every membership-scoped team route (#218)."""
 	owner_headers = await register_and_login(client)
 	stranger_headers = await register_and_login(client)

--- a/apps/api/tests/test_teams.py
+++ b/apps/api/tests/test_teams.py
@@ -273,6 +273,145 @@ async def test_invalid_invitation_token_returns_404(client):
 	assert response.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_accept_invitation_wrong_email_rejected(client):
+	"""A user whose email differs from the invited email cannot accept (403)."""
+	owner_headers = await register_and_login(client)
+	invited_email = f"invited_{uuid4()}@example.com"
+	# A different user (different email) tries to accept the token.
+	stranger_headers = await register_and_login(client)
+
+	create_resp = await client.post("/teams", headers=owner_headers, json={"name": "Bound Invite"})
+	team_id = create_resp.json()["id"]
+
+	inv_resp = await client.post(
+		f"/teams/{team_id}/invitations",
+		headers=owner_headers,
+		json={"email": invited_email, "role": "viewer"},
+	)
+	token = inv_resp.json()["token"]
+
+	resp = await client.post(f"/teams/invitations/{token}/accept", headers=stranger_headers)
+	assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_accept_invitation_case_variant_account_rejected(client):
+	"""A case-variant account cannot accept a token addressed to another email.
+
+	Account emails are case-sensitive (auth_service), so victim@ and VICTIM@ are
+	distinct accounts. The email binding must reject the variant (403), otherwise
+	an attacker could register a case-variant and accept a leaked token.
+	"""
+	owner_headers = await register_and_login(client)
+	local = f"casevariant_{uuid4().hex}"
+	invited_email = f"{local}@example.com"
+	# Attacker registers the upper-cased variant — a different account.
+	attacker_headers = await register_and_login(client, invited_email.upper())
+
+	create_resp = await client.post("/teams", headers=owner_headers, json={"name": "Case Invite"})
+	team_id = create_resp.json()["id"]
+
+	inv_resp = await client.post(
+		f"/teams/{team_id}/invitations",
+		headers=owner_headers,
+		json={"email": invited_email, "role": "viewer"},
+	)
+	token = inv_resp.json()["token"]
+
+	resp = await client.post(f"/teams/invitations/{token}/accept", headers=attacker_headers)
+	assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_cannot_invite_as_owner(client):
+	"""Ownership is not grantable via invitation (schema rejects role=owner)."""
+	owner_headers = await register_and_login(client)
+	create_resp = await client.post("/teams", headers=owner_headers, json={"name": "No Owner Invite"})
+	team_id = create_resp.json()["id"]
+
+	resp = await client.post(
+		f"/teams/{team_id}/invitations",
+		headers=owner_headers,
+		json={"email": f"co_{uuid4()}@example.com", "role": "owner"},
+	)
+	assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_legacy_owner_invitation_rejected_on_accept(client, test_db):
+	"""A pre-existing owner invitation (issued before role restriction) cannot
+	be accepted — the role guard is enforced at acceptance, not just creation."""
+	from datetime import datetime, timedelta
+	import secrets
+	from uuid import UUID
+	from src.models.team_invitation import TeamInvitation
+
+	owner_headers = await register_and_login(client)
+	invitee_email = f"legacy_{uuid4()}@example.com"
+	invitee_headers = await register_and_login(client, invitee_email)
+
+	create_resp = await client.post("/teams", headers=owner_headers, json={"name": "Legacy Owner"})
+	team_id = create_resp.json()["id"]
+	members = await client.get(f"/teams/{team_id}/members", headers=owner_headers)
+	inviter_id = members.json()[0]["user_id"]
+
+	# Insert directly to bypass schema validation, simulating a token created
+	# before `owner` was removed from invitable roles.
+	token = secrets.token_urlsafe(32)
+	test_db.add(TeamInvitation(
+		team_id=UUID(team_id),
+		inviter_id=UUID(inviter_id),
+		email=invitee_email,
+		role="owner",
+		token=token,
+		status="pending",
+		expires_at=datetime.utcnow() + timedelta(days=7),
+	))
+	await test_db.flush()
+
+	resp = await client.post(f"/teams/invitations/{token}/accept", headers=invitee_headers)
+	assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Non-member access is rejected on every team route (regression for #218)
+# ---------------------------------------------------------------------------
+
+
+# One case per route. Parametrized (not looped in a single test) because the
+# test-db fixture rolls its savepoint back on the first permission-denied
+# response, which would erase the registered users for any later request.
+NON_MEMBER_ROUTES = [
+	("get", "/teams/{team_id}", None),
+	("patch", "/teams/{team_id}", {"name": "Hijack"}),
+	("delete", "/teams/{team_id}", None),
+	("get", "/teams/{team_id}/members", None),
+	("patch", "/teams/{team_id}/members/{other_user}", {"role": "editor"}),
+	("delete", "/teams/{team_id}/members/{other_user}", None),
+	("post", "/teams/{team_id}/invitations", {"email": "outsider@example.com", "role": "viewer"}),
+	("get", "/teams/{team_id}/invitations", None),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method,url_tmpl,body", NON_MEMBER_ROUTES)
+async def test_non_member_blocked_on_team_route(client, method, url_tmpl, body):
+	"""A non-member receives 403 on every membership-scoped team route (#218)."""
+	owner_headers = await register_and_login(client)
+	stranger_headers = await register_and_login(client)
+
+	create_resp = await client.post("/teams", headers=owner_headers, json={"name": "Locked Down"})
+	team_id = create_resp.json()["id"]
+
+	url = url_tmpl.format(team_id=team_id, other_user=uuid4())
+	kwargs = {"headers": stranger_headers}
+	if body is not None:
+		kwargs["json"] = body
+	resp = await getattr(client, method)(url, **kwargs)
+	assert resp.status_code == 403, f"{method.upper()} {url} -> {resp.status_code}"
+
+
 # ---------------------------------------------------------------------------
 # Member management
 # ---------------------------------------------------------------------------

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,40 +1,28 @@
-# Issue #216 — Stripe webhook signature bypass (security, apps/api)
+# Issue #218 — Team authz: email-bound invitations + RLS backstop docs
 
-Plan source: self-authored (no plan comment). Branch: `fix/216-stripe-webhook-signature`
+**Title:** [P4.4] fix(api): invitation acceptance not bound to invited email; team tables lack RLS backstop
+**Plan source:** self-authored (issue body had acceptance criteria, no step plan)
 
-## Vulnerability
-`billing_service.process_webhook` falls back to `json.loads(payload)` and processes
-events **unsigned** when `webhook_secret`/`sig_header` are absent. Latent today only
-because `STRIPE_SECRET_KEY` isn't a Settings field (`extra="ignore"` drops it →
-`_stripe_enabled()` always False → early return). Becomes live the moment billing is
-enabled.
+## Findings (codebase audit)
+- `team_service.accept_invitation` (team_service.py:201) creates a `TeamMember` with `invitation.role` and **never checks** the accepting user's email against `invitation.email`. A forwarded/leaked token = anyone joins.
+- Every existing team route operating on a team **already** calls `rbac_service.assert_permission` — the mandatory helper already exists. Gap is regression-test coverage, not missing code.
+- Team tables (`teams`, `team_members`, `team_invitations`) have **no `tenant_id`** column → per-tenant RLS is inherently inapplicable; isolation relies on RBAC. Needs to be documented as intentional.
+- Invitation `role` schema currently allows `owner`; a forwardable owner-invite token is an escalation vector.
 
-## Fix 1 — Settings fields (`config.py`, spaces indent)
-- Add `STRIPE_SECRET_KEY: Optional[str] = None` and `STRIPE_WEBHOOK_SECRET: Optional[str] = None`.
-- Makes them real, validated Settings (no longer silently dropped). Satisfies AC1.
+## Steps
+1. **AC1 — Email-bind acceptance.** `accept_invitation(db, token, user_id, user_email)`: reject with **403** when `invitation.email.lower() != user_email.lower()`. Router passes `current_user.email`.
+2. **AC2 — Restrict invitation roles.** `InvitationCreate.role` pattern → `^(editor|viewer|analyst)$` (drop `owner`). Native Pydantic 422. Co-owner promotion stays on `update_member_role` (owner-only, non-forwardable).
+3. **AC3 — Membership guard + regression tests.** Helper already present on every route; add non-member→403 regression tests for the mutating/read routes. No redundant helper added (would be dead abstraction).
+4. **AC4 — Document RLS exclusion.** Security note in `team_service.py` module docstring + pointer comment in migration 009 explaining team tables are intentionally not RLS-scoped (no tenant_id; RBAC-enforced).
+5. **Tests (TDD):** wrong-email→403, case-insensitive match→201, owner-role invite→422, non-member→403 across routes.
 
-## Fix 2 — Enforce signature (`billing_service.process_webhook`, tabs indent)
-- Keep the `_stripe_enabled()` early-return (`ignored` when billing off) — existing
-  behavior/tests rely on it.
-- When enabled: **remove the `json.loads` unsigned fallback entirely.**
-  - `webhook_secret` or `sig_header` missing → raise `HTTPException(400)` (per AC2).
-  - else `construct_event(...)`; on `SignatureVerificationError` → 400 (already present).
-- Net: no code path ever parses an unsigned/unverified payload.
-
-## Fix 3 — Tests (`tests/unit/test_billing_unit.py` + `tests/test_billing.py`, tabs)
-- enabled + secret set + **missing** sig_header → 400 (AC3).
-- enabled + secret set + **invalid** signature (mock `construct_event` raises
-  `SignatureVerificationError`) → 400 (AC3).
-- enabled + secret set + valid signature → processed.
-- Settings exposes `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` (AC1).
-- Existing webhook tests (stripe disabled → 200 ignored) remain green.
-
-## Notes / decisions
-- AC says "Reject with 400 when secret/sig_header missing." A missing server-side
-  `webhook_secret` is arguably a 500 (misconfig), but I follow the AC literally → 400
-  for both missing cases. Logged distinctly for ops.
-- Scope is small (security hardening) → single agent, TDD.
-
-## Verification
-- `uv run pytest tests/test_billing.py tests/unit/test_billing_unit.py`
-- Cross-family review (CodeRabbit), demo (Phase 11), CI gate (Phase 12), PR → merge.
+## Acceptance criteria
+- [x] Email match required before membership; reject otherwise. (Implemented as
+      **exact** match, not case-folded — account emails are case-sensitive, so
+      case-insensitive matching would let a case-variant account accept a leaked
+      token. Follow-up issue: app-wide email canonicalization.)
+- [x] Invitation roles restricted (owner not grantable via invitation; enforced
+      at creation **and** acceptance for legacy tokens).
+- [x] Membership/permission helper on every team route + regression tests
+      (non-member → 403 across all routes; helper already present per-route).
+- [x] Team tables documented as intentionally not RLS-scoped.


### PR DESCRIPTION
Closes #218.

## Problem
Team authz relied entirely on RBAC. Two concrete gaps:
1. `accept_invitation` created a membership from a token **without verifying the accepting user's email** against the invitation — a forwarded/leaked token let anyone join with the invited role.
2. Invitation roles allowed `owner`; a forwardable owner-invite token is a privilege-escalation vector.
3. Team tables are not RLS-scoped, and that was undocumented (a future missed permission check = silent cross-account access).

## Changes
- **Email-bound acceptance** (`team_service.accept_invitation`): rejects with **403** when the accepting user's email does not match the invitation email. The router now passes `current_user.email`.
- **Role restriction** (`schemas/team.py` + `team_service`): `owner` is no longer invitable. Enforced at **creation** (Pydantic → 422) **and at acceptance** (legacy/pre-deploy `owner` tokens → 403), so tokens issued before this change can't still grant ownership. Co-owner promotion remains on the owner-only `PATCH /teams/{id}/members/{user}` route, which is not forwardable.
- **RLS documentation** (`team_service` module docstring + migration 009): team tables (`teams`, `team_members`, `team_invitations`) have no `tenant_id` and are intentionally not RLS-scoped; isolation is enforced via RBAC (`assert_permission`), which every team route already calls.
- **Regression tests**: wrong-email → 403, case-variant account → 403, owner-invite → 422, legacy owner token → 403, and non-member → 403 across **every** membership-scoped team route.

## Acceptance criteria
- [x] Email match required before membership; reject otherwise.
- [x] Invitation roles restricted (owner not grantable via invitation).
- [x] Mandatory membership/permission helper on every team route + regression tests (non-member → 403).
- [x] Team tables documented as intentionally not RLS-scoped.

## Note — deviation from the literal "case-insensitive" wording (intentional)
The issue asked for a *case-insensitive* email match. Implemented as an **exact** match instead, because account emails are stored and looked up **case-sensitively** in `auth_service` (`victim@x.com` and `Victim@x.com` can be distinct accounts). A case-insensitive match here would let an attacker register a case-variant of the invited email and accept a leaked token — defeating the fix (flagged in cross-family review). Exact match is consistent with the app's current identity model and an attacker cannot register the victim's *exact* (already-taken) email.

The "proper" way to get safe case-insensitivity is app-wide email canonicalization (normalize at registration/login, enforce canonical uniqueness), which touches auth identity + needs a data migration — out of scope for this team-authz fix. Follow-up issue: #255.

## Known limitations
- Exact (not case-folded) email match, per the note above. Legitimate invitations must use the same email casing the recipient registered with — consistent with the existing case-sensitive login.
- App-wide email canonicalization tracked as a follow-up (#255).

## Testing
- `apps/api`: `tests/test_teams.py` — 29 passed (PostgreSQL 16, migrations applied).
- `ruff` clean on changed files.
- Full backend suite: 1469 passed, 1 pre-existing unrelated failure (`test_audio_snippets.py::test_download_url_no_s3_config`, S3-config dependent — fails identically on `main`, not touched by this PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Team invitations are now email-bound—users can only accept invitations sent to their specific email address.

* **Security Improvements**
  * Owner role can no longer be assigned through invitations; only editor, viewer, and analyst roles are invitable.
  * Added validation to reject invitations when the accepting user's email doesn't match the invitation's target email.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->