### PR TITLE
fix(web): replace hardcoded gray colors with design tokens; harden download cleanup, signup trim & SSE unmount guards (#226)

### DIFF
--- a/apps/web/__tests__/app/signup/page.test.tsx
+++ b/apps/web/__tests__/app/signup/page.test.tsx
@@ -30,6 +30,21 @@ describe('SignupPage', () => {
     expect(screen.getByRole('button', { name: /sign up/i })).toBeInTheDocument()
   })
 
+  it('trims whitespace from the full name before sending', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({}) }) as jest.Mock
+    global.fetch = fetchMock
+
+    render(<SignupPage />)
+    await userEvent.type(screen.getByLabelText(/full name/i), '  Jane Doe  ')
+    await fillAndSubmit()
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body.full_name).toBe('Jane Doe')
+  })
+
   it('shows the error and resets loading on failure', async () => {
     global.fetch = jest
       .fn()

--- a/apps/web/__tests__/lib/download.test.ts
+++ b/apps/web/__tests__/lib/download.test.ts
@@ -82,6 +82,31 @@ describe('downloadAudioFile', () => {
     createElementSpy.mockRestore()
   })
 
+  it('revokes the object URL even if removeChild throws', async () => {
+    const mockBlob = new Blob(['audio data'], { type: 'audio/mpeg' })
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      blob: jest.fn().mockResolvedValue(mockBlob),
+    } as unknown as Response)
+
+    const createElementSpy = jest.spyOn(document, 'createElement').mockReturnValue({
+      href: '',
+      download: '',
+      click: jest.fn(),
+    } as unknown as HTMLAnchorElement)
+    ;(document.body.removeChild as jest.Mock).mockImplementation(() => {
+      throw new Error('removeChild failed')
+    })
+
+    await expect(
+      downloadAudioFile('https://example.com/audio.mp3', 'test.mp3')
+    ).rejects.toThrow('removeChild failed')
+
+    expect(window.URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+
+    createElementSpy.mockRestore()
+  })
+
   it('throws an error if fetch response is not ok', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,

--- a/apps/web/src/app/(auth)/episodes/[id]/page.tsx
+++ b/apps/web/src/app/(auth)/episodes/[id]/page.tsx
@@ -265,7 +265,9 @@ export default function EpisodePage() {
         console.warn(`SSE error: ${message} (attempt ${attempt}/${maxRetries})`)
       },
       onFallbackToPolling: handleFallbackToPolling,
-      onStatusChange: setConnectionStatus,
+      onStatusChange: (s) => {
+        if (isMountedRef.current) setConnectionStatus(s)
+      },
       maxRetries: 5,
       retryDelay: 1000,
     })

--- a/apps/web/src/app/(auth)/episodes/[id]/page.tsx
+++ b/apps/web/src/app/(auth)/episodes/[id]/page.tsx
@@ -98,6 +98,14 @@ export default function EpisodePage() {
   const [savingTts, setSavingTts] = useState(false)
   const robustESRef = useRef<RobustEventSource | null>(null)
   const stopPollingRef = useRef<(() => void) | null>(null)
+  const isMountedRef = useRef(true)
+
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
 
   // Backend calls (fetch + EventSource) go through the same-origin /api/proxy
   // handler, which injects the bearer token server-side from the httpOnly cookie
@@ -109,6 +117,7 @@ export default function EpisodePage() {
       )
       if (response.ok) {
         const data = await response.json() as Episode
+        if (!isMountedRef.current) return
         setEpisode(data)
         if (data.tts_config_id) {
           setSelectedTtsConfigId(data.tts_config_id)
@@ -198,6 +207,7 @@ export default function EpisodePage() {
     const sseUrl = `/api/proxy/generation/episodes/${params.id}/progress`
 
     const handleMessage = (raw: unknown) => {
+      if (!isMountedRef.current) return
       const data = raw as { status: string; progress?: GenerationProgress }
       const newStatus = data.status
       const newProgress = data.progress

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -19,10 +19,10 @@ export default function Home() {
   }, [session, status, router])
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+    <div className="min-h-screen flex items-center justify-center bg-background">
       <div className="text-center">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">Podcastfy Studio</h1>
-        <p className="text-gray-600">Loading...</p>
+        <h1 className="text-2xl font-bold text-foreground mb-2">Podcastfy Studio</h1>
+        <p className="text-muted-foreground">Loading...</p>
       </div>
     </div>
   )

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -24,7 +24,7 @@ export default function SignupPage() {
       const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/register`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, password, full_name: fullName }),
+        body: JSON.stringify({ email, password, full_name: fullName.trim() }),
       })
 
       if (!response.ok) {

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -33,11 +33,13 @@ export async function downloadAudioFile(
   const link = document.createElement("a")
   link.href = objectUrl
   link.download = filename
+  let appended = false
   try {
     document.body.appendChild(link)
+    appended = true
     link.click()
   } finally {
     window.URL.revokeObjectURL(objectUrl)
-    document.body.removeChild(link)
+    if (appended) document.body.removeChild(link)
   }
 }

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -33,8 +33,11 @@ export async function downloadAudioFile(
   const link = document.createElement("a")
   link.href = objectUrl
   link.download = filename
-  document.body.appendChild(link)
-  link.click()
-  document.body.removeChild(link)
-  window.URL.revokeObjectURL(objectUrl)
+  try {
+    document.body.appendChild(link)
+    link.click()
+  } finally {
+    window.URL.revokeObjectURL(objectUrl)
+    document.body.removeChild(link)
+  }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,57 +1,31 @@
-# Issue #234 — IP-pin outbound fetches (DNS-rebinding SSRF residual)
+# Issue #226 — fix(web): design tokens + robustness nits
 
-Follow-up to #206. `validate_public_url` resolves the host and rejects non-public
-IPs, but `requests`/`httpx` **re-resolve** at connect time → TOCTOU DNS-rebinding
-window. Fix: pin the connection to the IP the guard already validated, while
-keeping the original `Host` header, SNI, and cert verification against the hostname.
+Branch: `fix/226-web-design-tokens-robustness`
+Plan source: self-authored (issue had only an empty CodeRabbit planner prompt).
 
-`validate_public_url` already **returns** the list of resolved public IPs — pin to `resolved[0]`.
+## Acceptance criteria (hard gate)
+- [ ] Replace gray classes with `bg-background`/`text-foreground`/`text-muted-foreground`
+- [ ] Wrap download click+cleanup in try/finally
+- [ ] Trim `fullName` in signup
 
-## Plan
+## Plan (TDD: test first where it adds value)
 
-### 1. New helper: `apps/api/src/utils/pinned_fetch.py`
-- `pinned_session(url, ip) -> requests.Session`: a `Session` with a `_PinnedIPAdapter`
-  mounted for the URL's scheme. The adapter:
-  - rewrites the request URL host → `ip` (IPv6-bracketed, port preserved),
-  - keeps `Host: <original host[:port]>`,
-  - for https, sets urllib3 `server_hostname` + `assert_hostname` = hostname on the
-    pool (SNI + cert verified against the hostname, not the IP).
-- `pin_httpx(url, ip) -> (pinned_url, headers, extensions)`: returns the IP URL,
-  `{"Host": host}`, and `{"sni_hostname": host}` (httpx verifies TLS against the host).
-- `_ip_netloc(ip, port)` helper (IPv6 bracketing + optional port).
+1. **page.tsx** (`src/app/page.tsx:22-25`) — replace `bg-gray-50`→`bg-background`,
+   `text-gray-900`→`text-foreground`, `text-gray-600`→`text-muted-foreground`.
+   Verify: grep shows no `gray-` left in changed files.
 
-### 2. `content_extraction_service.py` `_fetch_and_extract_safely` (requests.get)
-- Capture `resolved = validate_public_url(...)` (already strict, non-empty).
-- Fetch via `with pinned_session(current_url, resolved[0]) as s: s.get(...)`.
+2. **download.ts** (`src/lib/download.ts:33-39`) — wrap appendChild/click/removeChild
+   in try, move `removeChild` + `revokeObjectURL` into `finally`.
+   Test: removeChild throws → revokeObjectURL still called (extend download.test.ts).
 
-### 3. `tasks/platform_distribution.py` `_distribute_via_webhook` (requests.post/get)
-- Capture `resolved` from the existing strict `validate_public_url(...)`.
-- Issue POST/GET through `pinned_session(webhook_url, resolved[0])`.
+3. **signup/page.tsx** (line 27) — send `full_name: fullName.trim()`.
+   Test: padded fullName → request body has trimmed value
+   (extend __tests__/app/signup/page.test.tsx).
 
-### 4. `services/source_validator_service.py` `_check_url_accessibility` (httpx.head)
-- Make `_validate_url_not_internal` return the resolved IP list.
-- Validate at the **top of the loop** for `current_url` (covers first hop + every
-  redirect hop), capture IPs, and `client.head(pin_httpx(current_url, ips[0]))`.
-- Remove now-redundant per-hop re-validation block.
+4. **episodes/[id]/page.tsx** — review item. Add `isMountedRef` guard: set false on
+   unmount; early-return in `handleMessage` and guard `setEpisode` in `loadEpisode`
+   so SSE-driven async callbacks don't setState after unmount.
 
-## Tests
-- `tests/unit/test_pinned_fetch.py`: `_ip_netloc` (v4/v6/port); `pinned_session.send`
-  rewrites URL→IP + preserves Host + carries server_hostname/assert_hostname on the
-  pool; `pin_httpx` output shape.
-- Rebinding proof (per AC#3): patch `socket.getaddrinfo` to return public IP at
-  validation then private IP on any later call; patch urllib3's
-  `util.connection.create_connection` chokepoint to capture the connect target;
-  assert the socket connects to the **validated public IP** (an IP literal → no
-  re-resolution), never the rebind private IP. Mirror for the httpx HEAD path.
-- Existing SSRF/extraction/webhook tests stay green.
-
-## Acceptance criteria
-- [ ] Content-extraction + webhook fetches connect only to the guard-validated IP (no re-resolution window).
-- [ ] TLS verification still works for HTTPS targets.
-- [ ] Rebinding test (guard sees public IP, connect would get private IP) is blocked.
-
-## Design notes
-- No process-wide `getaddrinfo` monkeypatching (issue's explicit constraint) —
-  pinning is per-connection/per-request, safe under Celery/threadpool concurrency.
-- No new dependencies (requests/httpx/urllib3 already present).
-- Plan source: issue body "Proposed fix" (no separate plan comment).
+## Quality gate
+- `npm test` (jest), `npm run lint`, `npx tsc --noEmit`
+- cross-family review (codex/coderabbit), demo, CI green → merge


### PR DESCRIPTION
Closes #226

## What
P5.3 release-audit cleanup for `apps/web` — design-system compliance + robustness nits.

### Acceptance criteria
- [x] Replace hardcoded gray classes with design tokens (`bg-background` / `text-foreground` / `text-muted-foreground`)
- [x] Wrap download click + cleanup in `try/finally`
- [x] Trim `fullName` in signup

### Changes
- **`src/app/page.tsx`** — `bg-gray-50`→`bg-background`, `text-gray-900`→`text-foreground`, `text-gray-600`→`text-muted-foreground` (per `apps/web/CLAUDE.md` token map).
- **`src/lib/download.ts`** — wrap link `click()` in `try/finally`; `revokeObjectURL` always runs (no blob-URL leak), and `removeChild` only runs if `appendChild` succeeded (avoids masking the original error).
- **`src/app/signup/page.tsx`** — send `full_name: fullName.trim()` (rejects whitespace-only padding).
- **`src/app/(auth)/episodes/[id]/page.tsx`** — review item: add `isMountedRef` guard so SSE/polling callbacks (`handleMessage`, `onStatusChange`) and the async `loadEpisode` don't `setState` after unmount.

## Tests
- Extended `__tests__/lib/download.test.ts` — `revokeObjectURL` still called when `removeChild` throws.
- Extended `__tests__/app/signup/page.test.tsx` — padded full name is trimmed before submit.
- Full suite: **244 passing**. ESLint clean. No new `tsc` errors.

## Review
Cross-family review by `codex` — both findings (download cleanup ordering, unguarded `onStatusChange`) addressed in the second commit.

## Known limitations
- Pre-existing repo-wide `tsc` errors (missing Hugeicons names, `@radix-ui/react-progress`, zod `errorMap`) are unrelated to this change and unchanged (155 before/after).