### PR TITLE
fix(tasks): delete composed audio temp file after S3 upload

### DIFF
--- a/apps/api/src/tasks/s3_upload.py
+++ b/apps/api/src/tasks/s3_upload.py
@@ -117,8 +117,10 @@ def upload_to_s3_task(
             "SignatureDoesNotMatch", "AccessDenied",
         })
         if error_code in NON_RETRYABLE_CODES:
-            # Permanent errors are never retried.
+            # Permanent errors are never retried — terminal failure, so the temp
+            # artifact is disposable (re-running generation re-composes it).
             logger.error(f"S3 upload failed with non-retryable error ({error_code}): {e}")
+            _cleanup_temp_file(file_path)
             raise
         # Retryable S3 error — retry with exponential backoff
         logger.warning(

--- a/apps/api/src/tasks/s3_upload.py
+++ b/apps/api/src/tasks/s3_upload.py
@@ -2,6 +2,7 @@
 Celery tasks for S3 file uploads
 """
 import os
+import tempfile
 import logging
 from celery import Task
 from typing import Dict, Any
@@ -14,6 +15,24 @@ from src.config import settings
 from src.tasks.retry_utils import calculate_backoff
 
 logger = logging.getLogger(__name__)
+
+
+def _cleanup_temp_file(file_path: str) -> None:
+    """Best-effort delete of a temp upload artifact once it is no longer needed.
+
+    Only removes files under the system temp dir so it can never delete a
+    persistent file (e.g. under ``data/``); never raises. Call this only when the
+    local copy is disposable: after a successful upload, or after retries are
+    exhausted (no further retry will read it) — never on the retry path.
+    """
+    try:
+        temp_root = os.path.realpath(tempfile.gettempdir())
+        real = os.path.realpath(file_path)
+        if os.path.commonpath([temp_root, real]) == temp_root and os.path.isfile(real):
+            os.remove(real)
+            logger.info("Removed temp upload artifact: %s", real)
+    except Exception as exc:  # cleanup must never fail the task
+        logger.warning("Failed to clean up temp file %s: %s", file_path, exc)
 
 
 @celery_app.task(bind=True, name="upload_to_s3", time_limit=300, max_retries=3)
@@ -80,6 +99,9 @@ def upload_to_s3_task(
         else:
             s3_url = f"https://{bucket_name}.s3.{region}.amazonaws.com/{s3_key}"
 
+        # Upload succeeded — the local copy is now disposable.
+        _cleanup_temp_file(file_path)
+
         return {
             "status": "success",
             "s3_key": s3_key,
@@ -107,6 +129,9 @@ def upload_to_s3_task(
             raise self.retry(exc=e, countdown=calculate_backoff(self.request.retries))
         except self.MaxRetriesExceededError:
             logger.error(f"S3 upload failed after {self.max_retries} retries for {file_path}: {e}")
+            # Retries exhausted — no further retry will read the file, so the temp
+            # artifact is disposable. Without this, the failed tail leaks /tmp too.
+            _cleanup_temp_file(file_path)
             return {
                 "status": "failed",
                 "s3_key": None,
@@ -124,6 +149,9 @@ def upload_to_s3_task(
             raise self.retry(exc=e, countdown=calculate_backoff(self.request.retries))
         except self.MaxRetriesExceededError:
             logger.error(f"S3 upload failed after {self.max_retries} retries for {file_path}: {e}")
+            # Retries exhausted — no further retry will read the file, so the temp
+            # artifact is disposable. Without this, the failed tail leaks /tmp too.
+            _cleanup_temp_file(file_path)
             return {
                 "status": "failed",
                 "s3_key": None,

--- a/apps/api/tests/test_s3_upload.py
+++ b/apps/api/tests/test_s3_upload.py
@@ -725,3 +725,36 @@ class TestTempFileCleanup:
         finally:
             if os.path.exists(path):
                 os.remove(path)
+
+    def test_temp_file_deleted_on_non_retryable_error(self):
+        """Non-retryable failure (e.g. AccessDenied) is terminal — it raises and
+        no retry follows, so the temp artifact must still be cleaned up."""
+        path = self._make_temp_file()
+        try:
+            client_error = ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+                "PutObject",
+            )
+            with (
+                patch("src.tasks.s3_upload.settings") as mock_settings,
+                patch("src.tasks.s3_upload.boto3") as mock_boto,
+                patch("src.tasks.s3_upload.os.path.getsize", return_value=16),
+            ):
+                mock_settings.AWS_REGION = "us-east-1"
+                mock_s3 = MagicMock()
+                mock_s3.upload_file.side_effect = client_error
+                mock_boto.client.return_value = mock_s3
+
+                try:
+                    self._invoke_upload(
+                        file_path=path,
+                        s3_key="test/key.mp3",
+                        bucket_name="my-bucket",
+                    )
+                except ClientError:
+                    pass  # non-retryable errors re-raise — expected
+
+            assert not os.path.exists(path), "temp file should be deleted on terminal non-retryable error"
+        finally:
+            if os.path.exists(path):
+                os.remove(path)

--- a/apps/api/tests/test_s3_upload.py
+++ b/apps/api/tests/test_s3_upload.py
@@ -5,6 +5,8 @@ Uses unittest.mock to avoid requiring real AWS credentials or a running database
 Tests invoke the underlying task logic by calling the task's __wrapped__ function
 or by configuring Celery eager mode.
 """
+import os
+import tempfile
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -579,3 +581,147 @@ class TestNonRetryableS3Errors:
 
         assert result["status"] == "failed"
         assert "InternalError" in result["error"]
+
+
+# ============================================================================
+# Temp-file cleanup (issue #275)
+# ============================================================================
+
+class TestTempFileCleanup:
+    """The composed audio temp file must be deleted once it's safely in S3, but
+    only when it lives under the system temp dir and never while a retry could
+    still need it."""
+
+    def _invoke_upload(self, **kwargs):
+        from src.tasks.s3_upload import upload_to_s3_task
+        return _invoke_task(upload_to_s3_task, **kwargs)
+
+    def _make_temp_file(self) -> str:
+        """Create a real file under the system temp dir; return its path."""
+        fd, path = tempfile.mkstemp(prefix="composed_", suffix=".mp3")
+        os.write(fd, b"fake audio bytes")
+        os.close(fd)
+        return path
+
+    def test_temp_file_deleted_after_successful_upload(self):
+        """Success path: a temp-dir file is removed once uploaded to S3."""
+        path = self._make_temp_file()
+        try:
+            with (
+                patch("src.tasks.s3_upload.settings") as mock_settings,
+                patch("src.tasks.s3_upload.boto3") as mock_boto,
+            ):
+                mock_settings.AWS_REGION = "us-east-1"
+                mock_boto.client.return_value = MagicMock()
+
+                result = self._invoke_upload(
+                    file_path=path,
+                    s3_key="test/key.mp3",
+                    bucket_name="my-bucket",
+                )
+
+            assert result["status"] == "success"
+            assert not os.path.exists(path), "temp file should be deleted after upload"
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
+
+    def test_non_temp_file_is_not_deleted(self, tmp_path):
+        """Guard: a file OUTSIDE the system temp dir must never be deleted."""
+        # tmp_path is pytest's per-test dir; force it outside tempfile.gettempdir()
+        # by pointing gettempdir() elsewhere so this path is treated as non-temp.
+        persistent = tmp_path / "audio.mp3"
+        persistent.write_bytes(b"keep me")
+        fake_temp_root = tmp_path / "systmp"
+        fake_temp_root.mkdir()
+
+        with (
+            patch("src.tasks.s3_upload.settings") as mock_settings,
+            patch("src.tasks.s3_upload.boto3") as mock_boto,
+            patch("src.tasks.s3_upload.os.path.getsize", return_value=7),
+            patch("src.tasks.s3_upload.tempfile.gettempdir", return_value=str(fake_temp_root)),
+        ):
+            mock_settings.AWS_REGION = "us-east-1"
+            mock_boto.client.return_value = MagicMock()
+
+            result = self._invoke_upload(
+                file_path=str(persistent),
+                s3_key="test/key.mp3",
+                bucket_name="my-bucket",
+            )
+
+        assert result["status"] == "success"
+        assert persistent.exists(), "non-temp file must be preserved"
+
+    def test_temp_file_kept_while_retrying(self):
+        """Retry path: a transient error that triggers a retry must NOT delete
+        the file — the next retry still needs it."""
+        path = self._make_temp_file()
+        try:
+            from src.tasks.s3_upload import upload_to_s3_task
+
+            # retry() raises Retry; the task never reaches a terminal branch.
+            with (
+                patch("src.tasks.s3_upload.settings") as mock_settings,
+                patch("src.tasks.s3_upload.boto3") as mock_boto,
+                patch("src.tasks.s3_upload.os.path.getsize", return_value=16),
+                patch.object(
+                    upload_to_s3_task,
+                    "retry",
+                    side_effect=RuntimeError("retry-signal"),
+                ),
+            ):
+                mock_settings.AWS_REGION = "us-east-1"
+                mock_s3 = MagicMock()
+                mock_s3.upload_file.side_effect = RuntimeError("Connection timeout")
+                mock_boto.client.return_value = mock_s3
+                upload_to_s3_task.request.update(retries=0)
+
+                try:
+                    self._invoke_upload(
+                        file_path=path,
+                        s3_key="test/key.mp3",
+                        bucket_name="my-bucket",
+                    )
+                except RuntimeError:
+                    pass  # the retry signal — expected
+
+            assert os.path.exists(path), "file must be kept while a retry is pending"
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
+
+    def test_temp_file_deleted_after_retries_exhausted(self):
+        """Terminal-failure path: once retries are exhausted no retry will read
+        the file, so the temp artifact must be cleaned up to avoid leaking /tmp."""
+        path = self._make_temp_file()
+        try:
+            from src.tasks.s3_upload import upload_to_s3_task
+
+            with (
+                patch("src.tasks.s3_upload.settings") as mock_settings,
+                patch("src.tasks.s3_upload.boto3") as mock_boto,
+                patch("src.tasks.s3_upload.os.path.getsize", return_value=16),
+                patch.object(
+                    upload_to_s3_task,
+                    "retry",
+                    side_effect=upload_to_s3_task.MaxRetriesExceededError(),
+                ),
+            ):
+                mock_settings.AWS_REGION = "us-east-1"
+                mock_s3 = MagicMock()
+                mock_s3.upload_file.side_effect = RuntimeError("Connection timeout")
+                mock_boto.client.return_value = mock_s3
+                upload_to_s3_task.request.update(retries=3)
+
+                result = self._invoke_upload(
+                    file_path=path,
+                    s3_key="test/key.mp3",
+                    bucket_name="my-bucket",
+                )
+
+            assert result["status"] == "failed"
+            assert not os.path.exists(path), "temp file should be deleted after terminal failure"
+        finally:
+            if os.path.exists(path):
+                os.remove(path)


### PR DESCRIPTION
## Summary
Audio composition writes `/tmp/composed_{episode_id}.mp3`, uploads it to S3, but **never deleted it**. Under sustained generation `/tmp` fills with stale `composed_*.mp3` files until uploads fail with "no space left on device".

This adds a guarded `_cleanup_temp_file` helper and calls it once the local copy is disposable.

## Changes (`apps/api/src/tasks/s3_upload.py`)
- **`_cleanup_temp_file(file_path)`** — best-effort delete restricted to files under `tempfile.gettempdir()` (resolved via `os.path.realpath` + `os.path.commonpath`, so it can never remove a `data/` file). Never raises.
- Called on the **success path** (after `upload_file` succeeds).
- Called on **terminal failure** — inside both `except … MaxRetriesExceededError` branches, before returning `status: "failed"`. Retries are exhausted there, so no retry will read the file.
- The **retry path is untouched** — a pending retry still has its file.

## Why also clean up on terminal failure
Plan 009 scoped this to the success path, but reviewer **@m13v** (and CodeRabbit) flagged that an upload exhausting its retries never reaches the success branch — so the failed tail leaks `/tmp` exactly like the original bug. Cleaning up at terminal failure (where it's provably safe — no further retry) fully closes the leak. Confirmed via the workflow chain that no later task (`distribute_to_platform_task`) reads the local file — distribution reads metadata from the committed Episode row / `s3_url`.

## Tests (`apps/api/tests/test_s3_upload.py` — `TestTempFileCleanup`, real temp files)
| Scenario | Expectation |
|---|---|
| Success upload, temp-dir path | file **deleted** |
| Success upload, non-temp path | file **kept** (guard) |
| Retry pending (transient error) | file **kept** |
| Retries exhausted (terminal failure) | file **deleted** |

## Verification (outcome evidence)
- `uv run pytest tests/test_s3_upload.py -k "Cleanup or upload"` → **21 passed**
- `uv run ruff check src/tasks/s3_upload.py tests/test_s3_upload.py` → clean
- `s3_upload.py` coverage 93%

## Known Limitations
- Cleanup is intentionally restricted to the system temp dir. If composition output ever moves off `/tmp` (e.g. to `data/`), the guard will stop cleaning it — revisit the temp-dir restriction then (noted in plan 009 maintenance notes).
- Does not retroactively sweep already-orphaned `/tmp/composed_*.mp3` from before this fix; a TTL sweep would be a separate enhancement.

Closes #275