### PR TITLE
fix(ci): fail-fast dev deploy + validate API port before teardown

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -180,15 +180,20 @@ jobs:
             find . -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true
             find . -type f -name '*.pyc' -delete 2>/dev/null || true
 
-            # Port must match the nginx upstream (deployment/nginx/podcastfy.conf:8001).
-            # Guard against a stray API_PORT reintroducing the 8000/8001 drift.
-            # Validated BEFORE tearing down the running service so a bad port never
-            # leaves the API deleted-but-not-restarted.
-            API_EFFECTIVE_PORT="${API_PORT:-8001}"
-            if [ "\$API_EFFECTIVE_PORT" != "8001" ]; then
-              echo "API_PORT=\$API_EFFECTIVE_PORT must be 8001 to match the nginx upstream" >&2
-              exit 1
-            fi
+            # The API port is per-environment: this is a multi-tenant host, so the
+            # port that nginx proxies to differs per app (dev podcast = 8005, not the
+            # single-tenant 8001 in deployment/nginx/podcastfy.conf). The source of
+            # truth is the environment's API_PORT variable, which must match that
+            # environment's nginx upstream. Require it to be set and numeric so a
+            # missing/typo'd value fails fast BEFORE the running service is torn
+            # down, rather than silently binding a port nginx doesn't proxy.
+            API_EFFECTIVE_PORT="${API_PORT}"
+            case "\$API_EFFECTIVE_PORT" in
+              ''|*[!0-9]*)
+                echo "API_PORT must be set to the numeric port matching this environment's nginx upstream (got: '\$API_EFFECTIVE_PORT')" >&2
+                exit 1
+                ;;
+            esac
 
             # Restart API service (delete and recreate to ensure fresh start)
             if pm2 describe podcaststudiohub-api > /dev/null 2>&1; then

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -159,6 +159,9 @@ jobs:
 
           # Install dependencies and restart on server
           ssh -i ~/.ssh/deploy_key $SSH_USER@$SSH_HOST << EOF
+            # Fail fast: a failed migration or sync must abort the deploy before
+            # the running API is torn down, rather than silently continuing.
+            set -e
             cd $SERVER_PATH/api
 
             # Install uv if not already installed
@@ -177,19 +180,22 @@ jobs:
             find . -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true
             find . -type f -name '*.pyc' -delete 2>/dev/null || true
 
+            # Port must match the nginx upstream (deployment/nginx/podcastfy.conf:8001).
+            # Guard against a stray API_PORT reintroducing the 8000/8001 drift.
+            # Validated BEFORE tearing down the running service so a bad port never
+            # leaves the API deleted-but-not-restarted.
+            API_EFFECTIVE_PORT="${API_PORT:-8001}"
+            if [ "\$API_EFFECTIVE_PORT" != "8001" ]; then
+              echo "API_PORT=\$API_EFFECTIVE_PORT must be 8001 to match the nginx upstream" >&2
+              exit 1
+            fi
+
             # Restart API service (delete and recreate to ensure fresh start)
             if pm2 describe podcaststudiohub-api > /dev/null 2>&1; then
               echo "Stopping existing API service..."
               pm2 delete podcaststudiohub-api
             fi
 
-            # Port must match the nginx upstream (deployment/nginx/podcastfy.conf:8001).
-            # Guard against a stray API_PORT reintroducing the 8000/8001 drift.
-            API_EFFECTIVE_PORT="${API_PORT:-8001}"
-            if [ "\$API_EFFECTIVE_PORT" != "8001" ]; then
-              echo "API_PORT=\$API_EFFECTIVE_PORT must be 8001 to match the nginx upstream" >&2
-              exit 1
-            fi
             echo "Starting API service on port \$API_EFFECTIVE_PORT..."
             EMAIL_ENABLED=false \
             REQUIRE_EMAIL_VERIFICATION=false \

--- a/deployment/tests/test_deploy_hardening.py
+++ b/deployment/tests/test_deploy_hardening.py
@@ -15,14 +15,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-dev.yml"
 CONFIG = REPO_ROOT / "apps" / "api" / "src" / "config.py"
-NGINX_CONF = REPO_ROOT / "deployment" / "nginx" / "podcastfy.conf"
 HARDEN_SCRIPT = REPO_ROOT / "deployment" / "scripts" / "harden-host.sh"
-
-
-def _nginx_upstream_port() -> str:
-	m = re.search(r"upstream\s+podcastfy_api\s*\{[^}]*?127\.0\.0\.1:(\d+)", NGINX_CONF.read_text())
-	assert m, "could not find the FastAPI upstream port in the nginx config"
-	return m.group(1)
 
 
 # ── AC2: API binds loopback, not 0.0.0.0 ───────────────────────────────────
@@ -46,17 +39,21 @@ def test_config_default_host_is_loopback():
 # ── AC2: deploy port matches the nginx upstream ────────────────────────────
 
 
-def test_workflow_deploy_port_matches_nginx_upstream():
-	port = _nginx_upstream_port()
+def test_workflow_requires_explicit_numeric_api_port():
+	# The deploy host is multi-tenant, so the API port is per-environment (the
+	# environment's API_PORT variable, which must match that environment's nginx
+	# upstream) rather than a single repo-wide constant. The workflow must NOT
+	# hardcode an equality check against one port, and must reject an unset or
+	# non-numeric API_PORT so a missing/typo'd value fails fast.
 	text = WORKFLOW.read_text()
-	# The deploy port must fall back to the nginx upstream port, not 8000.
-	assert f"${{API_PORT:-{port}}}" in text, (
-		f"deploy port fallback must match nginx upstream ({port})"
+	# No silent default and no hardcoded single-port equality (the old 8000/8001 drift guard).
+	assert "${API_PORT:-" not in text, "API_PORT must be explicit, not a silent default"
+	assert '!= "8001"' not in text and '!= "8000"' not in text, (
+		"deploy must not hardcode a single API port; it is per-environment"
 	)
-	assert "${API_PORT:-8000}" not in text, "stale 8000 port fallback drifts from nginx upstream"
-	# A stray API_PORT override must be rejected, not silently reintroduce the drift.
-	assert f'!= "{port}"' in text and "exit 1" in text, (
-		"deploy must hard-fail if the effective API port != nginx upstream"
+	# Unset / non-numeric API_PORT must hard-fail before the service is torn down.
+	assert "*[!0-9]*" in text and "exit 1" in text, (
+		"deploy must reject an unset or non-numeric API_PORT"
 	)
 
 


### PR DESCRIPTION
## Why
Investigating the failing **Deploy to Development** runs surfaced three coupled problems. This PR fixes the two that live in the repo; the third was an environment fix applied out-of-band (see below).

The `Deploy API` SSH heredoc had **no `set -e`**, so a failed `alembic upgrade head` didn't abort — the script continued to `pm2 delete podcaststudiohub-api`, then hit the port guard's `exit 1` **before** `pm2 start`, leaving dev with the API **deleted and never restarted** (the source of the 502s on the live-dev Playwright check).

The port guard also **hardcoded 8001**. But the dev host is **multi-tenant** — live nginx proxies `dev.podcaststudiohub.me`'s API to `127.0.0.1:8005` (env `API_PORT=8005`); 8001 belongs to another app. So the guard rejected every dev deploy even though 8005 is correct.

## Changes
- Add `set -e` to the `Deploy API` heredoc → a failed migration/sync aborts **before** any teardown.
- Move the port guard **ahead of** `pm2 delete`.
- Replace the hardcoded `!= "8001"` / `${API_PORT:-8001}` with a **require-explicit-numeric** check: unset/non-numeric `API_PORT` hard-fails; otherwise the environment's configured port (which must match that environment's nginx upstream) is used as-is.
- Update `deployment/tests/test_deploy_hardening.py` to the new per-environment semantics (8 tests pass); drop the now-unused repo-nginx-port coupling.

## Environment fixes applied out-of-band (not in this PR)
- Dev DB was reset to alembic `002`; migration `003` failed because the migration role `podcastfy_user` lacks `CREATEROLE`. Resolved by pre-creating the `podcastfy_app` role as superuser, then `alembic upgrade head` (→ 011), then restarting the API on 8005. **Dev is back up** (`/api/health` → 200).
- `API_PORT=8005` in the `development` environment is **correct** (matches live nginx) and was left unchanged.

## Follow-up
- Add a CI job that runs migrations as a **non-superuser** role mirroring dev, so the `CREATEROLE`-class failure fails the PR instead of the deploy.