### PR TITLE
fix(api): StorageService reads AWS_S3_BUCKET, not non-existent S3_BUCKET_NAME (#291)

### DIFF
--- a/apps/api/src/services/storage_service.py
+++ b/apps/api/src/services/storage_service.py
@@ -30,7 +30,12 @@ class StorageService:
         self.aws_access_key_id = aws_access_key_id or getattr(settings, "AWS_ACCESS_KEY_ID", None)
         self.aws_secret_access_key = aws_secret_access_key or getattr(settings, "AWS_SECRET_ACCESS_KEY", None)
         self.bucket_name = bucket_name or getattr(settings, "AWS_S3_BUCKET", None)
-        self.region_name = region_name or getattr(settings, "AWS_REGION", "us-east-1")
+        resolved_region = (
+            region_name
+            if region_name is not None
+            else getattr(settings, "AWS_REGION", None)
+        )
+        self.region_name = resolved_region or "us-east-1"
 
         # Initialize S3 client
         self.s3_client = boto3.client(

--- a/apps/api/src/services/storage_service.py
+++ b/apps/api/src/services/storage_service.py
@@ -16,7 +16,7 @@ class StorageService:
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         bucket_name: Optional[str] = None,
-        region_name: str = "us-east-1",
+        region_name: Optional[str] = None,
     ):
         """
         Initialize S3 storage service
@@ -24,13 +24,13 @@ class StorageService:
         Args:
             aws_access_key_id: AWS access key (uses settings.AWS_ACCESS_KEY_ID if not provided)
             aws_secret_access_key: AWS secret key (uses settings.AWS_SECRET_ACCESS_KEY if not provided)
-            bucket_name: S3 bucket name (uses settings.S3_BUCKET_NAME if not provided)
-            region_name: AWS region
+            bucket_name: S3 bucket name (uses settings.AWS_S3_BUCKET if not provided)
+            region_name: AWS region (uses settings.AWS_REGION, default "us-east-1", if not provided)
         """
         self.aws_access_key_id = aws_access_key_id or getattr(settings, "AWS_ACCESS_KEY_ID", None)
         self.aws_secret_access_key = aws_secret_access_key or getattr(settings, "AWS_SECRET_ACCESS_KEY", None)
-        self.bucket_name = bucket_name or getattr(settings, "S3_BUCKET_NAME", None)
-        self.region_name = region_name
+        self.bucket_name = bucket_name or getattr(settings, "AWS_S3_BUCKET", None)
+        self.region_name = region_name or getattr(settings, "AWS_REGION", "us-east-1")
 
         # Initialize S3 client
         self.s3_client = boto3.client(

--- a/apps/api/tests/unit/test_storage_service.py
+++ b/apps/api/tests/unit/test_storage_service.py
@@ -60,6 +60,22 @@ def test_init_sets_region(mock_boto3_client):
 	assert svc.region_name == "eu-west-1"
 
 
+def test_init_no_args_resolves_bucket_and_region_from_settings():
+	"""Regression for #291: a no-arg StorageService() must pick up AWS_S3_BUCKET
+	and AWS_REGION from settings, not the non-existent S3_BUCKET_NAME (which left
+	bucket_name=None and broke episode download + RSS upload)."""
+	with patch("src.services.storage_service.boto3.client") as mock_client, \
+		patch("src.services.storage_service.settings") as mock_settings:
+		mock_client.return_value = MagicMock()
+		mock_settings.AWS_ACCESS_KEY_ID = "key"
+		mock_settings.AWS_SECRET_ACCESS_KEY = "secret"
+		mock_settings.AWS_S3_BUCKET = "configured-bucket"
+		mock_settings.AWS_REGION = "eu-central-1"
+		svc = StorageService()
+	assert svc.bucket_name == "configured-bucket"
+	assert svc.region_name == "eu-central-1"
+
+
 # ===========================================================================
 # upload_file
 # ===========================================================================

--- a/apps/api/tests/unit/test_storage_service.py
+++ b/apps/api/tests/unit/test_storage_service.py
@@ -60,20 +60,45 @@ def test_init_sets_region(mock_boto3_client):
 	assert svc.region_name == "eu-west-1"
 
 
-def test_init_no_args_resolves_bucket_and_region_from_settings():
+@pytest.mark.asyncio
+async def test_no_arg_service_downloads_against_configured_bucket():
 	"""Regression for #291: a no-arg StorageService() must pick up AWS_S3_BUCKET
-	and AWS_REGION from settings, not the non-existent S3_BUCKET_NAME (which left
-	bucket_name=None and broke episode download + RSS upload)."""
+	and AWS_REGION from settings (not the non-existent S3_BUCKET_NAME, which left
+	bucket_name=None and broke episode download + RSS upload), and the download
+	path must hit S3 with that resolved bucket."""
+	with patch("src.services.storage_service.boto3.client") as mock_client, \
+		patch("src.services.storage_service.settings") as mock_settings:
+		mock_s3 = MagicMock()
+		mock_client.return_value = mock_s3
+		mock_settings.AWS_ACCESS_KEY_ID = "key"
+		mock_settings.AWS_SECRET_ACCESS_KEY = "secret"
+		mock_settings.AWS_S3_BUCKET = "configured-bucket"
+		mock_settings.AWS_REGION = "eu-central-1"
+
+		svc = StorageService()  # exactly how episodes.py / rss_generation_service.py build it
+		assert svc.bucket_name == "configured-bucket"
+		assert svc.region_name == "eu-central-1"
+
+		# boto3 client created in the configured region, and the download path
+		# (which was broken with Bucket=None) now targets the real bucket.
+		assert mock_client.call_args.kwargs["region_name"] == "eu-central-1"
+		await svc.download_file("episodes/ep1.mp3", "/tmp/ep1.mp3")
+		mock_s3.download_file.assert_called_once_with(
+			Bucket="configured-bucket", Key="episodes/ep1.mp3", Filename="/tmp/ep1.mp3"
+		)
+
+
+def test_init_region_falls_back_to_us_east_1_when_settings_empty():
+	"""Empty/None AWS_REGION must still resolve to the ultimate 'us-east-1' default."""
 	with patch("src.services.storage_service.boto3.client") as mock_client, \
 		patch("src.services.storage_service.settings") as mock_settings:
 		mock_client.return_value = MagicMock()
 		mock_settings.AWS_ACCESS_KEY_ID = "key"
 		mock_settings.AWS_SECRET_ACCESS_KEY = "secret"
-		mock_settings.AWS_S3_BUCKET = "configured-bucket"
-		mock_settings.AWS_REGION = "eu-central-1"
+		mock_settings.AWS_S3_BUCKET = "b"
+		mock_settings.AWS_REGION = ""
 		svc = StorageService()
-	assert svc.bucket_name == "configured-bucket"
-	assert svc.region_name == "eu-central-1"
+	assert svc.region_name == "us-east-1"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
Fixes #291 (P0.1 launch blocker). `StorageService.__init__` fell back to `getattr(settings, "S3_BUCKET_NAME", None)`, but `Settings` defines `AWS_S3_BUCKET` (config.py:59) with `extra="ignore"` — so every default-constructed `StorageService()` got `bucket_name=None`. Episode download (`routers/episodes.py`) and RSS upload (`rss_generation_service.py`) both default-construct it and failed with `boto3 ParamValidationError` in any default deployment.

## Changes
- `bucket_name` falls back to `settings.AWS_S3_BUCKET`.
- `region_name` default → `None`, falls back to `settings.AWS_REGION` (ultimate default `"us-east-1"`). Explicit overrides still work.
- Docstring corrected.
- Regression test: a no-arg `StorageService()` with patched settings resolves `bucket_name`/`region_name` to configured values (fails on old code, passes on fix — verified RED→GREEN).

## Verification
- `tests/unit/test_storage_service.py` — 15 passed
- `tests/test_download_endpoint.py` — 12 passed
- `tests/test_rss_feed.py` — 20 passed
- `ruff check` — clean

## Known Limitations
- The regression guard is a focused unit test on settings resolution (the actual bug), rather than CodeRabbit's heavier suggestion of driving `head_object` end-to-end through the download endpoint. The existing `test_download_endpoint.py` already covers the endpoint with a mocked StorageService; the new test covers the construction path that was broken.

https://claude.ai/code/session_01J5W2mJRAPFNkrC2HeZHVUZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage configuration handling so the service now uses the expected application settings for bucket and region values when no overrides are provided.
  * Added a fallback for region selection to help avoid startup issues when region settings are missing.
* **Tests**
  * Added coverage for default storage initialization to ensure configuration is resolved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->