### PR TITLE
fix(web): add server-side route protection middleware for the (auth) route group

### DIFF
--- a/apps/web/__tests__/middleware.test.ts
+++ b/apps/web/__tests__/middleware.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for server-side route protection (issue #222).
+ *
+ * Runs in the node environment: NextRequest needs the global Request/Response
+ * Web primitives, which jsdom does not provide.
+ *
+ * The middleware must redirect unauthenticated requests to /login *before* any
+ * protected page renders, instead of relying solely on the client-side redirect.
+ */
+import { NextRequest } from 'next/server'
+import { getToken } from 'next-auth/jwt'
+
+jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }))
+
+// withAuth reads the secret from the environment at call time.
+process.env.NEXTAUTH_SECRET = 'test-secret'
+
+// Imported after the mock so withAuth captures the mocked getToken.
+import middleware from '@/middleware'
+
+const mockGetToken = getToken as jest.Mock
+
+function callMiddleware(path: string) {
+  const req = new NextRequest(new URL(`http://localhost${path}`))
+  // withAuth ignores the NextFetchEvent for redirect decisions.
+  return middleware(req as never, {} as never)
+}
+
+afterEach(() => mockGetToken.mockReset())
+
+describe('route protection middleware', () => {
+  it('redirects unauthenticated access to /login before render', async () => {
+    mockGetToken.mockResolvedValue(null)
+
+    const res = await callMiddleware('/dashboard')
+
+    expect(res?.status).toBe(307)
+    const location = res?.headers.get('location') ?? ''
+    expect(location).toContain('/login')
+    // Preserves where the user was headed so they land back after signing in.
+    expect(location).toContain('callbackUrl')
+  })
+
+  it('lets authenticated requests through', async () => {
+    mockGetToken.mockResolvedValue({ userId: 'u1', tenantId: 't1' })
+
+    const res = await callMiddleware('/dashboard')
+
+    // withAuth returns undefined (or a pass-through NextResponse.next()) when the
+    // session is valid — never a redirect to /login.
+    expect(res?.status).not.toBe(307)
+    expect(res?.headers.get('location') ?? '').not.toContain('/login')
+  })
+})

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,24 @@
+/**
+ * Server-side route protection for the (auth) route group (issue #222).
+ *
+ * Previously the (auth) pages were gated only client-side (a post-hydration
+ * useEffect redirect), so protected page bundles were served to unauthenticated
+ * users and the gate could be bypassed by disabling JS or racing the redirect.
+ *
+ * next-auth's withAuth runs in middleware before the page renders: it reads the
+ * session JWT (httpOnly cookie) via NEXTAUTH_SECRET and redirects requests
+ * without a valid session to /login. The client-side redirect stays as a
+ * secondary, defense-in-depth guard. Data is also protected by backend authz.
+ */
+import { withAuth } from 'next-auth/middleware'
+
+// Default authorized check is `!!token`; we only override the sign-in page so
+// redirects land on our /login route instead of next-auth's built-in page.
+export default withAuth({
+  pages: { signIn: '/login' },
+})
+
+export const config = {
+  // Route group "(auth)" is not part of the URL, so match the actual paths.
+  matcher: ['/dashboard/:path*', '/episodes/:path*', '/projects/:path*'],
+}


### PR DESCRIPTION
## Summary

Closes #222. Adds the missing server-side route protection for the `(auth)` route group.

Previously the protected pages (`/dashboard`, `/episodes/*`, `/projects/*`) were gated **only** client-side via a post-hydration `useEffect` redirect, so:
- protected page bundles were served to unauthenticated users, and
- the gate was bypassable by disabling JS or racing the redirect.

(Data was still protected by backend authz, so this is defense-in-depth.)

## Changes

- **`apps/web/src/middleware.ts`** (new) — `next-auth` `withAuth` middleware that checks the session JWT (via `NEXTAUTH_SECRET`) in middleware *before* the page renders and redirects requests without a valid session to `/login` (with `callbackUrl`). Matcher covers `/dashboard/:path*`, `/episodes/:path*`, `/projects/:path*`. The existing client-side redirect stays as a secondary guard.
- **`apps/web/__tests__/middleware.test.ts`** (new) — asserts unauthenticated access redirects (307) to `/login` before render, and authenticated requests pass through.

## Testing

- `npx jest __tests__/middleware.test.ts` — 2 passed
- Full web suite: 256 passed / 36 suites
- `next lint` on `src/middleware.ts` — clean

## Known limitations

- Uses next-auth's default `authorized` check (`!!token`) — any authenticated user may access the `(auth)` group; per-route role/tenant authorization is unchanged (still enforced by the backend API).
- Pre-existing `tsc` errors in unrelated files (`projects/[id]/page.tsx`, `ThemeToggle.tsx`, `progress.tsx`, `validation.ts`) are not touched by this PR.