### PR TITLE
fix(tasks): lock episode row when recording per-platform distribution results (#276)

### DIFF
--- a/apps/api/src/tasks/callbacks.py
+++ b/apps/api/src/tasks/callbacks.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from celery import Task
+from sqlalchemy import select
 
 from src.database import SyncSessionLocal
 from src.models.episode import Episode
@@ -21,6 +22,21 @@ logger = logging.getLogger(__name__)
 def _utcnow_iso() -> str:
 	"""Return current UTC time as ISO 8601 string."""
 	return datetime.now(timezone.utc).isoformat()
+
+
+def _get_episode_for_update(db: Any, episode_id: str) -> Optional[Episode]:
+	"""
+	Fetch an Episode with a row-level lock (SELECT ... FOR UPDATE).
+
+	Callbacks read-modify-write the ``generation_progress`` JSONB column. The
+	per-platform distribution callbacks run as independent Celery tasks that can
+	overlap, so an unlocked read-modify-write loses updates (issue #276). Locking
+	the row serializes concurrent callbacks: the second blocks until the first
+	commits, then re-reads the merged value. The lock is released on commit.
+	"""
+	return db.execute(
+		select(Episode).where(Episode.id == uuid_module.UUID(episode_id)).with_for_update()
+	).scalar_one_or_none()
 
 
 def _update_episode(
@@ -41,7 +57,7 @@ def _update_episode(
 	"""
 	try:
 		with SyncSessionLocal() as db:
-			episode = db.get(Episode, uuid_module.UUID(episode_id))
+			episode = _get_episode_for_update(db, episode_id)
 			if episode is None:
 				logger.error("Episode %s not found in database", episode_id)
 				return False
@@ -176,7 +192,7 @@ def on_distribution_complete(
 
 	try:
 		with SyncSessionLocal() as db:
-			episode = db.get(Episode, uuid_module.UUID(episode_id))
+			episode = _get_episode_for_update(db, episode_id)
 			if episode is None:
 				logger.error("Episode %s not found in database", episode_id)
 				return

--- a/apps/api/tests/unit/test_celery_callbacks.py
+++ b/apps/api/tests/unit/test_celery_callbacks.py
@@ -31,10 +31,14 @@ def _mock_episode(episode_id: str) -> MagicMock:
 def _make_sync_session(episode: MagicMock):
 	"""
 	Return a mock that behaves like a SyncSessionLocal() context manager,
-	yielding a session whose .get() returns *episode*.
+	yielding a session whose locked fetch returns *episode*.
+
+	Callbacks fetch the episode via
+	``db.execute(select(...).with_for_update()).scalar_one_or_none()`` (issue
+	#276), so the mock resolves that chain to *episode*.
 	"""
 	mock_session = MagicMock()
-	mock_session.get.return_value = episode
+	mock_session.execute.return_value.scalar_one_or_none.return_value = episode
 	mock_ctx = MagicMock()
 	mock_ctx.__enter__ = MagicMock(return_value=mock_session)
 	mock_ctx.__exit__ = MagicMock(return_value=False)
@@ -264,6 +268,30 @@ class TestOnDistributionComplete:
 
 		assert "spotify" in episode.generation_progress["distribution"]
 		assert "apple_podcasts" in episode.generation_progress["distribution"]
+
+	def test_fetches_episode_with_row_lock(self):
+		"""The episode is fetched FOR UPDATE so concurrent platform callbacks
+		serialize instead of losing updates (issue #276)."""
+		episode_id = str(uuid.uuid4())
+		episode = _mock_episode(episode_id)
+		mock_ctx, mock_session = _make_sync_session(episode)
+
+		result = {"status": "success", "platform": "spotify"}
+
+		from src.tasks.callbacks import on_distribution_complete
+
+		with patch("src.tasks.callbacks.SyncSessionLocal", return_value=mock_ctx):
+			_invoke_task(
+				on_distribution_complete,
+				result=result,
+				episode_id=episode_id,
+				platform="spotify",
+			)
+
+		# Locked fetch, not a plain db.get(): the SELECT carries a FOR UPDATE clause.
+		stmt = mock_session.execute.call_args.args[0]
+		assert stmt._for_update_arg is not None
+		mock_session.get.assert_not_called()
 
 	def test_skips_update_on_failure_result(self):
 		"""No database update when result indicates failure."""
@@ -581,6 +609,22 @@ class TestUpdateEpisodeHelper:
 
 		assert result is False
 		mock_session.commit.assert_not_called()
+
+	def test_fetches_episode_with_row_lock(self):
+		"""_update_episode fetches FOR UPDATE so every callback sharing it
+		(upload/composition/workflow) is protected from lost updates (issue #276)."""
+		episode_id = str(uuid.uuid4())
+		episode = _mock_episode(episode_id)
+		mock_ctx, mock_session = _make_sync_session(episode)
+
+		from src.tasks.callbacks import _update_episode
+
+		with patch("src.tasks.callbacks.SyncSessionLocal", return_value=mock_ctx):
+			_update_episode(episode_id, updates={"generation_status": "complete"})
+
+		stmt = mock_session.execute.call_args.args[0]
+		assert stmt._for_update_arg is not None
+		mock_session.get.assert_not_called()
 
 	def test_returns_false_on_db_exception(self):
 		"""Returns False (does not re-raise) when a DB exception occurs."""


### PR DESCRIPTION
## Summary

Fixes a lost-update race (#276) when an episode is distributed to more than one platform. Each platform's `on_distribution_complete` callback is an independent Celery task; they can overlap and each did an **unlocked** read-modify-write of the `generation_progress` JSONB column, so whichever committed last overwrote the others — only one platform's distribution metadata survived.

## Fix

Fetch the episode under a row lock (`SELECT ... FOR UPDATE`) via a small `_get_episode_for_update` helper, applied in:
- `on_distribution_complete` (the inline read-modify-write), and
- the shared `_update_episode` helper — which also protects the upload / composition / workflow-complete / workflow-failure callbacks that do the same JSONB read-modify-write.

Concurrent callbacks now serialize: the second blocks until the first commits, then re-reads the merged value (lock released on commit). The workflow structure in `podcast_generation.py` is untouched — the tasks are **not** serialized to work around it, per the ticket.

## Evidence

- Emitted SQL against the real PostgreSQL dialect ends in `... WHERE episodes.id = %(id_1)s::UUID FOR UPDATE` — lock is real, bound params, no string interpolation.
- `test_fetches_episode_with_row_lock` (×2) assert the fetch carries a `FOR UPDATE` clause and that `db.get()` is no longer used.
- `test_accumulates_multiple_platforms` confirms two platforms recorded for one episode both persist.
- Failed-status early return preserved (`test_skips_update_on_failure_result`).
- `pytest tests/unit/test_celery_callbacks.py` → 27 passed; `ruff check` clean.

## Known Limitations

Unit tests mock the session, so they verify the locking *mechanism* (FOR UPDATE is requested) rather than true concurrent execution; real row-lock serialization would need an integration test against Postgres. The `_for_update_arg`/SQL-compilation checks plus the real-dialect SQL above cover that the lock is actually emitted.

Closes #276

https://claude.ai/code/session_01J5W2mJRAPFNkrC2HeZHVUZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of episode progress updates when multiple background callbacks run at the same time.
  * Prevented lost updates by ensuring progress changes are applied to a locked record before saving.
  * Expanded automated test coverage to verify the safer update path is used during callback processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->