### PR TITLE
fix(api): expires_in computed from JWT_ACCESS_TOKEN_EXPIRE_MINUTES (#219)

### DIFF
--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -95,7 +95,7 @@ async def register(
         return TokenResponse(
             access_token=access_token,
             token_type="bearer",
-            expires_in=86400,  # 24 hours in seconds
+            expires_in=settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES * 60,
             user=UserResponse.model_validate(user)
         )
 
@@ -159,7 +159,7 @@ async def login(
     return TokenResponse(
         access_token=access_token,
         token_type="bearer",
-        expires_in=86400,  # 24 hours in seconds
+        expires_in=settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES * 60,
         user=UserResponse.model_validate(user)
     )
 

--- a/apps/api/src/schemas/auth.py
+++ b/apps/api/src/schemas/auth.py
@@ -81,7 +81,7 @@ class TokenResponse(BaseModel):
         "example": {
             "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
             "token_type": "bearer",
-            "expires_in": 86400,
+            "expires_in": 1800,
             "user": {
                 "id": "123e4567-e89b-12d3-a456-426614174000",
                 "email": "user@example.com",

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -195,11 +195,11 @@ async def test_register_success(client: AsyncClient):
     assert "user" in data
 
     # Verify token properties
+    from src.config import settings as _settings
     assert data["token_type"] == "bearer"
-    assert data["expires_in"] == 86400
+    assert data["expires_in"] == _settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES * 60
 
     # Verify user data
-    from src.config import settings as _settings
     user = data["user"]
     assert user["email"] == "newuser@example.com"
     assert user["full_name"] == "New User"
@@ -387,6 +387,9 @@ async def test_login_success(client: AsyncClient, test_db: AsyncSession):
     assert "token_type" in data
     assert "expires_in" in data
     assert "user" in data
+
+    from src.config import settings as _settings
+    assert data["expires_in"] == _settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES * 60
 
     # Verify user data matches registered user
     user = data["user"]


### PR DESCRIPTION
## Summary
`POST /auth/register` and `POST /auth/login` returned `expires_in=86400` (24h) while the issued JWT actually expires after `JWT_ACCESS_TOKEN_EXPIRE_MINUTES` (default 30m = 1800s). Clients trusting `expires_in` for refresh scheduling got silent 401s ~29.5 min after the advertised lifetime.

Fixes #219.

## Changes
- `apps/api/src/routers/auth.py` — both endpoints now return `expires_in=settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES * 60` (matches the value used to mint the token).
- `apps/api/src/schemas/auth.py` — corrected the stale OpenAPI example (`86400` → `1800`).
- `apps/api/tests/test_auth.py` — register/login tests now assert `expires_in == JWT_ACCESS_TOKEN_EXPIRE_MINUTES * 60` (previously asserted the buggy `86400`).

## Acceptance criteria
- [x] `expires_in = settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES * 60`

## Testing
- RED verified: old code fails the updated assertion (`assert 86400 == (30 * 60)`).
- GREEN: `pytest tests/test_auth.py` — 54 passed.
- `ruff check` clean.

## Known limitations
- `expires_in` reflects access-token lifetime only; there is no refresh-token endpoint, so clients must re-authenticate at expiry (unchanged by this PR).