### PR TITLE
fix(api): store OAuth CSRF state in Redis for multi-instance correctness (#273)

### DIFF
--- a/apps/api/src/services/distribution_target_service.py
+++ b/apps/api/src/services/distribution_target_service.py
@@ -13,9 +13,11 @@ from typing import Optional
 from uuid import UUID
 
 import httpx
+from redis import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, or_
 
+from ..config import settings
 from ..models.distribution_target import DistributionTarget
 from ..schemas.distribution_target import (
 	WebhookDistributionCreate,
@@ -71,18 +73,28 @@ async def _decrypt_sensitive_headers(db: AsyncSession, headers: dict) -> dict:
 	return result
 
 
-# In-memory OAuth state store: {state: {user_id: str, created_at: datetime}}
-# In production, replace with Redis for multi-instance support.
-_oauth_states: dict[str, dict] = {}
+# OAuth CSRF state is stored in Redis (keyed "oauth_state:<state>") so it works
+# across multiple API processes and survives restarts/deploys — a module dict
+# breaks both (issue #273). Redis TTL handles expiry, so no manual cleanup.
+_OAUTH_STATE_PREFIX = "oauth_state:"
 _STATE_TTL_SECONDS = 600  # 10 minutes
+
+
+def _redis() -> Redis:
+	"""Redis client for OAuth state, constructed from settings.REDIS_URL.
+
+	Mirrors how rate_limiter.py builds its client (same Redis instance, no new
+	infra). decode_responses=True so getdel returns str, not bytes.
+	"""
+	return Redis.from_url(settings.REDIS_URL, decode_responses=True)
 
 
 def generate_oauth_state(user_id: str) -> str:
 	"""
 	Generate a CSRF state token for OAuth flows.
 
-	Stores the state in memory with a TTL of 10 minutes.
-	In production environments with multiple API instances, use Redis.
+	Stores the state in Redis under "oauth_state:<state>" with a 10-minute TTL,
+	so it is visible to any API process and cleaned up automatically on expiry.
 
 	Args:
 		user_id: ID of the user initiating the OAuth flow
@@ -91,53 +103,30 @@ def generate_oauth_state(user_id: str) -> str:
 		Secure random state token
 	"""
 	state = secrets.token_urlsafe(32)
-	_oauth_states[state] = {
-		"user_id": user_id,
-		"created_at": datetime.now(timezone.utc),
-	}
-	# Clean up expired states while we're here
-	_cleanup_expired_states()
+	_redis().setex(f"{_OAUTH_STATE_PREFIX}{state}", _STATE_TTL_SECONDS, str(user_id))
 	return state
 
 
 def validate_oauth_state(state: str) -> Optional[str]:
 	"""
-	Validate and consume an OAuth state token.
+	Validate and consume an OAuth state token (one-time use).
 
-	Returns the user_id if valid, None if invalid or expired.
-	Removes the state after validation (one-time use).
+	Uses an atomic GETDEL so a state cannot be replayed — concurrent callbacks
+	race for the single delete and only one wins. Fails closed: if Redis is
+	unreachable, returns None (reject) rather than accepting, because this is a
+	CSRF security control (unlike the rate limiter, which fails open).
 
 	Args:
 		state: OAuth state token to validate
 
 	Returns:
-		user_id string if valid, None if invalid/expired
+		user_id string if valid, None if invalid/expired/Redis error
 	"""
-	state_data = _oauth_states.get(state)
-	if not state_data:
+	try:
+		return _redis().getdel(f"{_OAUTH_STATE_PREFIX}{state}")
+	except Exception as exc:
+		logger.warning("OAuth state validation failed (Redis error) — rejecting: %s", exc)
 		return None
-
-	# Check TTL
-	age = datetime.now(timezone.utc) - state_data["created_at"]
-	if age.total_seconds() > _STATE_TTL_SECONDS:
-		del _oauth_states[state]
-		return None
-
-	# Consume the state (one-time use)
-	del _oauth_states[state]
-	return state_data["user_id"]
-
-
-def _cleanup_expired_states() -> None:
-	"""Remove expired OAuth states from memory."""
-	now = datetime.now(timezone.utc)
-	expired = [
-		state
-		for state, data in _oauth_states.items()
-		if (now - data["created_at"]).total_seconds() > _STATE_TTL_SECONDS
-	]
-	for state in expired:
-		del _oauth_states[state]
 
 
 async def create_webhook_target(

--- a/apps/api/tests/test_distribution_targets.py
+++ b/apps/api/tests/test_distribution_targets.py
@@ -6,8 +6,40 @@ validation, and tenant isolation for distribution targets.
 """
 
 import pytest
+from types import SimpleNamespace
 from uuid import uuid4
 from unittest.mock import patch, AsyncMock, MagicMock
+
+
+class _FakeOAuthRedis:
+	"""In-memory stand-in for the OAuth-state Redis client.
+
+	The test suite runs without a Redis server (rate limiting is disabled and the
+	rate-limiter tests mock Redis), so the OAuth CSRF state store is faked here.
+	Supports only the subset distribution_target_service uses: setex + getdel.
+	"""
+
+	def __init__(self):
+		self._store = {}
+
+	def setex(self, key, ttl, value):
+		self._store[key] = value
+
+	def getdel(self, key):
+		return self._store.pop(key, None)
+
+
+@pytest.fixture(autouse=True)
+def fake_oauth_state_store(monkeypatch):
+	"""Back OAuth CSRF state with an in-memory store so authorize/callback work
+	without a real Redis. One shared instance per test so generate→validate sees
+	the same state."""
+	fake = _FakeOAuthRedis()
+	monkeypatch.setattr(
+		"src.services.distribution_target_service.Redis",
+		SimpleNamespace(from_url=lambda *a, **k: fake),
+	)
+	return fake
 
 
 @pytest.fixture

--- a/apps/api/tests/unit/test_oauth_state.py
+++ b/apps/api/tests/unit/test_oauth_state.py
@@ -1,0 +1,85 @@
+"""
+Unit tests for Redis-backed OAuth CSRF state (issue #273).
+
+Redis is mocked so no real server is required, mirroring test_rate_limiter.py.
+The state store must be:
+- multi-instance safe (Redis-backed, not a module dict)
+- one-time use (validate consumes the state atomically via GETDEL)
+- fail-closed (a Redis error during validation rejects, returns None)
+"""
+import os
+
+# Ensure required env vars are set before any src imports
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://x:x@localhost/x")
+os.environ.setdefault("ENCRYPTION_KEY", "a" * 32)
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-unit-tests")
+
+from unittest.mock import MagicMock, patch
+
+from src.services import distribution_target_service as svc
+
+
+def _patch_redis(redis_mock):
+	"""Patch the module's Redis so _redis() returns redis_mock."""
+	return patch.object(svc, "Redis", **{"from_url.return_value": redis_mock})
+
+
+class FakeRedis:
+	"""Minimal in-memory Redis double supporting setex + getdel."""
+
+	def __init__(self):
+		self.store = {}
+
+	def setex(self, key, ttl, value):
+		self.store[key] = value
+
+	def getdel(self, key):
+		return self.store.pop(key, None)
+
+
+def test_generate_returns_token_and_stores_in_redis():
+	fake = FakeRedis()
+	with _patch_redis(fake):
+		state = svc.generate_oauth_state("user-123")
+
+	assert isinstance(state, str) and len(state) > 20
+	assert fake.store[f"oauth_state:{state}"] == "user-123"
+
+
+def test_generate_sets_ttl():
+	redis_mock = MagicMock()
+	with _patch_redis(redis_mock):
+		state = svc.generate_oauth_state("user-123")
+
+	redis_mock.setex.assert_called_once_with(
+		f"oauth_state:{state}", svc._STATE_TTL_SECONDS, "user-123"
+	)
+
+
+def test_validate_happy_path_returns_user_id():
+	fake = FakeRedis()
+	with _patch_redis(fake):
+		state = svc.generate_oauth_state("user-123")
+		assert svc.validate_oauth_state(state) == "user-123"
+
+
+def test_validate_missing_or_expired_returns_none():
+	fake = FakeRedis()  # empty: expired keys are gone (Redis TTL)
+	with _patch_redis(fake):
+		assert svc.validate_oauth_state("never-issued") is None
+
+
+def test_validate_replay_second_attempt_returns_none():
+	fake = FakeRedis()
+	with _patch_redis(fake):
+		state = svc.generate_oauth_state("user-123")
+		assert svc.validate_oauth_state(state) == "user-123"
+		# Replay: one-time use means the second validation fails
+		assert svc.validate_oauth_state(state) is None
+
+
+def test_validate_fails_closed_on_redis_error():
+	redis_mock = MagicMock()
+	redis_mock.getdel.side_effect = RuntimeError("redis down")
+	with _patch_redis(redis_mock):
+		assert svc.validate_oauth_state("anything") is None


### PR DESCRIPTION
## Summary
OAuth CSRF state tokens (Spotify/Apple distribution flows) were stored in a module-level Python dict. With more than one API process (the normal HA shape — and every PM2 restart) a state issued by one process is invisible to another, so the OAuth callback fails with "invalid state"; in-flight states were also lost on every restart/deploy. The codebase already solved this exact "shared ephemeral state" problem for rate limiting with Redis — OAuth state was the lone holdout.

## Change
- `generate_oauth_state` / `validate_oauth_state` now store state in Redis keyed `oauth_state:<state>` with a 600s TTL, via a `_redis()` accessor that mirrors `rate_limiter.py` (`Redis.from_url(settings.REDIS_URL, decode_responses=True)` — same Redis, no new infra).
- Validation uses an atomic `GETDEL` → one-time use, replay-safe (concurrent callbacks race for the single delete).
- **Fails closed**: a Redis error during validation returns `None` (reject), because this is a CSRF security control — unlike the rate limiter, which fails open.
- Removed the in-memory `_oauth_states` dict and `_cleanup_expired_states` (Redis TTL handles expiry).
- Public signatures unchanged, so the two callers in `routers/distribution_targets.py` are untouched.

## Tests
New `tests/unit/test_oauth_state.py` (Redis mocked, mirroring `test_rate_limiter.py`):
- generate → validate happy path
- missing/expired → `None`
- replay (validate twice) → second returns `None`
- Redis error → `None` (fail closed)

Gate: `uv run pytest tests/ -k "distribution or oauth" -q` → 145 passed. `ruff check` clean on changed files.

## Known limitations
- `validate_oauth_state` stays synchronous (blocking Redis call from the async callback), matching the existing rate-limiter pattern and the issue plan's "keep signatures" constraint. Making the OAuth state path fully async is out of scope.

Closes #273

https://claude.ai/code/session_01J5W2mJRAPFNkrC2HeZHVUZ