### PR TITLE
docs: correct stale Next.js/React version claims (15/19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ podcaststudiohub/
 │   │   ├── alembic/      # DB migrations (versions/ up to 012_…)
 │   │   ├── tests/        # pytest + pytest-bdd
 │   │   └── pyproject.toml
-│   └── web/              # Next.js 14 frontend (TypeScript, App Router)
+│   └── web/              # Next.js 15 frontend (TypeScript, App Router)
 │       └── src/          # app/, components/, hooks/, lib/, types/, middleware.ts
 ├── deployment/           # VPS deploy: nginx/, scripts/, tests/, README.md (PM2 + nginx)
 ├── tests/e2e/            # Playwright end-to-end tests
@@ -43,7 +43,7 @@ podcaststudiohub/
 
 ### Frontend (`apps/web`)
 
-- **Next.js 14** App Router, TypeScript, **Tailwind + Shadcn/UI**, TanStack Query.
+- **Next.js 15** App Router, TypeScript, **Tailwind + Shadcn/UI**, TanStack Query.
 - Auth: the backend issues JWTs; authenticated browser calls and SSE go through a server-side
   `/api/proxy` Route Handler so the JWT is never exposed to the client.
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ podcaststudiohub/
 - Podcastfy v0.4.1 for podcast generation
 
 **Frontend (Next.js)**
-- Next.js 14 (App Router)
+- Next.js 15 (App Router)
 - TypeScript
-- React 18
+- React 19
 - Tailwind CSS + Shadcn/UI components
 - NextAuth.js for authentication
 - TanStack Query for data fetching


### PR DESCRIPTION
## Summary
Docs claimed **Next.js 14 / React 18**, but `apps/web/package.json` pins **Next.js 15 / React 19**. Stale version docs send contributors to the wrong migration/API references. This aligns the docs with the authoritative manifest.

## Changes
- `README.md:46` — Next.js 14 → **15** (App Router)
- `README.md:48` — React 18 → **19**
- `CLAUDE.md:26` — "Next.js 14 frontend" → **15**
- `CLAUDE.md:46` — "**Next.js 14** App Router" → **15**

Docs-only. No code, config, or `package.json` changes.

## Verification (outcome evidence)
- `grep -rn "Next.js 14\|React 18" README.md CLAUDE.md` → **no matches** (was 4)
- `grep -n "Next.js 15\|React 19" README.md CLAUDE.md` → corrected lines present
- Repo-wide `*.md` scan → no other stale instances
- Numbers match `apps/web/package.json`: `"next": "^15.5.14"`, `"react": "^19"`

## Known Limitations
None. Reviewer note: re-confirm numbers match `apps/web/package.json` at merge time (per plan 003 maintenance note).

Closes #269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation to reflect a newer frontend stack.
  * Revised the tech stack details to show Next.js 15 and React 19.
  * Aligned architecture and frontend section references with the latest version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->