### PR TITLE
test(ci): run migrations under the dev least-privilege model

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,76 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Coverage reports uploaded as artifacts." >> $GITHUB_STEP_SUMMARY
 
+  # The main backend job runs migrations as the Postgres superuser, so a
+  # migration needing privileges the *real* migration user lacks passes CI but
+  # breaks deploy. (This took dev down: 003's CREATE ROLE failed under the
+  # non-CREATEROLE server role, leaving the schema 9 versions behind.) This job
+  # mirrors the server's least-privilege model so that class of failure fails
+  # the PR instead.
+  migrate-as-non-superuser:
+    name: Migrations run under dev privilege model
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+
+      - name: Install dependencies
+        working-directory: apps/api
+        run: uv sync
+
+      - name: Provision dev-parity roles and database
+        env:
+          PGPASSWORD: postgres
+        run: |
+          # Mirror the dev server: a non-superuser, non-CREATEROLE role owns the
+          # database and runs migrations; the podcastfy_app role is provisioned
+          # out-of-band (as a DBA would). Migrations must NOT require any privilege
+          # beyond what this owner role has. Throwaway CI credentials reuse the
+          # ubiquitous postgres/postgres service password (no real secret here).
+          psql -h localhost -U postgres -v ON_ERROR_STOP=1 <<'SQL'
+          CREATE ROLE podcastfy_user LOGIN PASSWORD 'postgres' NOSUPERUSER NOCREATEDB NOCREATEROLE;
+          CREATE DATABASE podcastfy OWNER podcastfy_user;
+          CREATE ROLE podcastfy_app LOGIN PASSWORD 'postgres' NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT;
+          SQL
+
+      - name: Run migrations as the non-superuser owner
+        working-directory: apps/api
+        env:
+          DATABASE_URL: postgresql+asyncpg://podcastfy_user:postgres@localhost:5432/podcastfy
+        run: |
+          # config.py requires these at import; generate ephemeral values at
+          # runtime so no secret-looking literal sits in the workflow file.
+          # ENCRYPTION_KEY must be >=32 chars (config validator).
+          export ENCRYPTION_KEY="$(printf 'x%.0s' {1..32})"
+          export JWT_SECRET_KEY=ci
+          uv run alembic upgrade head
+
   test-frontend:
     name: Frontend Tests (Next.js/Jest)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why
The `Backend Tests` job runs `alembic upgrade head` as the Postgres **superuser**, so a migration that needs privileges the **real server migration role lacks** passes CI but breaks the deploy. This is the gap that took dev down: migration `003`'s `CREATE ROLE podcastfy_app` failed under the non-`CREATEROLE` server role, leaving dev's schema **9 versions behind** while PRs stayed green.

## What
Adds a `migrate-as-non-superuser` job that mirrors the server's privilege model:
- a non-superuser, non-`CREATEROLE` role **owns** the database and runs the **full migration chain**;
- `podcastfy_app` is provisioned **out-of-band** (as a DBA would on the server).

Any migration that needs privileges beyond what the owner role has now **fails the PR** instead of the deploy.

Verified locally against a fresh Postgres 16: `001 → 011` succeed under this model (exit 0).

## Scope / honesty
This validates the **documented least-privilege model** (it assumes `podcastfy_app` is provisioned out-of-band, which is the operational contract). It does **not** simulate "operator forgot to provision the role" — fully eliminating that would mean moving role creation out of migration `003` entirely (a larger refactor) so the chain is self-sufficient under any owner. Happy to do that as a follow-up if you want CI to also catch the operational gap.

Trusted extensions (`pgcrypto`, `uuid-ossp`) are creatable by the DB-owner role in PG13+, so `001` works without superuser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added database migration verification in the CI/CD pipeline to ensure migrations complete successfully with restricted database credentials, validating production-ready compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->