### PR TITLE
fix(api): restrict episode/project update to user-editable fields (#271)

### DIFF
--- a/apps/api/src/schemas/episode.py
+++ b/apps/api/src/schemas/episode.py
@@ -56,7 +56,16 @@ class EpisodeCreate(BaseModel):
 
 
 class EpisodeUpdate(BaseModel):
-	"""Schema for updating an existing episode. All fields optional for partial updates."""
+	"""Schema for updating an existing episode (public, user-editable fields only).
+
+	System-managed fields (generation_status, generation_progress, s3_key, s3_url,
+	duration_seconds, file_size_bytes, file_path, transcript_path, task_id,
+	task_started_at, task_completed_at) are deliberately NOT accepted here: they are
+	written only by the generation pipeline (src/tasks/** and the generation router),
+	never by an end user. See episode_service.EPISODE_USER_EDITABLE_FIELDS for the
+	service-layer allowlist that enforces this even if the schema regresses.
+	All fields optional for partial updates.
+	"""
 
 	episode_number: Optional[int] = Field(
 		None,
@@ -67,14 +76,6 @@ class EpisodeUpdate(BaseModel):
 		None,
 		description="JSONB metadata for episode information"
 	)
-	generation_status: Optional[str] = Field(
-		None,
-		description="Generation status (draft, queued, processing, completed, failed)"
-	)
-	generation_progress: Optional[dict] = Field(
-		None,
-		description="Generation progress tracking data"
-	)
 	tts_config_id: Optional[UUID] = Field(
 		None,
 		description="TTS configuration ID"
@@ -82,42 +83,6 @@ class EpisodeUpdate(BaseModel):
 	template_id: Optional[UUID] = Field(
 		None,
 		description="Conversation template ID"
-	)
-	s3_key: Optional[str] = Field(
-		None,
-		description="S3 storage key for audio file"
-	)
-	s3_url: Optional[str] = Field(
-		None,
-		description="S3 URL for audio file"
-	)
-	duration_seconds: Optional[float] = Field(
-		None,
-		description="Audio duration in seconds"
-	)
-	file_size_bytes: Optional[int] = Field(
-		None,
-		description="Audio file size in bytes"
-	)
-	file_path: Optional[str] = Field(
-		None,
-		description="Local file path"
-	)
-	transcript_path: Optional[str] = Field(
-		None,
-		description="Transcript file path"
-	)
-	task_id: Optional[str] = Field(
-		None,
-		description="Celery task UUID for tracking background generation job"
-	)
-	task_started_at: Optional[datetime] = Field(
-		None,
-		description="When the Celery task was submitted to the broker"
-	)
-	task_completed_at: Optional[datetime] = Field(
-		None,
-		description="When the Celery task finished (success or failure)"
 	)
 
 	@field_validator('episode_metadata')

--- a/apps/api/src/services/episode_service.py
+++ b/apps/api/src/services/episode_service.py
@@ -22,6 +22,19 @@ from ..schemas.episode import EpisodeCreate, EpisodeUpdate, BatchEpisodeCreate
 VALID_SORT_FIELDS = {"episode_number", "created_at", "duration_seconds"}
 VALID_SORT_ORDERS = {"asc", "desc"}
 
+# Fields an end user may set through the public update endpoint. Everything else
+# (generation_status, generation_progress, s3_key/s3_url, duration_seconds,
+# file_size_bytes, file_path, transcript_path, task_*) is system-managed and is
+# written only by the generation pipeline via set_episode_system_fields(). This
+# allowlist is the source of truth: a system field re-added to EpisodeUpdate stays
+# unwritable until it is deliberately added here.
+EPISODE_USER_EDITABLE_FIELDS = {
+	"episode_number",
+	"episode_metadata",
+	"tts_config_id",
+	"template_id",
+}
+
 
 async def create_episode(
 	db: AsyncSession,
@@ -248,6 +261,37 @@ async def update_episode(
 	"""
 	update_dict = update_data.model_dump(exclude_unset=True)
 	for field, value in update_dict.items():
+		if field not in EPISODE_USER_EDITABLE_FIELDS:
+			# Never mass-assign system-managed fields, even if a future schema
+			# change re-adds one to EpisodeUpdate.
+			continue
+		setattr(episode, field, value)
+
+	await db.commit()
+	return episode
+
+
+async def set_episode_system_fields(
+	db: AsyncSession,
+	episode: Episode,
+	**fields,
+) -> Episode:
+	"""Write pipeline-managed (system) episode fields directly.
+
+	For internal use by the generation pipeline only (e.g. transcript_path,
+	generation_progress, s3_key). This intentionally bypasses the
+	EPISODE_USER_EDITABLE_FIELDS allowlist that guards update_episode, so it must
+	never be reachable from a request handler with user-controlled field names.
+
+	Args:
+		db: Database session
+		episode: Existing episode instance
+		**fields: Episode column names mapped to their new values
+
+	Returns:
+		Updated Episode instance
+	"""
+	for field, value in fields.items():
 		setattr(episode, field, value)
 
 	await db.commit()

--- a/apps/api/src/services/project_service.py
+++ b/apps/api/src/services/project_service.py
@@ -13,6 +13,18 @@ from typing import Optional
 from ..models import Project
 from ..schemas.project import ProjectCreate, ProjectUpdate
 
+# Fields an end user may set through the public update endpoint. Defense-in-depth
+# allowlist so a future ProjectUpdate addition (e.g. an ownership/billing column)
+# can't silently become mass-assignable. Mirrors EPISODE_USER_EDITABLE_FIELDS.
+PROJECT_USER_EDITABLE_FIELDS = {
+	"name",
+	"description",
+	"podcast_metadata",
+	"default_tts_config_id",
+	"default_template_id",
+	"is_archived",
+}
+
 
 async def create_project(
 	db: AsyncSession,
@@ -131,6 +143,8 @@ async def update_project(
 	"""
 	update_dict = update_data.model_dump(exclude_unset=True)
 	for field, value in update_dict.items():
+		if field not in PROJECT_USER_EDITABLE_FIELDS:
+			continue  # never mass-assign non-user-editable fields
 		setattr(project, field, value)
 
 	await db.commit()

--- a/apps/api/src/services/quality_metrics_service.py
+++ b/apps/api/src/services/quality_metrics_service.py
@@ -36,7 +36,7 @@ import statistics
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .episode_service import get_episode_by_id, update_episode
+from .episode_service import get_episode_by_id, set_episode_system_fields
 
 
 logger = logging.getLogger(__name__)
@@ -185,12 +185,15 @@ class QualityMetricsCalculator:
 		# Calculate metrics
 		metrics = await self.calculate_metrics(episode_id, transcript_path)
 
-		# Update episode.generation_progress with quality metrics
-		current_progress = episode.generation_progress or {}
+		# Update episode.generation_progress with quality metrics. Build a NEW dict
+		# rather than mutating episode.generation_progress in place: plain JSONB
+		# columns don't track in-place mutation, and reassigning the same object
+		# reference would not register as a change, so the metrics might never persist.
+		current_progress = dict(episode.generation_progress or {})
 		current_progress["quality_metrics"] = metrics.to_dict()
 
-		# Update episode in database
-		await update_episode(db, episode_id, {"generation_progress": current_progress})
+		# Update episode in database (generation_progress is a system-managed field)
+		await set_episode_system_fields(db, episode, generation_progress=current_progress)
 
 		self.logger.info(
 			f"Stored quality metrics in episode {episode_id} generation_progress"

--- a/apps/api/src/services/script_generation_service.py
+++ b/apps/api/src/services/script_generation_service.py
@@ -34,8 +34,11 @@ from podcastfy.content_generator import ContentGenerator
 
 from ..config import settings
 from ..models import Episode
-from ..schemas.episode import EpisodeUpdate
-from .episode_service import get_episode_by_id, update_episode, update_generation_status
+from .episode_service import (
+	get_episode_by_id,
+	set_episode_system_fields,
+	update_generation_status,
+)
 from .content_service import get_content_sources
 
 
@@ -216,9 +219,8 @@ class ScriptGenerationService:
 				# Save transcript to file
 				transcript_path = await self._save_transcript(episode_id, transcript)
 
-				# Update episode with transcript_path and status='complete'
-				update_data = EpisodeUpdate(transcript_path=transcript_path)
-				await update_episode(db, episode, update_data)
+				# Update episode with transcript_path (system field) and status='complete'
+				await set_episode_system_fields(db, episode, transcript_path=transcript_path)
 
 				await self._update_status(
 					db, episode, 'complete',

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -77,6 +77,35 @@ async def test_db():
 
 
 @pytest.fixture
+def set_system_fields(test_db):
+    """Return an async helper that sets pipeline-managed (system) episode fields
+    directly in the DB — the same path the generation pipeline uses
+    (episode_service.set_episode_system_fields).
+
+    The public PUT endpoint intentionally refuses system fields
+    (generation_status, generation_progress, s3_key, duration_seconds, …), so
+    tests that need an episode in a particular generated state set them here
+    instead of through the API. Relies on the RLS tenant context already
+    established on the shared test session by a preceding API request.
+
+    Usage:
+        await set_system_fields(episode_id, generation_status="complete", s3_key="…")
+    """
+    from uuid import UUID
+    from src.services.episode_service import (
+        get_episode_by_id,
+        set_episode_system_fields,
+    )
+
+    async def _set(episode_id, **fields):
+        episode = await get_episode_by_id(test_db, UUID(str(episode_id)))
+        await set_episode_system_fields(test_db, episode, **fields)
+        return episode
+
+    return _set
+
+
+@pytest.fixture
 async def client(test_db):
     """
     Create an async HTTP client for testing FastAPI endpoints with test database.

--- a/apps/api/tests/test_download_endpoint.py
+++ b/apps/api/tests/test_download_endpoint.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock, patch
 # ============================================================================
 
 @pytest.fixture
-async def episode_and_auth(client):
+async def episode_and_auth(client, set_system_fields):
 	"""Create user, project, and a complete episode with s3_key set."""
 	# Register user
 	reg_response = await client.post("/auth/register", json={
@@ -56,14 +56,14 @@ async def episode_and_auth(client):
 	assert ep_response.status_code == 201
 	episode_id = ep_response.json()["id"]
 
-	# Update episode to "complete" status with s3_key and file_size_bytes
-	update_response = await client.put(f"/episodes/{episode_id}", headers=headers, json={
-		"generation_status": "complete",
-		"s3_key": f"podcasts/user-test/episode-{episode_id}.mp3",
-		"s3_url": f"https://test-bucket.s3.amazonaws.com/podcasts/user-test/episode-{episode_id}.mp3",
-		"file_size_bytes": 5242880
-	})
-	assert update_response.status_code == 200
+	# Mark complete with s3_key/file_size_bytes (system fields — set as the pipeline does)
+	await set_system_fields(
+		episode_id,
+		generation_status="complete",
+		s3_key=f"podcasts/user-test/episode-{episode_id}.mp3",
+		s3_url=f"https://test-bucket.s3.amazonaws.com/podcasts/user-test/episode-{episode_id}.mp3",
+		file_size_bytes=5242880,
+	)
 
 	return episode_id, headers
 
@@ -136,7 +136,7 @@ async def test_download_episode_not_complete(client, episode_and_auth):
 
 
 @pytest.mark.asyncio
-async def test_download_episode_missing_s3_key(client, episode_and_auth):
+async def test_download_episode_missing_s3_key(client, episode_and_auth, set_system_fields):
 	"""Returns 404 when episode is complete but s3_key is not set."""
 	_, headers = episode_and_auth
 
@@ -158,10 +158,8 @@ async def test_download_episode_missing_s3_key(client, episode_and_auth):
 	})
 	episode_id = ep_response.json()["id"]
 
-	# Mark complete without setting s3_key
-	await client.put(f"/episodes/{episode_id}", headers=headers, json={
-		"generation_status": "complete"
-	})
+	# Mark complete without setting s3_key (system field — set as the pipeline does)
+	await set_system_fields(episode_id, generation_status="complete")
 
 	response = await client.get(f"/episodes/{episode_id}/download", headers=headers)
 	assert response.status_code == 404

--- a/apps/api/tests/test_episodes.py
+++ b/apps/api/tests/test_episodes.py
@@ -6,6 +6,7 @@ status filtering, and tenant isolation for episodes.
 """
 
 import pytest
+from datetime import datetime, timezone
 from uuid import uuid4
 
 
@@ -339,8 +340,8 @@ async def test_create_multiple_episodes_same_project(client, project_and_auth):
 # ============================================================================
 
 @pytest.mark.asyncio
-async def test_update_generation_status(client, project_and_auth):
-	"""Test updating episode generation status."""
+async def test_update_cannot_change_generation_status(client, project_and_auth):
+	"""generation_status is system-managed and must not be writable via PUT."""
 	project_id, headers = project_and_auth
 
 	# Create episode
@@ -352,26 +353,20 @@ async def test_update_generation_status(client, project_and_auth):
 	assert create_response.json()["generation_status"] == "draft"
 	episode_id = create_response.json()["id"]
 
-	# Update status to generating
+	# Attempt to forge the generation status — must be silently ignored
 	update_response = await client.put(
 		f"/episodes/{episode_id}",
 		headers=headers,
-		json={"generation_status": "generating"}
+		json={"generation_status": "complete", "episode_number": 2}
 	)
 	assert update_response.status_code == 200
-	assert update_response.json()["generation_status"] == "generating"
-
-	# Update status to complete
-	complete_response = await client.put(
-		f"/episodes/{episode_id}",
-		headers=headers,
-		json={"generation_status": "complete"}
-	)
-	assert complete_response.json()["generation_status"] == "complete"
+	data = update_response.json()
+	assert data["generation_status"] == "draft"  # unchanged
+	assert data["episode_number"] == 2  # user-editable field still applied
 
 
 @pytest.mark.asyncio
-async def test_filter_by_status(client, project_and_auth):
+async def test_filter_by_status(client, project_and_auth, set_system_fields):
 	"""Test filtering episodes by generation status."""
 	project_id, headers = project_and_auth
 
@@ -390,10 +385,8 @@ async def test_filter_by_status(client, project_and_auth):
 	})
 	ep2_id = ep2_resp.json()["id"]
 
-	# Update one to generating
-	await client.put(f"/episodes/{ep1_id}", headers=headers, json={
-		"generation_status": "generating"
-	})
+	# Move one to 'generating' (system field — set directly, as the pipeline does)
+	await set_system_fields(ep1_id, generation_status="generating")
 
 	# Keep ep2 in draft
 
@@ -817,8 +810,9 @@ async def test_episode_created_with_null_task_fields(client, project_and_auth):
 
 
 @pytest.mark.asyncio
-async def test_update_task_id(client, project_and_auth):
-	"""Test storing a Celery task UUID in task_id field."""
+async def test_update_cannot_set_task_fields(client, project_and_auth):
+	"""task_id/task_started_at/task_completed_at are system-managed (Celery
+	tracking) and must not be writable via the public PUT endpoint."""
 	project_id, headers = project_and_auth
 
 	create_response = await client.post("/episodes", headers=headers, json={
@@ -828,93 +822,80 @@ async def test_update_task_id(client, project_and_auth):
 	})
 	episode_id = create_response.json()["id"]
 
-	celery_task_uuid = "550e8400-e29b-41d4-a716-446655440000"
 	update_response = await client.put(
 		f"/episodes/{episode_id}",
 		headers=headers,
 		json={
-			"task_id": celery_task_uuid,
-			"generation_status": "queued"
-		}
-	)
-	assert update_response.status_code == 200
-	data = update_response.json()
-	assert data["task_id"] == celery_task_uuid
-	assert data["generation_status"] == "queued"
-
-
-@pytest.mark.asyncio
-async def test_update_task_started_at(client, project_and_auth):
-	"""Test storing task_started_at timestamp when Celery task is submitted."""
-	project_id, headers = project_and_auth
-
-	create_response = await client.post("/episodes", headers=headers, json={
-		"project_id": project_id,
-		"episode_number": 1,
-		"episode_metadata": {"title": "Task Start Test", "description": "Desc"}
-	})
-	episode_id = create_response.json()["id"]
-
-	started_at = "2026-03-17T10:00:00+00:00"
-	update_response = await client.put(
-		f"/episodes/{episode_id}",
-		headers=headers,
-		json={
-			"task_id": "abc-123-def-456",
-			"task_started_at": started_at,
-			"generation_status": "queued"
-		}
-	)
-	assert update_response.status_code == 200
-	data = update_response.json()
-	assert data["task_started_at"] is not None
-	assert data["task_id"] == "abc-123-def-456"
-
-
-@pytest.mark.asyncio
-async def test_update_task_completed_at(client, project_and_auth):
-	"""Test storing task_completed_at timestamp when Celery task finishes."""
-	project_id, headers = project_and_auth
-
-	create_response = await client.post("/episodes", headers=headers, json={
-		"project_id": project_id,
-		"episode_number": 1,
-		"episode_metadata": {"title": "Task Complete Test", "description": "Desc"}
-	})
-	episode_id = create_response.json()["id"]
-
-	# Simulate task submission
-	await client.put(
-		f"/episodes/{episode_id}",
-		headers=headers,
-		json={
-			"task_id": "abc-123-def-456",
+			"task_id": "550e8400-e29b-41d4-a716-446655440000",
 			"task_started_at": "2026-03-17T10:00:00+00:00",
-			"generation_status": "generating"
-		}
-	)
-
-	# Simulate task completion
-	completed_at = "2026-03-17T10:05:00+00:00"
-	update_response = await client.put(
-		f"/episodes/{episode_id}",
-		headers=headers,
-		json={
-			"task_completed_at": completed_at,
-			"generation_status": "complete"
+			"task_completed_at": "2026-03-17T10:05:00+00:00",
 		}
 	)
 	assert update_response.status_code == 200
 	data = update_response.json()
-	assert data["task_completed_at"] is not None
-	assert data["generation_status"] == "complete"
-	# task_id should remain from previous update
-	assert data["task_id"] == "abc-123-def-456"
+	assert data["task_id"] is None
+	assert data["task_started_at"] is None
+	assert data["task_completed_at"] is None
 
 
 @pytest.mark.asyncio
-async def test_task_fields_returned_in_get_episode(client, project_and_auth):
-	"""Test that task tracking fields are returned when fetching an episode."""
+async def test_update_ignores_all_system_fields(client, project_and_auth):
+	"""A PUT carrying every system-managed field must not mutate any of them,
+	while user-editable fields in the same request still apply (mass-assignment guard)."""
+	project_id, headers = project_and_auth
+
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "Forge Test", "description": "Desc"}
+	})
+	episode_id = create_response.json()["id"]
+
+	response = await client.put(
+		f"/episodes/{episode_id}",
+		headers=headers,
+		json={
+			"episode_metadata": {"title": "Legit Edit", "description": "Desc"},
+			"generation_status": "complete",
+			"generation_progress": {"stage": "complete", "progress": 100},
+			"s3_key": "user-1/forged.mp3",
+			"s3_url": "https://evil.example/forged.mp3",
+			"duration_seconds": 9999.0,
+			"file_size_bytes": 123456,
+			"file_path": "/etc/passwd",
+			"transcript_path": "/tmp/forged.txt",
+		},
+	)
+	assert response.status_code == 200
+	data = response.json()
+	# User-editable field applied
+	assert data["episode_metadata"]["title"] == "Legit Edit"
+	# Every system field unchanged from creation defaults
+	assert data["generation_status"] == "draft"
+	assert data["generation_progress"] == {}
+	assert data["s3_key"] is None
+	assert data["s3_url"] is None
+	assert data["duration_seconds"] is None
+	assert data["file_size_bytes"] is None
+	assert data["file_path"] is None
+	assert data["transcript_path"] is None
+
+
+def test_episode_allowlist_excludes_system_fields():
+	"""Defense-in-depth: the service allowlist must never include system fields."""
+	from src.services.episode_service import EPISODE_USER_EDITABLE_FIELDS
+
+	system_fields = {
+		"generation_status", "generation_progress", "s3_key", "s3_url",
+		"duration_seconds", "file_size_bytes", "file_path", "transcript_path",
+		"task_id", "task_started_at", "task_completed_at",
+	}
+	assert system_fields.isdisjoint(EPISODE_USER_EDITABLE_FIELDS)
+
+
+@pytest.mark.asyncio
+async def test_task_fields_returned_in_get_episode(client, project_and_auth, set_system_fields):
+	"""Task tracking fields set by the pipeline are returned when fetching an episode."""
 	project_id, headers = project_and_auth
 
 	create_response = await client.post("/episodes", headers=headers, json={
@@ -925,14 +906,11 @@ async def test_task_fields_returned_in_get_episode(client, project_and_auth):
 	episode_id = create_response.json()["id"]
 
 	celery_task_uuid = "deadbeef-dead-beef-dead-beefdeadbeef"
-	await client.put(
-		f"/episodes/{episode_id}",
-		headers=headers,
-		json={
-			"task_id": celery_task_uuid,
-			"task_started_at": "2026-03-17T09:00:00+00:00",
-			"generation_status": "generating"
-		}
+	await set_system_fields(
+		episode_id,
+		task_id=celery_task_uuid,
+		task_started_at=datetime(2026, 3, 17, 9, 0, tzinfo=timezone.utc),
+		generation_status="generating",
 	)
 
 	get_response = await client.get(f"/episodes/{episode_id}", headers=headers)
@@ -944,8 +922,8 @@ async def test_task_fields_returned_in_get_episode(client, project_and_auth):
 
 
 @pytest.mark.asyncio
-async def test_task_fields_in_list_response(client, project_and_auth):
-	"""Test that task tracking fields are included in list responses."""
+async def test_task_fields_in_list_response(client, project_and_auth, set_system_fields):
+	"""Task tracking fields set by the pipeline are included in list responses."""
 	project_id, headers = project_and_auth
 
 	create_response = await client.post("/episodes", headers=headers, json={
@@ -955,11 +933,7 @@ async def test_task_fields_in_list_response(client, project_and_auth):
 	})
 	episode_id = create_response.json()["id"]
 
-	await client.put(
-		f"/episodes/{episode_id}",
-		headers=headers,
-		json={"task_id": "task-uuid-123"}
-	)
+	await set_system_fields(episode_id, task_id="task-uuid-123")
 
 	list_response = await client.get(
 		f"/episodes?project_id={project_id}",
@@ -1078,18 +1052,18 @@ async def test_search_empty_returns_all(client, project_and_auth):
 
 
 @pytest.mark.asyncio
-async def test_filter_by_min_duration(client, project_and_auth):
+async def test_filter_by_min_duration(client, project_and_auth, set_system_fields):
 	"""Test filtering episodes by minimum duration."""
 	project_id, headers = project_and_auth
 
-	# Create episode and set duration via update
+	# Create episode and set duration (system field — set directly)
 	ep1 = await client.post("/episodes", headers=headers, json={
 		"project_id": project_id,
 		"episode_number": 1,
 		"episode_metadata": {"title": "Short", "description": "desc"}
 	})
 	ep1_id = ep1.json()["id"]
-	await client.put(f"/episodes/{ep1_id}", headers=headers, json={"duration_seconds": 60.0})
+	await set_system_fields(ep1_id, duration_seconds=60.0)
 
 	ep2 = await client.post("/episodes", headers=headers, json={
 		"project_id": project_id,
@@ -1097,7 +1071,7 @@ async def test_filter_by_min_duration(client, project_and_auth):
 		"episode_metadata": {"title": "Long", "description": "desc"}
 	})
 	ep2_id = ep2.json()["id"]
-	await client.put(f"/episodes/{ep2_id}", headers=headers, json={"duration_seconds": 3600.0})
+	await set_system_fields(ep2_id, duration_seconds=3600.0)
 
 	response = await client.get(f"/episodes?project_id={project_id}&min_duration=1000", headers=headers)
 	assert response.status_code == 200
@@ -1107,7 +1081,7 @@ async def test_filter_by_min_duration(client, project_and_auth):
 
 
 @pytest.mark.asyncio
-async def test_filter_by_max_duration(client, project_and_auth):
+async def test_filter_by_max_duration(client, project_and_auth, set_system_fields):
 	"""Test filtering episodes by maximum duration."""
 	project_id, headers = project_and_auth
 
@@ -1117,7 +1091,7 @@ async def test_filter_by_max_duration(client, project_and_auth):
 		"episode_metadata": {"title": "Short", "description": "desc"}
 	})
 	ep1_id = ep1.json()["id"]
-	await client.put(f"/episodes/{ep1_id}", headers=headers, json={"duration_seconds": 120.0})
+	await set_system_fields(ep1_id, duration_seconds=120.0)
 
 	ep2 = await client.post("/episodes", headers=headers, json={
 		"project_id": project_id,
@@ -1125,7 +1099,7 @@ async def test_filter_by_max_duration(client, project_and_auth):
 		"episode_metadata": {"title": "Long", "description": "desc"}
 	})
 	ep2_id = ep2.json()["id"]
-	await client.put(f"/episodes/{ep2_id}", headers=headers, json={"duration_seconds": 7200.0})
+	await set_system_fields(ep2_id, duration_seconds=7200.0)
 
 	response = await client.get(f"/episodes?project_id={project_id}&max_duration=500", headers=headers)
 	assert response.status_code == 200
@@ -1204,7 +1178,7 @@ async def test_invalid_sort_order_returns_422(client, project_and_auth):
 
 
 @pytest.mark.asyncio
-async def test_combined_search_and_status_filter(client, project_and_auth):
+async def test_combined_search_and_status_filter(client, project_and_auth, set_system_fields):
 	"""Test combining search query with status filter."""
 	project_id, headers = project_and_auth
 
@@ -1214,7 +1188,7 @@ async def test_combined_search_and_status_filter(client, project_and_auth):
 		"episode_metadata": {"title": "Science Talk", "description": "discussion"}
 	})
 	ep1_id = ep1.json()["id"]
-	await client.put(f"/episodes/{ep1_id}", headers=headers, json={"generation_status": "complete"})
+	await set_system_fields(ep1_id, generation_status="complete")
 
 	await client.post("/episodes", headers=headers, json={
 		"project_id": project_id,

--- a/apps/api/tests/test_projects.py
+++ b/apps/api/tests/test_projects.py
@@ -202,6 +202,43 @@ async def test_update_project_multiple_fields(client, auth_headers):
 
 
 @pytest.mark.asyncio
+async def test_update_project_ignores_ownership_fields(client, auth_headers):
+	"""A PUT carrying ownership/system fields must not reassign them
+	(mass-assignment guard); user-editable fields in the same request still apply."""
+	create_response = await client.post("/projects", headers=auth_headers, json={
+		"name": "Original Name",
+		"podcast_metadata": {
+			"show_title": "Show", "author": "Author", "description": "Desc"
+		}
+	})
+	created = create_response.json()
+	project_id = created["id"]
+	original_user_id = created["user_id"]
+	original_tenant_id = created["tenant_id"]
+
+	response = await client.put(f"/projects/{project_id}", headers=auth_headers, json={
+		"name": "Renamed",
+		"id": str(uuid4()),
+		"user_id": str(uuid4()),
+		"tenant_id": str(uuid4()),
+	})
+	assert response.status_code == 200
+	data = response.json()
+	assert data["name"] == "Renamed"  # user-editable field applied
+	assert data["id"] == project_id  # ownership unchanged
+	assert data["user_id"] == original_user_id
+	assert data["tenant_id"] == original_tenant_id
+
+
+def test_project_allowlist_excludes_ownership_fields():
+	"""Defense-in-depth: the service allowlist must never include ownership/system fields."""
+	from src.services.project_service import PROJECT_USER_EDITABLE_FIELDS
+
+	protected = {"id", "user_id", "tenant_id", "created_at", "updated_at"}
+	assert protected.isdisjoint(PROJECT_USER_EDITABLE_FIELDS)
+
+
+@pytest.mark.asyncio
 async def test_update_nonexistent_project(client, auth_headers):
 	"""Test updating project that doesn't exist."""
 	fake_id = str(uuid4())

--- a/apps/api/tests/test_quality_metrics.py
+++ b/apps/api/tests/test_quality_metrics.py
@@ -491,9 +491,9 @@ async def test_calculate_metrics_full_integration(mock_read, metrics_calculator,
 @pytest.mark.asyncio
 @patch('src.services.quality_metrics_service.QualityMetricsCalculator._read_transcript_file')
 @patch('src.services.quality_metrics_service.get_episode_by_id')
-@patch('src.services.quality_metrics_service.update_episode')
+@patch('src.services.quality_metrics_service.set_episode_system_fields')
 async def test_calculate_and_store_metrics(
-	mock_update, mock_get_episode, mock_read,
+	mock_set_fields, mock_get_episode, mock_read,
 	metrics_calculator, mock_db, sample_episode, balanced_transcript
 ):
 	"""Test metrics calculation and storage in generation_progress JSONB."""
@@ -509,17 +509,17 @@ async def test_calculate_and_store_metrics(
 	# Verify episode was fetched
 	mock_get_episode.assert_called_once_with(mock_db, episode_id)
 
-	# Verify update_episode was called with quality_metrics in generation_progress
-	mock_update.assert_called_once()
-	call_args = mock_update.call_args
+	# generation_progress is system-managed: written via set_episode_system_fields
+	# with the fetched episode object (not via the user-facing update path)
+	mock_set_fields.assert_called_once()
+	call_args = mock_set_fields.call_args
 	assert call_args[0][0] == mock_db
-	assert call_args[0][1] == episode_id
+	assert call_args[0][1] == sample_episode
 
-	updated_data = call_args[0][2]
-	assert "generation_progress" in updated_data
-	assert "quality_metrics" in updated_data["generation_progress"]
+	generation_progress = call_args.kwargs["generation_progress"]
+	assert "quality_metrics" in generation_progress
 
-	quality_metrics = updated_data["generation_progress"]["quality_metrics"]
+	quality_metrics = generation_progress["quality_metrics"]
 	assert quality_metrics["total_words"] == metrics.total_words
 	assert quality_metrics["tone"] == metrics.tone
 	assert quality_metrics["is_balanced"] == metrics.is_balanced

--- a/apps/api/tests/test_quality_metrics_endpoint.py
+++ b/apps/api/tests/test_quality_metrics_endpoint.py
@@ -85,22 +85,58 @@ async def user_project_episode(client):
 
 
 @pytest.fixture
-async def episode_with_metrics(client, user_project_episode):
+async def episode_with_metrics(client, user_project_episode, set_system_fields):
 	"""Episode that has quality metrics stored in generation_progress."""
 	project_id, episode_id, headers = user_project_episode
 
-	# Inject quality metrics via episode update
-	update = await client.put(f"/episodes/{episode_id}", headers=headers, json={
-		"generation_status": "complete",
-		"generation_progress": {
+	# Inject quality metrics (system fields — set as the pipeline does)
+	await set_system_fields(
+		episode_id,
+		generation_status="complete",
+		generation_progress={
 			"stage": "complete",
 			"progress": 100,
 			"quality_metrics": SAMPLE_QUALITY_METRICS,
 		},
-	})
-	assert update.status_code == 200
+	)
 
 	return project_id, episode_id, headers
+
+
+@pytest.mark.asyncio
+async def test_store_metrics_persists_alongside_existing_progress(
+	client, user_project_episode, set_system_fields, test_db
+):
+	"""Regression (#271 review): storing quality metrics must persist even when the
+	episode already has a non-empty generation_progress. generation_progress is a
+	plain JSONB column, so the writer must build a NEW dict — mutating the existing
+	dict in place and reassigning the same reference would not register as a change
+	and the metrics would silently fail to commit."""
+	from unittest.mock import AsyncMock, MagicMock, patch
+	from uuid import UUID
+	from src.services.quality_metrics_service import QualityMetricsCalculator
+	from src.services.episode_service import get_episode_by_id
+
+	_, episode_id, _ = user_project_episode
+
+	# Episode already carries pipeline progress before metrics are calculated
+	await set_system_fields(
+		episode_id,
+		generation_progress={"stage": "complete", "progress": 100},
+	)
+
+	fake_metrics = MagicMock()
+	fake_metrics.to_dict.return_value = SAMPLE_QUALITY_METRICS
+	with patch.object(
+		QualityMetricsCalculator, "calculate_metrics",
+		new=AsyncMock(return_value=fake_metrics),
+	):
+		await QualityMetricsCalculator().calculate_and_store_metrics(test_db, episode_id)
+
+	# Re-fetch from the DB: both the pre-existing progress and the new metrics survive
+	episode = await get_episode_by_id(test_db, UUID(episode_id))
+	assert episode.generation_progress.get("stage") == "complete"  # preserved
+	assert episode.generation_progress.get("quality_metrics") == SAMPLE_QUALITY_METRICS
 
 
 # ============================================================================
@@ -261,16 +297,14 @@ async def test_get_project_quality_metrics_with_episodes(client, episode_with_me
 
 
 @pytest.mark.asyncio
-async def test_get_project_quality_metrics_multiple_episodes(client, user_project_episode):
+async def test_get_project_quality_metrics_multiple_episodes(client, user_project_episode, set_system_fields):
 	"""Test aggregation with multiple episodes having different quality metrics."""
 	project_id, episode_id, headers = user_project_episode
 
 	# Update first episode with good metrics
-	await client.put(f"/episodes/{episode_id}", headers=headers, json={
-		"generation_progress": {
-			"stage": "complete",
-			"quality_metrics": SAMPLE_QUALITY_METRICS,
-		},
+	await set_system_fields(episode_id, generation_progress={
+		"stage": "complete",
+		"quality_metrics": SAMPLE_QUALITY_METRICS,
 	})
 
 	# Create a second episode with poor metrics
@@ -283,11 +317,9 @@ async def test_get_project_quality_metrics_multiple_episodes(client, user_projec
 		},
 	})
 	ep2_id = ep2.json()["id"]
-	await client.put(f"/episodes/{ep2_id}", headers=headers, json={
-		"generation_progress": {
-			"stage": "complete",
-			"quality_metrics": POOR_QUALITY_METRICS,
-		},
+	await set_system_fields(ep2_id, generation_progress={
+		"stage": "complete",
+		"quality_metrics": POOR_QUALITY_METRICS,
 	})
 
 	response = await client.get(
@@ -363,16 +395,14 @@ async def test_list_project_episode_metrics_with_data(client, episode_with_metri
 
 
 @pytest.mark.asyncio
-async def test_list_project_episode_metrics_pagination(client, user_project_episode):
+async def test_list_project_episode_metrics_pagination(client, user_project_episode, set_system_fields):
 	"""Test pagination parameters."""
 	project_id, episode_id, headers = user_project_episode
 
 	# Add metrics to episode 1
-	await client.put(f"/episodes/{episode_id}", headers=headers, json={
-		"generation_progress": {
-			"stage": "complete",
-			"quality_metrics": SAMPLE_QUALITY_METRICS,
-		},
+	await set_system_fields(episode_id, generation_progress={
+		"stage": "complete",
+		"quality_metrics": SAMPLE_QUALITY_METRICS,
 	})
 
 	# Create episodes 2 and 3 with metrics
@@ -385,11 +415,9 @@ async def test_list_project_episode_metrics_pagination(client, user_project_epis
 				"description": f"Description {i}",
 			},
 		})
-		await client.put(f"/episodes/{ep.json()['id']}", headers=headers, json={
-			"generation_progress": {
-				"stage": "complete",
-				"quality_metrics": SAMPLE_QUALITY_METRICS,
-			},
+		await set_system_fields(ep.json()["id"], generation_progress={
+			"stage": "complete",
+			"quality_metrics": SAMPLE_QUALITY_METRICS,
 		})
 
 	# Page 1 with page_size=2
@@ -417,16 +445,14 @@ async def test_list_project_episode_metrics_pagination(client, user_project_epis
 
 
 @pytest.mark.asyncio
-async def test_list_project_episode_metrics_sort_by_overall_score(client, user_project_episode):
+async def test_list_project_episode_metrics_sort_by_overall_score(client, user_project_episode, set_system_fields):
 	"""Test sorting by overall_score."""
 	project_id, episode_id, headers = user_project_episode
 
 	# Good episode
-	await client.put(f"/episodes/{episode_id}", headers=headers, json={
-		"generation_progress": {
-			"stage": "complete",
-			"quality_metrics": SAMPLE_QUALITY_METRICS,
-		},
+	await set_system_fields(episode_id, generation_progress={
+		"stage": "complete",
+		"quality_metrics": SAMPLE_QUALITY_METRICS,
 	})
 
 	# Poor episode
@@ -438,11 +464,9 @@ async def test_list_project_episode_metrics_sort_by_overall_score(client, user_p
 			"description": "Poor quality",
 		},
 	})
-	await client.put(f"/episodes/{ep2.json()['id']}", headers=headers, json={
-		"generation_progress": {
-			"stage": "complete",
-			"quality_metrics": POOR_QUALITY_METRICS,
-		},
+	await set_system_fields(ep2.json()["id"], generation_progress={
+		"stage": "complete",
+		"quality_metrics": POOR_QUALITY_METRICS,
 	})
 
 	# Sort descending by overall_score (best first)

--- a/apps/api/tests/test_script_generation.py
+++ b/apps/api/tests/test_script_generation.py
@@ -160,7 +160,7 @@ async def test_generate_script_success(
 	"""Test successful script generation with valid transcript."""
 	with patch('src.services.script_generation_service.get_episode_by_id') as mock_get_episode, \
 		 patch('src.services.script_generation_service.get_content_sources') as mock_get_sources, \
-		 patch('src.services.script_generation_service.update_episode') as mock_update_episode, \
+		 patch('src.services.script_generation_service.set_episode_system_fields') as mock_update_episode, \
 		 patch('src.services.script_generation_service.update_generation_status') as mock_update_status, \
 		 patch.object(generation_service, '_call_gemini_api', return_value=valid_transcript) as mock_gemini, \
 		 patch('builtins.open', mock_open()):
@@ -221,7 +221,7 @@ async def test_generate_script_with_template_config(
 
 	with patch('src.services.script_generation_service.get_episode_by_id') as mock_get_episode, \
 		 patch('src.services.script_generation_service.get_content_sources') as mock_get_sources, \
-		 patch('src.services.script_generation_service.update_episode'), \
+		 patch('src.services.script_generation_service.set_episode_system_fields'), \
 		 patch('src.services.script_generation_service.update_generation_status'), \
 		 patch.object(generation_service, '_call_gemini_api', return_value=valid_transcript) as mock_gemini, \
 		 patch('builtins.open', mock_open()):
@@ -254,7 +254,7 @@ async def test_generate_script_longform(
 	"""Test long-form script generation."""
 	with patch('src.services.script_generation_service.get_episode_by_id') as mock_get_episode, \
 		 patch('src.services.script_generation_service.get_content_sources') as mock_get_sources, \
-		 patch('src.services.script_generation_service.update_episode'), \
+		 patch('src.services.script_generation_service.set_episode_system_fields'), \
 		 patch('src.services.script_generation_service.update_generation_status'), \
 		 patch.object(generation_service, '_call_gemini_api', return_value=valid_transcript) as mock_gemini, \
 		 patch('builtins.open', mock_open()):
@@ -291,7 +291,7 @@ async def test_status_transition_draft_to_complete(
 	"""Test status transitions: draft → queued → generating → complete."""
 	with patch('src.services.script_generation_service.get_episode_by_id') as mock_get_episode, \
 		 patch('src.services.script_generation_service.get_content_sources') as mock_get_sources, \
-		 patch('src.services.script_generation_service.update_episode'), \
+		 patch('src.services.script_generation_service.set_episode_system_fields'), \
 		 patch('src.services.script_generation_service.update_generation_status') as mock_update_status, \
 		 patch.object(generation_service, '_call_gemini_api', return_value=valid_transcript), \
 		 patch('builtins.open', mock_open()):
@@ -317,7 +317,7 @@ async def test_status_transition_queued_to_complete(
 	"""Test status transitions from queued: queued → generating → complete."""
 	with patch('src.services.script_generation_service.get_episode_by_id') as mock_get_episode, \
 		 patch('src.services.script_generation_service.get_content_sources') as mock_get_sources, \
-		 patch('src.services.script_generation_service.update_episode'), \
+		 patch('src.services.script_generation_service.set_episode_system_fields'), \
 		 patch('src.services.script_generation_service.update_generation_status') as mock_update_status, \
 		 patch.object(generation_service, '_call_gemini_api', return_value=valid_transcript), \
 		 patch('builtins.open', mock_open()):
@@ -398,7 +398,7 @@ async def test_generate_script_empty_content(
 
 	with patch('src.services.script_generation_service.get_episode_by_id') as mock_get_episode, \
 		 patch('src.services.script_generation_service.get_content_sources') as mock_get_sources, \
-		 patch('src.services.script_generation_service.update_episode'), \
+		 patch('src.services.script_generation_service.set_episode_system_fields'), \
 		 patch('src.services.script_generation_service.update_generation_status') as mock_update_status:
 
 		mock_get_episode.return_value = draft_episode
@@ -518,7 +518,7 @@ async def test_generate_script_multiple_sources(
 	"""Test script generation with multiple content sources."""
 	with patch('src.services.script_generation_service.get_episode_by_id') as mock_get_episode, \
 		 patch('src.services.script_generation_service.get_content_sources') as mock_get_sources, \
-		 patch('src.services.script_generation_service.update_episode'), \
+		 patch('src.services.script_generation_service.set_episode_system_fields'), \
 		 patch('src.services.script_generation_service.update_generation_status'), \
 		 patch.object(generation_service, '_call_gemini_api', return_value=valid_transcript) as mock_gemini, \
 		 patch('builtins.open', mock_open()):
@@ -714,7 +714,7 @@ async def test_generation_progress_updates(
 	"""Test generation_progress JSONB is updated correctly."""
 	with patch('src.services.script_generation_service.get_episode_by_id') as mock_get_episode, \
 		 patch('src.services.script_generation_service.get_content_sources') as mock_get_sources, \
-		 patch('src.services.script_generation_service.update_episode'), \
+		 patch('src.services.script_generation_service.set_episode_system_fields'), \
 		 patch('src.services.script_generation_service.update_generation_status') as mock_update_status, \
 		 patch.object(generation_service, '_call_gemini_api', return_value=valid_transcript), \
 		 patch('builtins.open', mock_open()):
@@ -1023,7 +1023,7 @@ async def test_generate_script_retry_on_validation_failure(
 
 	with patch('src.services.script_generation_service.get_episode_by_id') as mock_get_episode, \
 		 patch('src.services.script_generation_service.get_content_sources') as mock_get_sources, \
-		 patch('src.services.script_generation_service.update_episode'), \
+		 patch('src.services.script_generation_service.set_episode_system_fields'), \
 		 patch('src.services.script_generation_service.update_generation_status'), \
 		 patch.object(generation_service, '_call_gemini_api', side_effect=side_effects) as mock_gemini, \
 		 patch('builtins.open', mock_open()):

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,49 +1,41 @@
-# Issue #225 — docs: rewrite CLAUDE.md/README for the SaaS monorepo; fix refs, auth, JWT drift; remove cruft & IP
+# Issue #271 — Restrict episode/project update to user-editable fields (mass-assignment)
 
-Plan source: issue body (acceptance criteria). Verified against current repo 2026-06-22.
+Branch: `advisor/005-restrict-update-mass-assignment`
+Plan source: issue body + `plans/005-restrict-update-mass-assignment.md` (no drift vs defc572)
 
-## Steps
+## Key adaptation vs the written plan
+The plan assumed only the Celery pipeline (`tasks/callbacks.py`) writes system fields and
+that nothing internal uses `update_episode`. **Two internal callers actually write system
+fields through `update_episode`:**
+- `script_generation_service.py:220` → `transcript_path`
+- `quality_metrics_service.py:193` → `generation_progress` — **already broken**: calls
+  `update_episode(db, episode_id, {dict})` but the signature is `(db, episode, EpisodeUpdate)`;
+  `dict.model_dump()` would raise in production (only passes today because the test mocks it).
 
-1. **Rewrite `CLAUDE.md` for the monorepo**
-   - Describe PodcastStudioHub SaaS monorepo: `apps/api` (FastAPI + Celery + Postgres + Alembic + JWT auth), `apps/web` (Next.js), `deployment/`.
-   - Add a scoped **Upstream Podcastfy Engine** subsection for the root `podcastfy/` package (keep useful engine details, clearly scoped).
-   - Fix dev commands to target the monorepo, not the upstream engine.
+So a blanket allowlist on `update_episode` would silently drop these legitimate writes.
+Adaptation: give the pipeline a dedicated `set_episode_system_fields()` writer and reserve
+`update_episode` (allowlisted) for the public endpoint. This also fixes the latent bug.
 
-2. **Fix `README.md` dead refs + auth wording**
-   - `requirements.txt` (line 110) → drop pip line, `uv sync` only.
-   - `docker-compose.yml` (tree line 291) → remove.
-   - `deployment/QUICKSTART.md` & `DEPLOYMENT.md` (tree 274-275) → `deployment/README.md`.
-   - `UPSTREAM_SYNC.md` (420/423) → remove dead refs, inline the note.
-   - Auth: lines 13 & 70 "session-based" / "session management" → JWT-based.
+## Steps (TDD)
+- [ ] **Schema** `schemas/episode.py`: `EpisodeUpdate` keeps only user-editable fields —
+      `episode_number`, `episode_metadata`, `tts_config_id`, `template_id`. Remove
+      `generation_status`, `generation_progress`, `s3_key`, `s3_url`, `duration_seconds`,
+      `file_size_bytes`, `file_path`, `transcript_path`, `task_id`, `task_started_at`,
+      `task_completed_at`.
+- [ ] **episode_service.py**: add `EPISODE_USER_EDITABLE_FIELDS` constant; filter in
+      `update_episode` (defense-in-depth). Add `set_episode_system_fields(db, episode, **fields)`
+      internal helper.
+- [ ] **script_generation_service.py:220-221**: write `transcript_path` via
+      `set_episode_system_fields`.
+- [ ] **quality_metrics_service.py:193**: write `generation_progress` via
+      `set_episode_system_fields` (fixes broken signature).
+- [ ] **project_service.py**: add `PROJECT_USER_EDITABLE_FIELDS` allowlist + filter in
+      `update_project`. `ProjectUpdate` schema unchanged (all 6 fields are user-editable).
+- [ ] **Tests**: episodes — PUT system fields ⇒ columns unchanged; user-editable update works.
+      projects — allowlist holds; normal update works. Update `test_quality_metrics` for the
+      new `set_episode_system_fields` call. Confirm `test_script_generation` still passes.
+- [ ] Verify: `uv run pytest tests/ -k "episode or project or quality or script" -q` + `ruff check .`
+- [ ] Update `plans/README.md` status row.
 
-3. **Fix JWT_ALGORITHM drift** — root `.env.example:17` `RS256` → `HS256` (matches `apps/api/src/config.py:33`). Keep file.
-
-4. **Replace hardcoded IP `47.88.89.175`** with `<SERVER_IP>` placeholder:
-   - `README.md` (1), `deployment/README.md` (30), `.github/DEPLOYMENT_SETUP.md` (4).
-
-5. **Remove dev cruft** (git rm tracked):
-   - `smoke-test-report-2025-11-11.md`, `schema-comparison-report-2025-11-11.md`, `coverage/combined-coverage-report.md`
-   - `TESTING_AUTOMATION_ANALYSIS.md`, `TESTING_GUIDE.md`, `TESTING_GUIDE_MANUAL.md`
-   - `apps/api/check_indexes.py`, `apps/api/verify_schema.py`, `apps/api/test_basic_operations.py`
-   - `apps/api/.apm/` (stray placeholder — 2 files)
-   - rm gitignored working-tree `demo.md` (root, apps/web, apps/api)
-
-6. **gitignore runtime output dirs** — add `coverage/`, `test-results/`, `playwright-report/`, `/data/` to `.gitignore`.
-   - `__pycache__/` already ignored; rm stale working dirs locally (no repo change).
-
-## Acceptance criteria
-- [ ] CLAUDE.md describes monorepo + scoped upstream-engine subsection
-- [ ] README dead refs fixed; auth described as JWT
-- [ ] root .env.example HS256
-- [ ] hardcoded IP replaced everywhere
-- [ ] dated reports, demo.md, apps/api scratch scripts deleted
-- [ ] coverage/, data/, test-results/, playwright-report/ gitignored
-- [ ] empty .apm placeholder deleted; stale __pycache__ handled
-
-## Deviations / notes
-- `TESTING_*.md`: issue groups as cruft; stale Nov-2025 guides → delete per issue.
-- Root `.env.example` kept & fixed (not deleted) — only full-stack example with Postgres/Redis/NextAuth vars.
-- `data/` has committed upstream sample mp3s; gitignore prevents new runtime data only, won't untrack samples.
-- `__pycache__` already gitignored — no repo change needed.
-- Root `.apm/` left intact; only stray `apps/api/.apm/` removed.
-- Docs-drift root cause (m13v comment) → out of scope of acceptance criteria; noted as Known Limitation, no regen/CI guard built (YAGNI).
+## Out of scope (unchanged)
+`tasks/**` (sync Celery writers via `_update_episode`), DB columns, auth/ownership.


### PR DESCRIPTION
## Summary

Fixes a **mass-assignment** vulnerability (#271). `EpisodeUpdate` exposed system-managed
fields and both `update_episode` / `update_project` wrote every provided field via a blind
`setattr` loop. An authenticated user could `PUT` an episode forging
`generation_status: "completed"`, `s3_key`, `duration_seconds`, `task_*`, etc. — lying to the
rest of the system about generation outcomes (bounded to their own tenant by RLS, but
illegitimate).

## What changed

- **Schema** — `EpisodeUpdate` now declares only user-editable fields: `episode_number`,
  `episode_metadata`, `tts_config_id`, `template_id`. All system fields removed.
- **Service allowlists (defense-in-depth)** — `EPISODE_USER_EDITABLE_FIELDS` /
  `PROJECT_USER_EDITABLE_FIELDS` filter every update before `setattr`, so a system field
  re-added to a schema in future stays unwritable until deliberately allowlisted.
- **Pipeline writer** — added `set_episode_system_fields()` for the generation pipeline's
  legitimate system-field writes. `script_generation_service` (`transcript_path`) and
  `quality_metrics_service` (`generation_progress`) now route through it.

## Adaptation vs. the written plan

The plan (`plans/005`) assumed only the Celery pipeline (`tasks/callbacks.py`) writes system
fields. In fact **two internal services wrote system fields through `update_episode`**, so a
blanket allowlist would have silently dropped legitimate writes. The dedicated
`set_episode_system_fields()` path resolves this and also **fixes a latent production bug**:
`quality_metrics_service` was calling `update_episode(db, episode_id, {dict})` — the wrong
signature (`dict.model_dump()` would raise); it only "passed" because the test mocked it.

## Production writers unaffected

Every system field is written directly on the episode object in `tasks/**`,
`routers/generation.py`, and `routers/content.py` — never via the public PUT endpoint — so
trimming the schema breaks no real flow. Verified by grep across `src/`.

## Tests

- New: every system field is unwritable via `PUT /episodes` and ownership fields via
  `PUT /projects` (mass-assignment guards); allowlist-constant guards; a real-DB regression
  for the JSONB persistence fix below.
- Test setup that abused the PUT backdoor to seed pipeline state now uses a shared
  `set_system_fields` conftest fixture (the same path the pipeline uses).
- **1500 backend tests pass.** (One unrelated, pre-existing failure —
  `test_audio_snippets.py::test_download_url_no_s3_config`, a stale mock target — fails
  identically on clean `main`; out of scope.)

## Review

Local cross-family `codex review` (vs `main`) flagged one [P2]: `quality_metrics_service`
mutated `episode.generation_progress` in place and reassigned the same reference, which a
plain JSONB column won't detect as a change → metrics could fail to persist. Fixed by
building a new dict; added a real-DB regression test that fails on the aliasing version and
passes on the fix.

## Known limitations

- Pre-existing `ruff check .` debt (17 findings) lives in unrelated files; all files changed
  here are ruff-clean. Not addressed to keep this PR focused.

Closes #271
