### PR TITLE
chore(web): remove unused lucide-react dependency (#267)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,7 +28,6 @@
     "@tanstack/react-query": "^5.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "^0.469.0",
     "next": "^15.5.14",
     "next-auth": "^4.24.0",
     "react": "^19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "@tanstack/react-query": "^5.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^0.469.0",
         "next": "^15.5.14",
         "next-auth": "^4.24.0",
         "react": "^19",
@@ -1360,15 +1359,6 @@
         "canvas": {
           "optional": true
         }
-      }
-    },
-    "apps/web/node_modules/lucide-react": {
-      "version": "0.469.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.469.0.tgz",
-      "integrity": "sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "apps/web/node_modules/next": {
@@ -10368,7 +10358,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },


### PR DESCRIPTION
## Summary
`lucide-react` was declared in `apps/web/package.json` but imported nowhere, and the repo's own ESLint config bans it in favor of `@hugeicons/react`. This removes the dead, explicitly-forbidden dependency and prunes it from the root lockfile.

## Changes
- Remove `"lucide-react": "^0.469.0"` from `apps/web/package.json`
- `npm install` pruned it from the root `package-lock.json` (`removed 1 package`)

## Verification
- `grep -rn lucide-react apps/web/src` → 0 matches (unchanged)
- `npm run lint` → ✔ No ESLint warnings or errors
- `npm run build` → ✓ compiled successfully

## Known Limitations
None. Manifest + lockfile only; no source files touched.

Closes #267