### PR TITLE
fix(tts): require non-empty ElevenLabs voice IDs (client + server validation) (#221)

### DIFF
--- a/apps/api/src/routers/tts_configurations.py
+++ b/apps/api/src/routers/tts_configurations.py
@@ -18,6 +18,7 @@ from ..schemas.tts_configuration import (
 	TTSConfigUpdate,
 	TTSConfigResponse,
 	TTSConfigListResponse,
+	_validate_provider_config,
 )
 from ..services.tts_configuration_service import (
 	create_tts_configuration,
@@ -165,6 +166,19 @@ async def update_tts_config_endpoint(
 			status_code=status.HTTP_404_NOT_FOUND,
 			detail="TTS configuration not found",
 		)
+
+	# A partial update sending only `config` (no `provider`) skips the schema's
+	# provider validator, which would let an empty-voice-ID ElevenLabs config
+	# through. Re-validate against the effective provider here (#221).
+	if update_data.config is not None:
+		effective_provider = update_data.provider or tts_config.provider
+		try:
+			_validate_provider_config(effective_provider, update_data.config)
+		except (ValueError, TypeError) as exc:
+			raise HTTPException(
+				status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+				detail=str(exc) or "Invalid TTS configuration",
+			)
 
 	updated_config = await update_tts_configuration(
 		db=db,

--- a/apps/api/src/schemas/tts_configuration.py
+++ b/apps/api/src/schemas/tts_configuration.py
@@ -56,6 +56,14 @@ def _validate_provider_config(provider: str, config: dict) -> dict:
 			raise ValueError(
 				f"Similarity boost must be between 0.0 and 1.0, got: {similarity_boost}"
 			)
+		# Key-presence alone isn't enough: empty/whitespace/null voice IDs produce
+		# a non-functional config. Require real, non-empty string values (#221).
+		for key in ("voice_1_id", "voice_2_id"):
+			value = config.get(key)
+			if not isinstance(value, str) or not value.strip():
+				raise ValueError(
+					"ElevenLabs config requires non-empty voice_1_id and voice_2_id"
+				)
 	return config
 
 

--- a/apps/api/tests/test_tts_configurations.py
+++ b/apps/api/tests/test_tts_configurations.py
@@ -537,6 +537,93 @@ async def test_validation_elevenlabs_missing_required_field(client, auth_headers
 
 
 @pytest.mark.asyncio
+async def test_validation_elevenlabs_empty_voice_1_id(client, auth_headers):
+	"""Test that ElevenLabs config with empty voice_1_id is rejected."""
+	payload = {
+		**ELEVENLABS_CONFIG,
+		"config": {**ELEVENLABS_CONFIG["config"], "voice_1_id": ""},
+	}
+	response = await client.post("/tts-configs", headers=auth_headers, json=payload)
+	assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_validation_elevenlabs_empty_voice_2_id(client, auth_headers):
+	"""Test that ElevenLabs config with empty voice_2_id is rejected."""
+	payload = {
+		**ELEVENLABS_CONFIG,
+		"config": {**ELEVENLABS_CONFIG["config"], "voice_2_id": ""},
+	}
+	response = await client.post("/tts-configs", headers=auth_headers, json=payload)
+	assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_validation_elevenlabs_both_voice_ids_empty(client, auth_headers):
+	"""Test that ElevenLabs config with both voice IDs empty is rejected."""
+	payload = {
+		**ELEVENLABS_CONFIG,
+		"config": {**ELEVENLABS_CONFIG["config"], "voice_1_id": "", "voice_2_id": ""},
+	}
+	response = await client.post("/tts-configs", headers=auth_headers, json=payload)
+	assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_validation_elevenlabs_whitespace_voice_ids(client, auth_headers):
+	"""Test that ElevenLabs config with whitespace-only voice IDs is rejected."""
+	payload = {
+		**ELEVENLABS_CONFIG,
+		"config": {**ELEVENLABS_CONFIG["config"], "voice_1_id": "   ", "voice_2_id": "   "},
+	}
+	response = await client.post("/tts-configs", headers=auth_headers, json=payload)
+	assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_validation_elevenlabs_null_voice_id(client, auth_headers):
+	"""Test that ElevenLabs config with a null voice_1_id is rejected."""
+	payload = {
+		**ELEVENLABS_CONFIG,
+		"config": {**ELEVENLABS_CONFIG["config"], "voice_1_id": None},
+	}
+	response = await client.post("/tts-configs", headers=auth_headers, json=payload)
+	assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_elevenlabs_empty_voice_id_rejected(client, auth_headers):
+	"""Test that a partial update (config only) with empty voice IDs is rejected.
+
+	The schema's provider validator is skipped when `provider` is absent from the
+	update payload, so the router must re-validate against the existing provider.
+	"""
+	create_resp = await _create_config(client, auth_headers, ELEVENLABS_CONFIG)
+	config_id = create_resp.json()["id"]
+
+	response = await client.put(
+		f"/tts-configs/{config_id}",
+		headers=auth_headers,
+		json={"config": {**ELEVENLABS_CONFIG["config"], "voice_1_id": "", "voice_2_id": ""}},
+	)
+	assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_malformed_config_value_rejected(client, auth_headers):
+	"""Test that a config-only update with a non-scalar numeric value yields 422, not 500."""
+	create_resp = await _create_config(client, auth_headers, ELEVENLABS_CONFIG)
+	config_id = create_resp.json()["id"]
+
+	response = await client.put(
+		f"/tts-configs/{config_id}",
+		headers=auth_headers,
+		json={"config": {**ELEVENLABS_CONFIG["config"], "stability": []}},
+	)
+	assert response.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_validation_elevenlabs_stability_out_of_range(client, auth_headers):
 	"""Test that ElevenLabs stability out of range is rejected."""
 	payload = {

--- a/apps/web/src/app/(auth)/episodes/[id]/page.tsx
+++ b/apps/web/src/app/(auth)/episodes/[id]/page.tsx
@@ -94,6 +94,8 @@ export default function EpisodePage() {
   const [selectedTtsConfigId, setSelectedTtsConfigId] = useState<string>("")
   const [newTtsProvider, setNewTtsProvider] = useState<string>("openai")
   const [newTtsName, setNewTtsName] = useState<string>("")
+  const [newTtsVoice1Id, setNewTtsVoice1Id] = useState<string>("")
+  const [newTtsVoice2Id, setNewTtsVoice2Id] = useState<string>("")
   const [savingTts, setSavingTts] = useState(false)
   const robustESRef = useRef<RobustEventSource | null>(null)
   const stopPollingRef = useRef<(() => void) | null>(null)
@@ -362,17 +364,30 @@ export default function EpisodePage() {
     }
   }
 
+  // ElevenLabs ships with empty voice-ID defaults, so a saved config is only
+  // usable once the user provides real voice IDs (#221). Other providers have
+  // working defaults and need no extra input.
+  const isTtsConfigValid =
+    newTtsName.trim() !== "" &&
+    (newTtsProvider !== "elevenlabs" ||
+      (newTtsVoice1Id.trim() !== "" && newTtsVoice2Id.trim() !== ""))
+
   const saveTTSConfig = async () => {
-    if (!newTtsName.trim()) return
+    if (!isTtsConfigValid) return
     setSavingTts(true)
     try {
+      const config = { ...(DEFAULT_CONFIGS[newTtsProvider] ?? {}) }
+      if (newTtsProvider === "elevenlabs") {
+        config.voice_1_id = newTtsVoice1Id.trim()
+        config.voice_2_id = newTtsVoice2Id.trim()
+      }
       const createResponse = await fetch(`/api/proxy/tts-configs`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: newTtsName,
           provider: newTtsProvider,
-          config: DEFAULT_CONFIGS[newTtsProvider] ?? {},
+          config,
           is_default: false,
         }),
       })
@@ -381,6 +396,8 @@ export default function EpisodePage() {
         setTtsConfigs((prev) => [...prev, newConfig])
         setSelectedTtsConfigId(newConfig.id)
         setNewTtsName("")
+        setNewTtsVoice1Id("")
+        setNewTtsVoice2Id("")
         showSuccessToast("TTS configuration saved")
       } else {
         showErrorToast("Failed to save TTS configuration")
@@ -754,9 +771,36 @@ export default function EpisodePage() {
                     </SelectContent>
                   </Select>
                 </div>
+                {newTtsProvider === "elevenlabs" && (
+                  <>
+                    <div>
+                      <Label htmlFor="new-tts-voice-1" className="mb-1">Voice 1 ID</Label>
+                      <Input
+                        id="new-tts-voice-1"
+                        value={newTtsVoice1Id}
+                        onChange={(e) => setNewTtsVoice1Id(e.target.value)}
+                        placeholder="21m00Tcm4TlvDq8ikWAM"
+                        aria-required="true"
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="new-tts-voice-2" className="mb-1">Voice 2 ID</Label>
+                      <Input
+                        id="new-tts-voice-2"
+                        value={newTtsVoice2Id}
+                        onChange={(e) => setNewTtsVoice2Id(e.target.value)}
+                        placeholder="AZnzlk1XvdvUeBnXmlld"
+                        aria-required="true"
+                      />
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      Required ElevenLabs voice IDs from your ElevenLabs account (Voice Library).
+                    </p>
+                  </>
+                )}
                 <Button
                   onClick={saveTTSConfig}
-                  disabled={savingTts || !newTtsName.trim()}
+                  disabled={savingTts || !isTtsConfigValid}
                   variant="outline"
                   className="w-full"
                 >


### PR DESCRIPTION
Closes #221

## Problem
The TTS dialog let users save an ElevenLabs config with **empty voice IDs** and showed a success toast. The backend validated key *presence* only (`required - set(config.keys())`), so empty strings passed. Generation then ran with no voice IDs — a non-functional config presented as saved.

## Changes
**Frontend** (`apps/web/.../episodes/[id]/page.tsx`)
- Added `Voice 1 ID` / `Voice 2 ID` inputs, shown only when ElevenLabs is selected.
- `saveTTSConfig` merges the trimmed values into the config payload; resets them on success.
- Save button is disabled until both voice IDs are non-empty (other providers unaffected — they have working defaults).

**Backend**
- `_validate_provider_config`: reject empty / whitespace-only / null voice IDs for ElevenLabs (requires a non-empty **string**, not just key presence).
- Router `PUT /tts-configs/{id}`: re-validate `config` against the existing provider on partial updates, closing the bypass where a config-only update skipped the schema validator. `ValueError`/`TypeError` → `422`.

## Tests
Added to `test_tts_configurations.py` (run against a real Postgres + migrations, RLS role): empty `voice_1_id`, empty `voice_2_id`, both empty, whitespace-only, null, partial-update bypass, and malformed non-scalar value. **46 passed.**

## Review
Independent cross-family review via `codex review` (3 rounds): all application findings addressed (null/non-string handling, partial-update bypass, `TypeError`→422). Final verdict: "the application changes appear sound."

## Known limitations / out of scope
- A stray untracked `apps/web/package-lock.json` exists in the working tree (present before this work, not created here, not included in this PR). It is a workspace-local lockfile that could shadow the root lock for `npm ci` — worth removing separately.
- Pre-existing `tsc` error in `page.tsx` (`setEpisode` SetStateAction type, line ~206) and codebase-wide mypy `Column[...]` typing warnings are unrelated to this change and left as-is.
- Client-side validation verified via `tsc`/ESLint + review; server-side validation has full automated coverage.