### PR TITLE
fix(auth): canonicalize emails app-wide (case-insensitive identity) (#255)

### DIFF
--- a/apps/api/alembic/versions/012_canonicalize_user_emails.py
+++ b/apps/api/alembic/versions/012_canonicalize_user_emails.py
@@ -1,0 +1,54 @@
+"""Canonicalize user emails to lowercase (case-insensitive identity)
+
+Revision ID: 012
+Revises: 011
+Create Date: 2026-06-20 00:00:00.000000
+
+Makes email case never identity-significant (#255):
+- Aborts if case-variant duplicate accounts already exist (manual dedupe
+  required — auto-merging would destroy account data).
+- Lowercases all existing emails.
+- Adds a functional unique index on lower(email) to enforce canonical uniqueness.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers
+revision: str = "012"
+down_revision: Union[str, None] = "011"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+	bind = op.get_bind()
+
+	# Abort loudly on case-variant collisions — merging accounts is not safe to
+	# automate (it would orphan owned resources / drop credentials). Operator
+	# must dedupe manually before this migration can proceed.
+	collisions = bind.execute(
+		sa.text(
+			"SELECT lower(email) AS canonical, count(*) AS n "
+			"FROM users GROUP BY lower(email) HAVING count(*) > 1"
+		)
+	).fetchall()
+	if collisions:
+		offenders = ", ".join(f"{row.canonical} (x{row.n})" for row in collisions)
+		raise RuntimeError(
+			"Cannot canonicalize user emails: case-variant duplicate accounts "
+			f"exist and must be merged/removed manually first: {offenders}"
+		)
+
+	op.execute("UPDATE users SET email = lower(email) WHERE email <> lower(email)")
+	op.create_index(
+		"uq_users_email_lower",
+		"users",
+		[sa.text("lower(email)")],
+		unique=True,
+	)
+
+
+def downgrade() -> None:
+	op.drop_index("uq_users_email_lower", table_name="users")

--- a/apps/api/src/services/auth_service.py
+++ b/apps/api/src/services/auth_service.py
@@ -6,7 +6,7 @@ from uuid import UUID, uuid4
 import bcrypt
 from jose import jwt, JWTError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, text
+from sqlalchemy import select, text, func
 from sqlalchemy.exc import IntegrityError
 from fastapi import HTTPException
 
@@ -237,7 +237,11 @@ async def get_user_by_email(session: AsyncSession, email: str) -> Optional["User
     Returns:
         User instance or None if not found
     """
-    result = await session.execute(select(User).where(User.email == email))
+    # Case-insensitive lookup: email is not identity-significant by case (#255).
+    # func.lower(...) also matches legacy mixed-case rows from before canonicalization.
+    result = await session.execute(
+        select(User).where(func.lower(User.email) == email.lower())
+    )
     return result.scalar_one_or_none()
 
 
@@ -269,6 +273,9 @@ async def create_user(
     try:
         # Generate unique tenant_id for new user (each user is their own tenant)
         tenant_id = uuid4()
+
+        # Canonicalize email to lowercase so case is never identity-significant (#255).
+        email = email.lower()
 
         # Create user with hashed password
         user = User(
@@ -319,9 +326,9 @@ async def authenticate_user(
     Returns:
         User model instance if valid credentials, None otherwise
     """
-    # Query user by email
+    # Query user by email (case-insensitive — case is not identity-significant, #255)
     result = await session.execute(
-        select(User).where(User.email == email)
+        select(User).where(func.lower(User.email) == email.lower())
     )
     user = result.scalar_one_or_none()
 

--- a/apps/api/src/services/team_service.py
+++ b/apps/api/src/services/team_service.py
@@ -221,13 +221,11 @@ async def accept_invitation(
 ) -> TeamMember:
 	"""Accept an invitation token and create a TeamMember record.
 
-	The accepting user's email must match the invited email exactly, otherwise a
-	forwarded/leaked token would let any user join. The match is exact (not
-	case-folded) because account emails are stored and looked up case-sensitively
-	(see auth_service): `victim@x.com` and `Victim@x.com` can be distinct
-	accounts, so a case-insensitive match here would let a case-variant account
-	accept a token addressed to another. Membership is created with the
-	invitation's role.
+	The accepting user's email must match the invited email, otherwise a
+	forwarded/leaked token would let any user join. The match is case-insensitive:
+	account emails are now canonicalized to lowercase at rest (#255), so case is
+	never identity-significant and a case-variant cannot be a distinct account.
+	Membership is created with the invitation's role.
 	"""
 	result = await db.execute(
 		select(TeamInvitation).where(TeamInvitation.token == token)
@@ -235,7 +233,7 @@ async def accept_invitation(
 	invitation = result.scalar_one_or_none()
 	if invitation is None:
 		raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invitation not found")
-	if invitation.email != user_email:
+	if invitation.email.lower() != user_email.lower():
 		raise HTTPException(
 			status_code=status.HTTP_403_FORBIDDEN,
 			detail="This invitation was sent to a different email address",

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -231,6 +231,63 @@ async def test_register_duplicate_email(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_register_canonicalizes_email_to_lowercase(client: AsyncClient):
+    """Email is stored lowercase at rest so case is never identity-significant (#255)."""
+    response = await client.post("/auth/register", json={
+        "email": "MixedCase@Example.COM",
+        "password": "SecurePass123!",
+        "full_name": "Mixed Case",
+    })
+    assert response.status_code == 201, response.text
+    assert response.json()["user"]["email"] == "mixedcase@example.com"
+
+
+@pytest.mark.asyncio
+async def test_register_case_variant_duplicate_rejected(client: AsyncClient):
+    """A case-variant of an existing email cannot create a second account (#255)."""
+    user_data = {
+        "email": "canon@example.com",
+        "password": "SecurePass123!",
+        "full_name": "First User",
+    }
+    response1 = await client.post("/auth/register", json=user_data)
+    assert response1.status_code == 201
+
+    response2 = await client.post("/auth/register", json={**user_data, "email": "Canon@Example.com"})
+    assert response2.status_code == 400
+    assert "already registered" in response2.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_login_is_case_insensitive(client: AsyncClient, test_db: AsyncSession):
+    """A user can log in regardless of the email case they type (#255)."""
+    from sqlalchemy import update, text
+
+    reg_resp = await client.post("/auth/register", json={
+        "email": "logincase@example.com",
+        "password": "SecurePass123!",
+        "full_name": "Login Case",
+    })
+    assert reg_resp.status_code == 201, reg_resp.text
+    user_id = reg_resp.json()["user"]["id"]
+    tenant_id = reg_resp.json()["user"]["tenant_id"]
+
+    # Verify the user so login is allowed
+    await test_db.execute(text(f"SET LOCAL app.tenant_id = '{tenant_id}'"))
+    await test_db.execute(
+        update(User).where(User.id == UUID(user_id)).values(is_verified=True)
+    )
+    await test_db.commit()
+
+    response = await client.post("/auth/login", json={
+        "email": "LOGINCASE@EXAMPLE.COM",
+        "password": "SecurePass123!",
+    })
+    assert response.status_code == 200, response.text
+    assert "access_token" in response.json()
+
+
+@pytest.mark.asyncio
 async def test_register_invalid_email(client: AsyncClient):
     """Test registration with invalid email format"""
     response = await client.post(

--- a/apps/api/tests/test_teams.py
+++ b/apps/api/tests/test_teams.py
@@ -299,18 +299,18 @@ async def test_accept_invitation_wrong_email_rejected(client: AsyncClient) -> No
 
 
 @pytest.mark.asyncio
-async def test_accept_invitation_case_variant_account_rejected(client: AsyncClient) -> None:
-	"""A case-variant account cannot accept a token addressed to another email.
+async def test_accept_invitation_case_insensitive_match(client: AsyncClient) -> None:
+	"""Invitation acceptance matches case-insensitively once identity is canonical (#255).
 
-	Account emails are case-sensitive (auth_service), so victim@ and VICTIM@ are
-	distinct accounts. The email binding must reject the variant (403), otherwise
-	an attacker could register a case-variant and accept a leaked token.
+	Account emails are canonicalized to lowercase at registration, so a user who
+	registers a case-variant of the invited email IS the same canonical account
+	and must be able to accept the token.
 	"""
 	owner_headers = await register_and_login(client)
 	local = f"casevariant_{uuid4().hex}"
 	invited_email = f"{local}@example.com"
-	# Attacker registers the upper-cased variant — a different account.
-	attacker_headers = await register_and_login(client, invited_email.upper())
+	# The invitee registers using an upper-cased variant — same canonical account.
+	invitee_headers = await register_and_login(client, invited_email.upper())
 
 	create_resp = await client.post("/teams", headers=owner_headers, json={"name": "Case Invite"})
 	team_id = create_resp.json()["id"]
@@ -322,8 +322,8 @@ async def test_accept_invitation_case_variant_account_rejected(client: AsyncClie
 	)
 	token = inv_resp.json()["token"]
 
-	resp = await client.post(f"/teams/invitations/{token}/accept", headers=attacker_headers)
-	assert resp.status_code == 403
+	resp = await client.post(f"/teams/invitations/{token}/accept", headers=invitee_headers)
+	assert resp.status_code == 201, resp.text
 
 
 @pytest.mark.asyncio

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,28 +1,35 @@
-# Issue #218 — Team authz: email-bound invitations + RLS backstop docs
+# Issue #255 — Canonicalize emails app-wide (case-insensitive identity)
 
-**Title:** [P4.4] fix(api): invitation acceptance not bound to invited email; team tables lack RLS backstop
-**Plan source:** self-authored (issue body had acceptance criteria, no step plan)
+Follow-up to #218/#254. Make email case never identity-significant.
 
-## Findings (codebase audit)
-- `team_service.accept_invitation` (team_service.py:201) creates a `TeamMember` with `invitation.role` and **never checks** the accepting user's email against `invitation.email`. A forwarded/leaked token = anyone joins.
-- Every existing team route operating on a team **already** calls `rbac_service.assert_permission` — the mandatory helper already exists. Gap is regression-test coverage, not missing code.
-- Team tables (`teams`, `team_members`, `team_invitations`) have **no `tenant_id`** column → per-tenant RLS is inherently inapplicable; isolation relies on RBAC. Needs to be documented as intentional.
-- Invitation `role` schema currently allows `owner`; a forwardable owner-invite token is an escalation vector.
+## Plan (adapted to apps/api)
 
-## Steps
-1. **AC1 — Email-bind acceptance.** `accept_invitation(db, token, user_id, user_email)`: reject with **403** when `invitation.email.lower() != user_email.lower()`. Router passes `current_user.email`.
-2. **AC2 — Restrict invitation roles.** `InvitationCreate.role` pattern → `^(editor|viewer|analyst)$` (drop `owner`). Native Pydantic 422. Co-owner promotion stays on `update_member_role` (owner-only, non-forwardable).
-3. **AC3 — Membership guard + regression tests.** Helper already present on every route; add non-member→403 regression tests for the mutating/read routes. No redundant helper added (would be dead abstraction).
-4. **AC4 — Document RLS exclusion.** Security note in `team_service.py` module docstring + pointer comment in migration 009 explaining team tables are intentionally not RLS-scoped (no tenant_id; RBAC-enforced).
-5. **Tests (TDD):** wrong-email→403, case-insensitive match→201, owner-role invite→422, non-member→403 across routes.
+### 1. Service layer — `src/services/auth_service.py`
+- `create_user`: lowercase `email` before constructing `User` (single normalization point).
+- `get_user_by_email`: match with `func.lower(User.email) == email.lower()`.
+- `authenticate_user`: same case-insensitive lookup.
+
+### 2. Invitation match — `src/services/team_service.py`
+- `accept_invitation`: relax exact match to case-insensitive
+  (`invitation.email.lower() != user_email.lower()`). Update the docstring
+  that documented the #218 case-sensitive workaround.
+
+### 3. Migration — `alembic/versions/012_canonicalize_user_emails.py` (down_revision `011`)
+- Detect case-variant duplicate `lower(email)` groups; **abort with a clear
+  error** if collisions exist (data loss is not auto-resolvable safely).
+- `UPDATE users SET email = lower(email)` for mixed-case rows.
+- Add functional unique index `uq_users_email_lower` on `lower(email)`.
+- downgrade: drop the index.
+
+### 4. Tests
+- `tests/test_auth.py`: email stored lowercase at register; duplicate
+  case-variant register rejected (400); login is case-insensitive.
+- `tests/test_teams.py`: repurpose `test_accept_invitation_case_variant_account_rejected`
+  — a case-variant registration is now the SAME canonical account, so accept
+  SUCCEEDS; add a case-insensitive invite-accept positive test. Keep
+  `test_accept_invitation_wrong_email_rejected` (genuinely different email → 403).
 
 ## Acceptance criteria
-- [x] Email match required before membership; reject otherwise. (Implemented as
-      **exact** match, not case-folded — account emails are case-sensitive, so
-      case-insensitive matching would let a case-variant account accept a leaked
-      token. Follow-up issue: app-wide email canonicalization.)
-- [x] Invitation roles restricted (owner not grantable via invitation; enforced
-      at creation **and** acceptance for legacy tokens).
-- [x] Membership/permission helper on every team route + regression tests
-      (non-member → 403 across all routes; helper already present per-route).
-- [x] Team tables documented as intentionally not RLS-scoped.
+- [ ] Emails canonical (lowercase) at rest; case-variant accounts cannot be created.
+- [ ] Login works case-insensitively for existing and new users.
+- [ ] Invitation acceptance matches case-insensitively once identity is canonical.


### PR DESCRIPTION
## Summary
Closes #255. Follow-up to #218/#254. Makes email case never identity-significant, so `victim@x.com` and `Victim@x.com` can no longer be distinct accounts.

## Changes
- **`auth_service.create_user`** — lowercases email at registration (single normalization point).
- **`auth_service.get_user_by_email` / `authenticate_user`** — case-insensitive lookup via `func.lower(User.email)`, which also matches any legacy mixed-case rows.
- **`team_service.accept_invitation`** — relaxes the #218 exact-match workaround to a case-insensitive comparison now that identity is canonical.
- **Migration `012`** — aborts loudly if case-variant duplicate accounts already exist (manual dedupe required — auto-merging would orphan owned resources); lowercases existing rows; adds functional unique index `uq_users_email_lower` on `lower(email)`.

## Acceptance criteria
- [x] Emails canonical (lowercase) at rest; case-variant accounts cannot be created.
- [x] Login works case-insensitively for existing and new users.
- [x] Invitation acceptance matches case-insensitively once identity is canonical.

## Testing
- New: register stores lowercase; case-variant duplicate register → 400; login case-insensitive; invitation accept matches case-insensitively.
- Repurposed `test_accept_invitation_case_variant_account_rejected` → `test_accept_invitation_case_insensitive_match` (a case-variant registration is now the *same* canonical account, so accept succeeds).
- Full `test_auth.py` + `test_teams.py` suite: **86 passed** locally against Postgres 16 with migration 012 applied.
- Verified migration's collision-abort path fires and the post-dedupe upgrade succeeds.

## Known limitations
- Invitation `email` rows are stored as submitted; the accept comparison is case-folded on both sides, so this is cosmetic only.
- Migration intentionally does **not** auto-merge collisions; operators with case-variant dupes must resolve them before upgrading (error names the offending addresses).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- **Case-insensitive login**: Users can now authenticate using their email address in any combination of uppercase or lowercase letters
- **Email normalization**: All email addresses are automatically stored in lowercase for consistent identity management and account matching
- **Case-variant consolidation**: Email addresses differing only in case are now treated as the same account

<!-- end of auto-generated comment: release notes by coderabbit.ai -->