### PR TITLE
perf(api): aggregate analytics in SQL instead of loading all events into memory

### DIFF
--- a/apps/api/src/services/analytics_service.py
+++ b/apps/api/src/services/analytics_service.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import Boolean, Float, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models.analytics_event import (
@@ -68,45 +68,70 @@ async def get_episode_analytics(
 	if date_to is None:
 		date_to = datetime.utcnow()
 
-	base_query = (
-		select(AnalyticsEvent)
-		.where(AnalyticsEvent.episode_id == episode_id)
-		.where(AnalyticsEvent.created_at >= date_from)
-		.where(AnalyticsEvent.created_at <= date_to)
+	window = (
+		(AnalyticsEvent.episode_id == episode_id)
+		& (AnalyticsEvent.created_at >= date_from)
+		& (AnalyticsEvent.created_at <= date_to)
 	)
 
-	result = await db.execute(base_query)
-	events = result.scalars().all()
-
-	# Count by event type
+	# Count by event type (GROUP BY instead of a Python loop over all rows)
 	counts: Dict[str, int] = {"download": 0, "play": 0, "stream": 0, "share": 0}
+	rows = await db.execute(
+		select(AnalyticsEvent.event_type, func.count())
+		.where(window)
+		.group_by(AnalyticsEvent.event_type)
+	)
+	for event_type, n in rows.all():
+		counts[event_type] = counts.get(event_type, 0) + n
+
+	# Device / app / country breakdowns — filter out falsy values to match the
+	# old `if event.<field>:` guard (skips both NULL and empty string).
 	device_breakdown: Dict[str, int] = {"mobile": 0, "desktop": 0, "tablet": 0, "unknown": 0}
-	app_breakdown: Dict[str, int] = {}
-	country_counts: Dict[str, int] = {}
+	rows = await db.execute(
+		select(AnalyticsEvent.device_type, func.count())
+		.where(window & AnalyticsEvent.device_type.isnot(None) & (AnalyticsEvent.device_type != ""))
+		.group_by(AnalyticsEvent.device_type)
+	)
+	for device, n in rows.all():
+		device_breakdown[device] = device_breakdown.get(device, 0) + n
 
-	total_duration = 0.0
-	completed_count = 0
-	play_count_for_avg = 0
+	rows = await db.execute(
+		select(AnalyticsEvent.app_name, func.count())
+		.where(window & AnalyticsEvent.app_name.isnot(None) & (AnalyticsEvent.app_name != ""))
+		.group_by(AnalyticsEvent.app_name)
+	)
+	app_breakdown: Dict[str, int] = {app: n for app, n in rows.all()}
 
-	for event in events:
-		counts[event.event_type] = counts.get(event.event_type, 0) + 1
+	rows = await db.execute(
+		select(AnalyticsEvent.country, func.count())
+		.where(window & AnalyticsEvent.country.isnot(None) & (AnalyticsEvent.country != ""))
+		.group_by(AnalyticsEvent.country)
+	)
+	country_counts: Dict[str, int] = {c: n for c, n in rows.all()}
 
-		if event.device_type:
-			device_breakdown[event.device_type] = device_breakdown.get(event.device_type, 0) + 1
+	# Listen duration: sum + count over plays whose JSONB duration is truthy
+	# (matches the old `if duration:` guard — excludes missing key, NULL, and 0).
+	duration_col = AnalyticsEvent.event_metadata["duration_listened_seconds"].astext.cast(Float)
+	total_duration, play_count_for_avg = (
+		await db.execute(
+			select(func.coalesce(func.sum(duration_col), 0.0), func.count())
+			.where(
+				window
+				& (AnalyticsEvent.event_type == "play")
+				& duration_col.isnot(None)
+				& (duration_col != 0)
+			)
+		)
+	).one()
 
-		if event.app_name:
-			app_breakdown[event.app_name] = app_breakdown.get(event.app_name, 0) + 1
-
-		if event.country:
-			country_counts[event.country] = country_counts.get(event.country, 0) + 1
-
-		if event.event_metadata and event.event_type == "play":
-			duration = event.event_metadata.get("duration_listened_seconds", 0)
-			if duration:
-				total_duration += duration
-				play_count_for_avg += 1
-			if event.event_metadata.get("completed", False):
-				completed_count += 1
+	# Completed plays: JSONB `completed` is true (missing/NULL/false excluded)
+	completed_col = AnalyticsEvent.event_metadata["completed"].astext.cast(Boolean)
+	completed_count = (
+		await db.execute(
+			select(func.count())
+			.where(window & (AnalyticsEvent.event_type == "play") & completed_col.is_(True))
+		)
+	).scalar_one()
 
 	total_plays = counts["play"]
 	avg_duration = total_duration / play_count_for_avg if play_count_for_avg > 0 else 0.0
@@ -144,38 +169,64 @@ async def get_project_analytics(
 	date_to = datetime.utcnow()
 	date_from = date_to - timedelta(days=days)
 
-	result = await db.execute(
-		select(AnalyticsEvent)
-		.where(AnalyticsEvent.project_id == project_id)
-		.where(AnalyticsEvent.created_at >= date_from)
-		.where(AnalyticsEvent.created_at <= date_to)
+	window = (
+		(AnalyticsEvent.project_id == project_id)
+		& (AnalyticsEvent.created_at >= date_from)
+		& (AnalyticsEvent.created_at <= date_to)
 	)
-	events = result.scalars().all()
 
-	total_downloads = 0
-	total_plays = 0
-	total_listen_seconds = 0.0
-	episode_downloads: Dict[str, int] = {}
+	# Download / play totals via GROUP BY event_type
+	type_counts = {
+		t: n
+		for t, n in (
+			await db.execute(
+				select(AnalyticsEvent.event_type, func.count())
+				.where(window)
+				.group_by(AnalyticsEvent.event_type)
+			)
+		).all()
+	}
+	total_downloads = type_counts.get("download", 0)
+	total_plays = type_counts.get("play", 0)
 
-	# Weekly buckets: key = "YYYY-WNN"
+	# Sum listen seconds over plays (missing/NULL duration counts as 0, matching
+	# the old `metadata.get("duration_listened_seconds", 0)`).
+	duration_col = AnalyticsEvent.event_metadata["duration_listened_seconds"].astext.cast(Float)
+	total_listen_seconds = (
+		await db.execute(
+			select(func.coalesce(func.sum(func.coalesce(duration_col, 0.0)), 0.0))
+			.where(window & (AnalyticsEvent.event_type == "play"))
+		)
+	).scalar_one()
+
+	# Per-episode download breakdown
+	episode_downloads: Dict[str, int] = {
+		str(eid): n
+		for eid, n in (
+			await db.execute(
+				select(AnalyticsEvent.episode_id, func.count())
+				.where(
+					window
+					& (AnalyticsEvent.event_type == "download")
+					& AnalyticsEvent.episode_id.isnot(None)
+				)
+				.group_by(AnalyticsEvent.episode_id)
+			)
+		).all()
+	}
+
+	# Weekly buckets: GROUP BY day in SQL (O(days), not O(events)), then bucket
+	# by Python's "%Y-W%W" so the key format stays byte-for-byte identical
+	# (Postgres ISO/`to_char` week numbering would NOT match strftime("%W")).
 	weekly: Dict[str, int] = {}
-
-	for event in events:
-		if event.event_type == "download":
-			total_downloads += 1
-		elif event.event_type == "play":
-			total_plays += 1
-			if event.event_metadata:
-				total_listen_seconds += event.event_metadata.get("duration_listened_seconds", 0)
-
-		# Episode breakdown for downloads
-		if event.episode_id and event.event_type == "download":
-			key = str(event.episode_id)
-			episode_downloads[key] = episode_downloads.get(key, 0) + 1
-
-		# Weekly bucketing
-		week_key = event.created_at.strftime("%Y-W%W")
-		weekly[week_key] = weekly.get(week_key, 0) + 1
+	day_rows = await db.execute(
+		select(func.date(AnalyticsEvent.created_at), func.count())
+		.where(window)
+		.group_by(func.date(AnalyticsEvent.created_at))
+	)
+	for day, n in day_rows.all():
+		week_key = day.strftime("%Y-W%W")
+		weekly[week_key] = weekly.get(week_key, 0) + n
 
 	top_episodes = sorted(
 		[{"episode_id": eid, "downloads": cnt} for eid, cnt in episode_downloads.items()],

--- a/apps/api/tests/test_analytics_aggregation.py
+++ b/apps/api/tests/test_analytics_aggregation.py
@@ -1,0 +1,224 @@
+"""
+Characterization tests for analytics SQL aggregation (issue #274).
+
+These pin the EXACT return-dict shapes of `get_episode_analytics` and
+`get_project_analytics` so the in-memory loops can be replaced with SQL
+aggregation without changing the frontend contract. They create a real
+project/episode via the API (FK parents), seed a known set of AnalyticsEvent
+rows directly on the session with custom dates/device/country/metadata, then
+assert the full returned dict.
+"""
+
+from datetime import datetime, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.models.analytics_event import AnalyticsEvent
+from src.services.analytics_service import (
+    get_episode_analytics,
+    get_project_analytics,
+)
+
+
+async def _setup_project_episode(client):
+    """Register a user and create a project + episode; return (project_id, episode_id) as UUIDs."""
+    resp = await client.post("/auth/register", json={
+        "email": f"test_{uuid4()}@example.com",
+        "password": "SecurePass123!",
+        "full_name": "Test User",
+    })
+    assert resp.status_code == 201, resp.text
+    headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+    resp = await client.post("/projects", json={
+        "name": f"Test Project {uuid4()}",
+        "description": "Analytics test project",
+        "podcast_metadata": {
+            "show_title": "Analytics Test Show",
+            "author": "Test Author",
+            "description": "Analytics test project",
+        },
+    }, headers=headers)
+    assert resp.status_code == 201, resp.text
+    project_id = UUID(resp.json()["id"])
+
+    resp = await client.post("/episodes", json={
+        "project_id": str(project_id),
+        "episode_metadata": {"title": f"Test Episode {uuid4()}", "description": "Test"},
+    }, headers=headers)
+    assert resp.status_code == 201, resp.text
+    episode_id = UUID(resp.json()["id"])
+
+    return project_id, episode_id
+
+
+def _mk_event(*, episode_id, project_id, event_type, created_at,
+              device_type=None, app_name=None, country=None, metadata=None):
+    return AnalyticsEvent(
+        tenant_id=uuid4(),  # no FK / no RLS on analytics_events
+        episode_id=episode_id,
+        project_id=project_id,
+        event_type=event_type,
+        device_type=device_type,
+        app_name=app_name,
+        country=country,
+        event_metadata=metadata,
+        created_at=created_at,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_episode_analytics_characterization(client, test_db):
+    """Exact dict for a mixed set of events within an explicit date window."""
+    proj, ep = await _setup_project_episode(client)
+    date_from = datetime(2026, 6, 1)
+    date_to = datetime(2026, 6, 30, 23, 59, 59)
+
+    events = [
+        _mk_event(episode_id=ep, project_id=proj, event_type="download",
+                  created_at=datetime(2026, 6, 10), device_type="mobile",
+                  app_name="apple_podcasts", country="US"),
+        _mk_event(episode_id=ep, project_id=proj, event_type="download",
+                  created_at=datetime(2026, 6, 11), device_type="desktop",
+                  app_name="spotify", country="GB"),
+        _mk_event(episode_id=ep, project_id=proj, event_type="play",
+                  created_at=datetime(2026, 6, 12), device_type="mobile",
+                  app_name="apple_podcasts", country="US",
+                  metadata={"duration_listened_seconds": 120, "completed": True}),
+        _mk_event(episode_id=ep, project_id=proj, event_type="play",
+                  created_at=datetime(2026, 6, 13), device_type="tablet",
+                  app_name="overcast", country="US",
+                  metadata={"duration_listened_seconds": 60, "completed": False}),
+        # play with empty metadata + NULL device/app/country: counted as play only
+        _mk_event(episode_id=ep, project_id=proj, event_type="play",
+                  created_at=datetime(2026, 6, 14), metadata={}),
+        _mk_event(episode_id=ep, project_id=proj, event_type="stream",
+                  created_at=datetime(2026, 6, 15), device_type="desktop",
+                  app_name="other", country="GB"),
+        _mk_event(episode_id=ep, project_id=proj, event_type="share",
+                  created_at=datetime(2026, 6, 16), device_type="mobile",
+                  app_name="other", country="US"),
+        # outside the window -> excluded entirely
+        _mk_event(episode_id=ep, project_id=proj, event_type="download",
+                  created_at=datetime(2026, 7, 5), device_type="mobile",
+                  app_name="apple_podcasts", country="US"),
+    ]
+    for e in events:
+        test_db.add(e)
+    await test_db.flush()
+
+    result = await get_episode_analytics(test_db, ep, date_from=date_from, date_to=date_to)
+
+    assert result == {
+        "episode_id": ep,
+        "period": {"from": date_from, "to": date_to},
+        "metrics": {
+            "total_downloads": 2,
+            "total_plays": 3,
+            "total_streams": 1,
+            "average_listen_duration_seconds": 90.0,
+            "completion_rate": 1 / 3,
+        },
+        "device_breakdown": {"mobile": 3, "desktop": 2, "tablet": 1, "unknown": 0},
+        "app_breakdown": {"apple_podcasts": 2, "spotify": 1, "overcast": 1, "other": 2},
+        "top_countries": [
+            {"country": "US", "downloads": 4},
+            {"country": "GB", "downloads": 2},
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_episode_analytics_zero_events(test_db):
+    """No events -> zero metrics, no division error, empty breakdowns/countries."""
+    ep = uuid4()
+    date_from = datetime(2026, 6, 1)
+    date_to = datetime(2026, 6, 30)
+
+    result = await get_episode_analytics(test_db, ep, date_from=date_from, date_to=date_to)
+
+    assert result == {
+        "episode_id": ep,
+        "period": {"from": date_from, "to": date_to},
+        "metrics": {
+            "total_downloads": 0,
+            "total_plays": 0,
+            "total_streams": 0,
+            "average_listen_duration_seconds": 0.0,
+            "completion_rate": 0.0,
+        },
+        "device_breakdown": {"mobile": 0, "desktop": 0, "tablet": 0, "unknown": 0},
+        "app_breakdown": {},
+        "top_countries": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_project_analytics_characterization(client, test_db):
+    """Exact dict for a project summary using now-relative dates (default 30d window)."""
+    proj, ep = await _setup_project_episode(client)
+    now = datetime.utcnow()
+
+    in_window = [
+        _mk_event(episode_id=ep, project_id=proj, event_type="download",
+                  created_at=now - timedelta(days=2)),
+        _mk_event(episode_id=ep, project_id=proj, event_type="download",
+                  created_at=now - timedelta(days=3)),
+        _mk_event(episode_id=ep, project_id=proj, event_type="play",
+                  created_at=now - timedelta(days=4),
+                  metadata={"duration_listened_seconds": 120, "completed": True}),
+        _mk_event(episode_id=ep, project_id=proj, event_type="play",
+                  created_at=now - timedelta(days=5),
+                  metadata={"duration_listened_seconds": 60}),
+        _mk_event(episode_id=ep, project_id=proj, event_type="play",
+                  created_at=now - timedelta(days=6), metadata={}),
+        _mk_event(episode_id=ep, project_id=proj, event_type="stream",
+                  created_at=now - timedelta(days=7)),
+        _mk_event(episode_id=ep, project_id=proj, event_type="share",
+                  created_at=now - timedelta(days=8)),
+    ]
+    # outside the 30-day window -> excluded
+    outside = _mk_event(episode_id=ep, project_id=proj, event_type="download",
+                        created_at=now - timedelta(days=40))
+    for e in in_window + [outside]:
+        test_db.add(e)
+    await test_db.flush()
+
+    # Expected weekly buckets: same formula the service uses, applied to the
+    # in-window event dates. This pins grouping/counts; the "%Y-W%W" format is
+    # preserved by construction (the service still buckets in Python).
+    weekly: dict[str, int] = {}
+    for e in in_window:
+        wk = e.created_at.strftime("%Y-W%W")
+        weekly[wk] = weekly.get(wk, 0) + 1
+    expected_weekly = [{"week": w, "downloads": c} for w, c in sorted(weekly.items())]
+
+    result = await get_project_analytics(test_db, proj, days=30)
+
+    assert result["project_id"] == proj
+    assert result["period"]["days"] == 30
+    assert result["summary"] == {
+        "total_downloads": 2,
+        "total_plays": 3,
+        "total_listen_hours": 0.05,
+    }
+    assert result["trends"] == {"weekly_downloads": expected_weekly}
+    assert result["top_episodes"] == [{"episode_id": str(ep), "downloads": 2}]
+
+
+@pytest.mark.asyncio
+async def test_get_project_analytics_zero_events(test_db):
+    """No events -> zero summary, empty trends/top_episodes."""
+    proj = uuid4()
+    result = await get_project_analytics(test_db, proj, days=7)
+
+    assert result["project_id"] == proj
+    assert result["period"]["days"] == 7
+    assert result["summary"] == {
+        "total_downloads": 0,
+        "total_plays": 0,
+        "total_listen_hours": 0.0,
+    }
+    assert result["trends"] == {"weekly_downloads": []}
+    assert result["top_episodes"] == []


### PR DESCRIPTION
## Summary
Closes #274. `get_episode_analytics` and `get_project_analytics` loaded **every** matching `AnalyticsEvent` row into Python and aggregated with for-loops — O(rows) memory/latency. This replaces the load-all + loops with SQL `GROUP BY` / `func.count` / `func.sum` (plus JSONB casts for `duration_listened_seconds` / `completed`), so responses are O(groups).

**No router/model/migration change.** Return-dict shapes are byte-for-byte identical (frontend contract).

## What changed
- `apps/api/src/services/analytics_service.py` — both functions rewritten with grouped SQL queries. No `scalars().all()` remains.
- `apps/api/tests/test_analytics_aggregation.py` — **new characterization tests** that pin the exact returned dict for both functions (written first, against the old code, so they passed before the refactor).

## Contract-preservation notes (reviewer focus)
- **Truthy filters**: device/app/country breakdowns filter `IS NOT NULL AND != ''` to match the old `if event.<field>:` guard (skips NULL *and* empty string).
- **JSONB casts**: duration sum/avg excludes plays with missing/NULL/zero duration (matches `if duration:`); `completed_count` counts only JSONB `completed = true`.
- **Weekly buckets**: deliberately **not** done with Postgres `to_char(..., 'IW')` — ISO/`to_char` week numbering does **not** equal Python's `strftime("%W")`. Instead grouped by `func.date(created_at)` (O(days), not O(events)) and bucketed in Python with the same `strftime("%Y-W%W")`, so the key format is preserved exactly.

## Tests
- `cd apps/api && uv run pytest tests/ -k "analytics" -q` → **44 passed**
- `cd apps/api && uv run ruff check src/services/analytics_service.py tests/test_analytics_aggregation.py` → clean
- Cross-family pre-PR review (`codex review`): no introduced bugs.

## Known limitations
- Tie ordering in `top_countries` / `top_episodes` remains as before (sorted by count desc; ties unordered) — the old code had the same non-determinism (no `ORDER BY` on the underlying scan), so this preserves the existing contract rather than tightening it.
- A composite index on `(episode_id, created_at)` / `(project_id, created_at)` already exists on the model; further index tuning is deliberately out of scope (see plan #274 maintenance notes).

https://claude.ai/code/session_01J5W2mJRAPFNkrC2HeZHVUZ