### PR TITLE
fix(api): stop returning raw exception text in HTTP error responses (#270)

### DIFF
--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -102,10 +102,11 @@ async def register(
     except HTTPException:
         # Re-raise HTTPExceptions from create_user (duplicate email, etc.)
         raise
-    except Exception as e:
+    except Exception:
+        logger.exception("Registration failed")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Registration failed: {str(e)}"
+            detail="Registration failed. Please try again."
         )
 
 

--- a/apps/api/src/routers/rss_feed.py
+++ b/apps/api/src/routers/rss_feed.py
@@ -6,6 +6,8 @@ feeds. The public feed endpoint requires no authentication, while management
 endpoints require a valid JWT token.
 """
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,6 +19,8 @@ from ..models import User
 from ..schemas.rss_feed import RSSFeedResponse, RSSFeedUpdate
 from ..services.rss_generation_service import RSSGenerationService
 from ..services.project_service import get_project_by_id
+
+logger = logging.getLogger(__name__)
 
 # Authenticated management endpoints nested under /projects
 router = APIRouter(tags=["rss-feed"])
@@ -85,10 +89,11 @@ async def generate_rss_feed(
 			status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
 			detail=str(e),
 		)
-	except Exception as e:
+	except Exception:
+		logger.exception("Failed to generate RSS feed for project %s", project_id)
 		raise HTTPException(
 			status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-			detail=f"Failed to generate RSS feed: {str(e)}",
+			detail="Failed to generate RSS feed.",
 		)
 
 	return rss_feed
@@ -197,10 +202,11 @@ async def update_rss_feed(
 			status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
 			detail=str(e),
 		)
-	except Exception as e:
+	except Exception:
+		logger.exception("Failed to regenerate RSS feed for project %s", project_id)
 		raise HTTPException(
 			status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-			detail=f"Failed to regenerate RSS feed: {str(e)}",
+			detail="Failed to regenerate RSS feed.",
 		)
 
 	return rss_feed
@@ -248,10 +254,11 @@ async def get_public_rss_feed(
 	# Fetch XML from S3
 	try:
 		xml_content = await _fetch_rss_from_s3(rss_service, rss_feed.s3_key)
-	except Exception as e:
+	except Exception:
+		logger.exception("Failed to fetch RSS feed for project %s", project_id)
 		raise HTTPException(
 			status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-			detail=f"Failed to fetch RSS feed: {str(e)}",
+			detail="Failed to fetch RSS feed.",
 		)
 
 	return Response(

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -212,6 +212,27 @@ async def test_register_success(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_register_internal_error_hides_details(client: AsyncClient):
+    """500 from an unexpected error returns a generic message, not exception internals."""
+    from unittest.mock import patch
+
+    secret = "asyncpg UniqueViolationError users_email_key constraint"
+    with patch("src.routers.auth.create_user", side_effect=RuntimeError(secret)):
+        response = await client.post(
+            "/auth/register",
+            json={
+                "email": "boom@example.com",
+                "password": "SecurePass123!",
+                "full_name": "Boom User",
+            },
+        )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Registration failed. Please try again."
+    assert secret not in response.text
+
+
+@pytest.mark.asyncio
 async def test_register_duplicate_email(client: AsyncClient):
     """Test registration with duplicate email"""
     user_data = {

--- a/apps/api/tests/test_rss_feed.py
+++ b/apps/api/tests/test_rss_feed.py
@@ -164,6 +164,27 @@ async def test_generate_rss_feed_invalid_metadata(client, project_with_metadata)
 	assert "show_title" in response.json()["detail"]
 
 
+@pytest.mark.asyncio
+async def test_generate_rss_feed_internal_error_hides_details(client, project_with_metadata):
+	"""500 from an unexpected error returns a generic message, not exception internals."""
+	project_id, headers = project_with_metadata
+	secret = "boto3 AccessDenied arn:aws:s3:::secret-bucket"
+
+	with patch("src.routers.rss_feed.RSSGenerationService") as MockService:
+		mock_instance = AsyncMock()
+		mock_instance.generate_rss_for_project.side_effect = RuntimeError(secret)
+		MockService.return_value = mock_instance
+
+		response = await client.post(
+			f"/projects/{project_id}/rss-feed/generate",
+			headers=headers,
+		)
+
+	assert response.status_code == 500
+	assert response.json()["detail"] == "Failed to generate RSS feed."
+	assert secret not in response.text
+
+
 # ============================================================================
 # GET /projects/{project_id}/rss-feed
 # ============================================================================
@@ -295,6 +316,28 @@ async def test_update_rss_feed_requires_auth(client, project_with_metadata):
 	assert response.status_code == 401
 
 
+@pytest.mark.asyncio
+async def test_update_rss_feed_internal_error_hides_details(client, project_with_metadata):
+	"""500 during regeneration returns a generic message, not exception internals."""
+	project_id, headers = project_with_metadata
+	secret = "psycopg constraint rss_feeds_pkey violated"
+
+	with patch("src.routers.rss_feed.RSSGenerationService") as MockService:
+		mock_instance = AsyncMock()
+		mock_instance.generate_rss_for_project.side_effect = RuntimeError(secret)
+		MockService.return_value = mock_instance
+
+		response = await client.put(
+			f"/projects/{project_id}/rss-feed",
+			headers=headers,
+			json={"podcast_metadata": {"show_title": "New Title"}},
+		)
+
+	assert response.status_code == 500
+	assert response.json()["detail"] == "Failed to regenerate RSS feed."
+	assert secret not in response.text
+
+
 # ============================================================================
 # GET /feeds/{project_id}/podcast.xml (public endpoint)
 # ============================================================================
@@ -356,6 +399,26 @@ async def test_public_feed_not_found_when_no_feed(client, project_with_metadata)
 
 	assert response.status_code == 404
 	assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_public_feed_internal_error_hides_details(client, project_with_metadata):
+	"""500 while fetching from S3 returns a generic message, not exception internals."""
+	project_id, _ = project_with_metadata
+	secret = "S3 NoSuchKey rss-feeds/internal/path.xml"
+	mock_feed = make_mock_rss_feed(project_id)
+
+	with patch("src.routers.rss_feed.RSSGenerationService") as MockService, \
+	     patch("src.routers.rss_feed._fetch_rss_from_s3", new=AsyncMock(side_effect=RuntimeError(secret))):
+		mock_instance = AsyncMock()
+		mock_instance.get_rss_feed.return_value = mock_feed
+		MockService.return_value = mock_instance
+
+		response = await client.get(f"/feeds/{project_id}/podcast.xml")
+
+	assert response.status_code == 500
+	assert response.json()["detail"] == "Failed to fetch RSS feed."
+	assert secret not in response.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Several API endpoints interpolated the raw exception message (`str(e)`) into the HTTP response `detail`, leaking internal implementation details to clients — DB constraint names, S3/boto error strings, XML parser errors, library internals. This logs the full error server-side (operators keep their debugging signal) and returns a generic, static message to the client.

Closes #270.

## Changes

| File | Before | After |
|------|--------|-------|
| `routers/auth.py` (register 500) | `detail=f"Registration failed: {str(e)}"` | `logger.exception(...)` + `"Registration failed. Please try again."` |
| `routers/rss_feed.py` (generate / regenerate / public-fetch 500s) | `detail=f"...: {str(e)}"` | module `logger` + `logger.exception(...)` + static `detail` |

Left untouched per the plan: the `ValueError` → 422 branches (intentional validation messages), re-raised `HTTPException`s, and `content.py:412` (already a safe static message).

## Tests

Added one test per fixed path that forces a generic `Exception` carrying a sentinel secret string and asserts:
- status code unchanged (500),
- `detail` equals the static message,
- the sentinel does **not** appear anywhere in the response body.

These fail against the old code (the secret was previously interpolated into `detail`).

`uv run pytest -k "auth or rss"` → **78 passed**. `ruff check` clean. Cross-family `codex review` found no issues.

## Verification
- `grep -rn 'detail=f.*str(e)' apps/api/src/routers/` → no matches.
