### PR TITLE
fix(storage): serve & persist generated audio when AWS_S3_BUCKET is unset (#292)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,11 @@ AWS_SECRET_ACCESS_KEY=your-aws-secret-key-here
 AWS_S3_BUCKET=your-s3-bucket-name
 AWS_REGION=us-east-1
 
+# Local audio storage (no-S3 fallback). When AWS_S3_BUCKET is unset, generated
+# audio is persisted here and served from disk. MUST be persistent, backed-up
+# storage in production — not ephemeral /tmp (issue #292).
+LOCAL_AUDIO_STORAGE_PATH=storage/audio
+
 # Backend API Configuration
 API_HOST=0.0.0.0
 API_PORT=8000

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -38,6 +38,11 @@ AWS_SECRET_ACCESS_KEY=your-aws-secret-key-here
 AWS_S3_BUCKET=your-s3-bucket-name
 AWS_REGION=us-east-1
 
+# Local audio storage (no-S3 fallback). When AWS_S3_BUCKET is unset, generated
+# audio is persisted here and served from disk. MUST be persistent, backed-up
+# storage in production — not ephemeral /tmp (issue #292).
+LOCAL_AUDIO_STORAGE_PATH=storage/audio
+
 # Celery Configuration
 CELERY_BROKER_URL=redis://localhost:6379/0
 CELERY_RESULT_BACKEND=redis://localhost:6379/0

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -59,6 +59,11 @@ class Settings(BaseSettings):
     AWS_S3_BUCKET: Optional[str] = None
     AWS_REGION: str = "us-east-1"
 
+    # Local audio storage (no-S3 fallback). When AWS_S3_BUCKET is unset, generated
+    # audio is persisted here and served from disk. MUST be a persistent, backed-up
+    # path in production — not ephemeral /tmp (issue #292).
+    LOCAL_AUDIO_STORAGE_PATH: str = "storage/audio"
+
     # Stripe billing (both required to enable billing; see billing_service)
     STRIPE_SECRET_KEY: Optional[str] = None
     STRIPE_WEBHOOK_SECRET: Optional[str] = None

--- a/apps/api/src/routers/episodes.py
+++ b/apps/api/src/routers/episodes.py
@@ -6,6 +6,7 @@ status filtering, and generation management. All endpoints require authenticatio
 and automatically enforce tenant isolation via RLS.
 """
 
+import os
 from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException, status, Query, Header
 from fastapi.responses import StreamingResponse
@@ -35,7 +36,14 @@ from ..services.episode_service import (
 	VALID_SORT_ORDERS,
 )
 from ..services.storage_service import StorageService
-from ..utils.download_utils import get_episode_filename, parse_range_header, iter_s3_body
+from ..config import settings
+from ..utils.download_utils import (
+	get_episode_filename,
+	parse_range_header,
+	iter_s3_body,
+	iter_local_file,
+	is_within_dir,
+)
 
 router = APIRouter(prefix="/episodes", tags=["episodes"])
 
@@ -350,26 +358,39 @@ async def download_episode_audio(
 			detail=f"Episode not ready for download. Status: {episode.generation_status}"
 		)
 
-	if not episode.s3_key:
+	# Prefer S3 when an object key exists; otherwise fall back to local disk
+	# (no-S3 deployments persist the artifact to LOCAL_AUDIO_STORAGE_PATH — #292).
+	has_s3 = bool(episode.s3_key)
+	# Only serve local files that live under the configured audio store, so a
+	# bad/corrupted file_path can't expose an arbitrary local file (issue #292).
+	has_local = (
+		bool(episode.file_path)
+		and is_within_dir(episode.file_path, settings.LOCAL_AUDIO_STORAGE_PATH)
+		and os.path.isfile(episode.file_path)
+	)
+
+	if not has_s3 and not has_local:
 		raise HTTPException(
 			status_code=status.HTTP_404_NOT_FOUND,
 			detail="Episode audio file not found in storage"
 		)
 
-	storage = StorageService()
-
-	# Get file metadata from S3
-	head_response = storage.s3_client.head_object(
-		Bucket=storage.bucket_name,
-		Key=episode.s3_key
-	)
-	total_size = head_response["ContentLength"]
-
 	filename = get_episode_filename(episode)
 	http_status = 200
 	start_byte = 0
-	content_length = total_size
 	extra_headers = {}
+
+	if has_s3:
+		storage = StorageService()
+		head_response = storage.s3_client.head_object(
+			Bucket=storage.bucket_name,
+			Key=episode.s3_key
+		)
+		total_size = head_response["ContentLength"]
+	else:
+		total_size = os.path.getsize(episode.file_path)
+
+	content_length = total_size
 
 	if range:
 		# Parse range header - return 416 on invalid range
@@ -386,18 +407,22 @@ async def download_episode_audio(
 		content_length = end_byte - start_byte + 1
 		extra_headers["Content-Range"] = f"bytes {start_byte}-{end_byte}/{total_size}"
 
-		s3_response = storage.s3_client.get_object(
-			Bucket=storage.bucket_name,
-			Key=episode.s3_key,
-			Range=f"bytes={start_byte}-{end_byte}"
-		)
+	if has_s3:
+		if range:
+			s3_response = storage.s3_client.get_object(
+				Bucket=storage.bucket_name,
+				Key=episode.s3_key,
+				Range=f"bytes={start_byte}-{end_byte}"
+			)
+		else:
+			s3_response = storage.s3_client.get_object(
+				Bucket=storage.bucket_name,
+				Key=episode.s3_key
+			)
+		content = iter_s3_body(s3_response["Body"])
 	else:
-		s3_response = storage.s3_client.get_object(
-			Bucket=storage.bucket_name,
-			Key=episode.s3_key
-		)
-
-	body = s3_response["Body"]
+		end_arg = end_byte if range else None
+		content = iter_local_file(episode.file_path, start=start_byte, end=end_arg)
 
 	response_headers = {
 		"Content-Disposition": f'attachment; filename="{filename}"',
@@ -408,7 +433,7 @@ async def download_episode_audio(
 	}
 
 	return StreamingResponse(
-		content=iter_s3_body(body),
+		content=content,
 		status_code=http_status,
 		headers=response_headers,
 		media_type="audio/mpeg"

--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -3,6 +3,7 @@ Celery tasks for podcast generation
 Wraps the existing podcastfy CLI functionality
 """
 import os
+import shutil
 import time
 import uuid as uuid_module
 import logging
@@ -28,6 +29,24 @@ def build_podcast_s3_key(user_id: str, episode_id: str) -> str:
     bucket-policy/IAM/lifecycle rules scope on (issue #215).
     """
     return f"podcasts/user-{user_id}/episode-{episode_id}.mp3"
+
+
+def _persist_local_audio(audio_file_path: str, episode_id: str) -> str:
+    """Copy generated audio out of ephemeral /tmp into persistent local storage.
+
+    Used when AWS_S3_BUCKET is unset: the artifact would otherwise be the only
+    copy and would live in /tmp, so the episode is marked complete yet becomes
+    permanently undownloadable once /tmp is cleared (issue #292). Returns the
+    persistent path (or the original path unchanged if it is already inside the
+    storage dir).
+    """
+    storage_dir = settings.LOCAL_AUDIO_STORAGE_PATH
+    os.makedirs(storage_dir, exist_ok=True)
+    dest = os.path.join(storage_dir, f"episode-{episode_id}.mp3")
+    if os.path.abspath(dest) == os.path.abspath(audio_file_path):
+        return audio_file_path
+    shutil.copy2(audio_file_path, dest)
+    return dest
 
 
 def _upload_to_s3_with_retries(
@@ -474,8 +493,13 @@ def finalize_episode_generation_task(
                     db.commit()
                     return {"status": "failed", "error": error_msg}
             else:
+                # No S3: persist the artifact off ephemeral /tmp so the episode
+                # stays downloadable from local disk (issue #292).
+                persistent_path = _persist_local_audio(audio_file_path, episode_id)
+                episode.file_path = persistent_path
                 logger.info(
-                    f"AWS_S3_BUCKET not configured, skipping S3 upload for episode {episode_id}"
+                    f"AWS_S3_BUCKET not configured; persisted episode {episode_id} "
+                    f"audio to {persistent_path}"
                 )
 
             # Update episode with all file metadata and mark as complete

--- a/apps/api/src/utils/download_utils.py
+++ b/apps/api/src/utils/download_utils.py
@@ -7,9 +7,25 @@ Provides helpers for:
 - S3 streaming with range support
 """
 
+import os
 import re
 import asyncio
 from typing import AsyncIterator
+
+
+def is_within_dir(path: str, root: str) -> bool:
+	"""True if ``path`` resolves to a location inside ``root``.
+
+	Defense-in-depth for the no-S3 download fallback: only files under the
+	configured audio storage root may be streamed from disk, so a corrupted or
+	mis-written ``file_path`` can never expose an arbitrary local file (issue
+	#292). Uses ``realpath`` so symlinks can't escape the root.
+	"""
+	if not path:
+		return False
+	root_real = os.path.realpath(root)
+	path_real = os.path.realpath(path)
+	return os.path.commonpath([root_real, path_real]) == root_real
 
 
 def sanitize_filename(filename: str) -> str:
@@ -116,6 +132,49 @@ def get_episode_filename(episode) -> str:
 		return f"{sanitized_title}.mp3"
 	else:
 		return "episode.mp3"
+
+
+async def iter_local_file(
+	path: str,
+	start: int = 0,
+	end: int | None = None,
+	chunk_size: int = 8192,
+) -> AsyncIterator[bytes]:
+	"""Async generator that streams a local file in chunks, with optional range.
+
+	Filesystem analogue of ``iter_s3_body`` for the no-S3 download path (issue
+	#292). Streams bytes ``[start, end]`` inclusive (``end=None`` means to EOF),
+	offloading blocking reads via ``asyncio.to_thread`` so the event loop is not
+	blocked.
+
+	Args:
+		path: Local filesystem path to the audio file.
+		start: First byte offset to read (inclusive).
+		end: Last byte offset to read (inclusive), or None for end of file.
+		chunk_size: Number of bytes per chunk (default 8KB).
+
+	Yields:
+		Bytes chunks from the file within the requested range.
+	"""
+	def _open():
+		f = open(path, "rb")
+		if start:
+			f.seek(start)
+		return f
+
+	f = await asyncio.to_thread(_open)
+	try:
+		remaining = None if end is None else (end - start + 1)
+		while remaining is None or remaining > 0:
+			to_read = chunk_size if remaining is None else min(chunk_size, remaining)
+			chunk = await asyncio.to_thread(f.read, to_read)
+			if not chunk:
+				break
+			if remaining is not None:
+				remaining -= len(chunk)
+			yield chunk
+	finally:
+		await asyncio.to_thread(f.close)
 
 
 async def iter_s3_body(body, chunk_size: int = 8192) -> AsyncIterator[bytes]:

--- a/apps/api/tests/test_download_endpoint.py
+++ b/apps/api/tests/test_download_endpoint.py
@@ -135,12 +135,8 @@ async def test_download_episode_not_complete(client, episode_and_auth):
 	assert "not ready" in response.json()["detail"].lower()
 
 
-@pytest.mark.asyncio
-async def test_download_episode_missing_s3_key(client, episode_and_auth, set_system_fields):
-	"""Returns 404 when episode is complete but s3_key is not set."""
-	_, headers = episode_and_auth
-
-	# Create a project and episode with complete status but no s3_key
+async def _make_complete_episode(client, headers, **system_fields):
+	"""Create a project + episode, then set pipeline-managed fields. Returns id."""
 	proj_response = await client.post("/projects", headers=headers, json={
 		"name": "No S3 Project",
 		"podcast_metadata": {
@@ -156,14 +152,85 @@ async def test_download_episode_missing_s3_key(client, episode_and_auth, set_sys
 		"episode_number": 1,
 		"episode_metadata": {"title": "No S3 Ep", "description": "Desc"}
 	})
-	episode_id = ep_response.json()["id"]
+	assert ep_response.status_code == 201
+	return ep_response.json()["id"], system_fields
 
-	# Mark complete without setting s3_key (system field — set as the pipeline does)
+
+@pytest.mark.asyncio
+async def test_download_episode_missing_s3_key(client, episode_and_auth, set_system_fields):
+	"""Returns 404 only when BOTH s3_key and a usable local file_path are absent."""
+	_, headers = episode_and_auth
+
+	episode_id, _ = await _make_complete_episode(client, headers)
+
+	# Mark complete with neither s3_key nor file_path (system fields — pipeline path)
 	await set_system_fields(episode_id, generation_status="complete")
 
 	response = await client.get(f"/episodes/{episode_id}/download", headers=headers)
 	assert response.status_code == 404
 	assert "audio file not found" in response.json()["detail"].lower()
+
+
+# ============================================================================
+# No-S3 local-disk download (issue #292)
+# ============================================================================
+
+@pytest.mark.asyncio
+async def test_download_local_file_success(
+	client, episode_and_auth, set_system_fields, tmp_path, monkeypatch
+):
+	"""Serves a 200 from local disk when s3_key is absent but file_path exists."""
+	from src.config import settings
+	monkeypatch.setattr(settings, "LOCAL_AUDIO_STORAGE_PATH", str(tmp_path))
+	_, headers = episode_and_auth
+	audio = b"LOCAL_MP3_CONTENT_" * 16
+	audio_path = tmp_path / "episode-local.mp3"
+	audio_path.write_bytes(audio)
+
+	episode_id, _ = await _make_complete_episode(client, headers)
+	await set_system_fields(
+		episode_id, generation_status="complete", s3_key=None, file_path=str(audio_path)
+	)
+
+	response = await client.get(f"/episodes/{episode_id}/download", headers=headers)
+
+	assert response.status_code == 200
+	assert response.headers["content-type"] == "audio/mpeg"
+	assert "attachment" in response.headers["content-disposition"]
+	assert ".mp3" in response.headers["content-disposition"]
+	assert int(response.headers["content-length"]) == len(audio)
+	assert response.headers["accept-ranges"] == "bytes"
+	assert response.content == audio
+
+
+@pytest.mark.asyncio
+async def test_download_local_file_range_206(
+	client, episode_and_auth, set_system_fields, tmp_path, monkeypatch
+):
+	"""Range request over a local file returns 206 with correct slice and headers."""
+	from src.config import settings
+	monkeypatch.setattr(settings, "LOCAL_AUDIO_STORAGE_PATH", str(tmp_path))
+	_, headers = episode_and_auth
+	audio = bytes(range(256)) * 8  # 2048 bytes
+	audio_path = tmp_path / "episode-local.mp3"
+	audio_path.write_bytes(audio)
+	total_size = len(audio)
+	range_start, range_end = 100, 199
+
+	episode_id, _ = await _make_complete_episode(client, headers)
+	await set_system_fields(
+		episode_id, generation_status="complete", s3_key=None, file_path=str(audio_path)
+	)
+
+	response = await client.get(
+		f"/episodes/{episode_id}/download",
+		headers={**headers, "Range": f"bytes={range_start}-{range_end}"}
+	)
+
+	assert response.status_code == 206
+	assert response.headers["content-range"] == f"bytes {range_start}-{range_end}/{total_size}"
+	assert int(response.headers["content-length"]) == 100
+	assert response.content == audio[range_start:range_end + 1]
 
 
 # ============================================================================

--- a/apps/api/tests/test_s3_upload.py
+++ b/apps/api/tests/test_s3_upload.py
@@ -224,11 +224,17 @@ class TestFinalizeEpisodeGenerationTask:
         mock_db.commit = MagicMock()
         return mock_db
 
-    def test_skips_s3_upload_when_bucket_not_configured(self):
-        """If AWS_S3_BUCKET is not set, episode is marked complete without S3 upload."""
+    def test_skips_s3_upload_when_bucket_not_configured(self, tmp_path):
+        """If AWS_S3_BUCKET is not set, episode is marked complete and the audio is
+        persisted off /tmp into LOCAL_AUDIO_STORAGE_PATH so it stays downloadable (#292)."""
         episode_id = str(uuid.uuid4())
         episode = _make_mock_episode(episode_id)
-        generation_result = self._make_generation_result()
+
+        # Real source file so the no-S3 branch can copy it to persistent storage.
+        src_audio = tmp_path / "episode-abc.mp3"
+        src_audio.write_bytes(b"FAKE_MP3")
+        storage_dir = tmp_path / "audio"
+        generation_result = self._make_generation_result(audio_file_path=str(src_audio))
         mock_db = self._make_db_context_manager(episode)
 
         with (
@@ -236,13 +242,17 @@ class TestFinalizeEpisodeGenerationTask:
             patch("src.tasks.podcast_generation.settings") as mock_settings,
         ):
             mock_settings.AWS_S3_BUCKET = None
+            mock_settings.LOCAL_AUDIO_STORAGE_PATH = str(storage_dir)
             result = self._invoke_finalize(episode_id, generation_result, mock_db)
 
         assert result["status"] == "success"
         assert episode.generation_status == "complete"
         assert episode.s3_url is None
         assert episode.s3_key is None
-        assert episode.file_path == "/tmp/episode-abc.mp3"
+        # file_path now points into persistent storage, not the ephemeral source
+        assert episode.file_path == str(storage_dir / f"episode-{episode_id}.mp3")
+        assert os.path.isfile(episode.file_path)
+        assert episode.file_path != str(src_audio)
 
     def test_populates_s3_url_on_successful_upload(self):
         """Episode.s3_url and s3_key are populated after successful S3 upload."""
@@ -380,12 +390,15 @@ class TestFinalizeEpisodeGenerationTask:
         expected_key = f"podcasts/user-{user_id}/episode-{episode_id}.mp3"
         assert captured.get("s3_key") == expected_key
 
-    def test_episode_stores_file_metadata(self):
+    def test_episode_stores_file_metadata(self, tmp_path):
         """Episode stores file_path, duration_seconds, file_size_bytes regardless of S3."""
         episode_id = str(uuid.uuid4())
         episode = _make_mock_episode(episode_id)
+        src_audio = tmp_path / "my-podcast.mp3"
+        src_audio.write_bytes(b"FAKE_MP3")
+        storage_dir = tmp_path / "audio"
         generation_result = self._make_generation_result(
-            audio_file_path="/tmp/my-podcast.mp3",
+            audio_file_path=str(src_audio),
             transcript_path="/tmp/my-podcast_transcript.txt",
             duration_seconds=450.5,
             file_size_bytes=9_999_999,
@@ -397,10 +410,14 @@ class TestFinalizeEpisodeGenerationTask:
             patch("src.tasks.podcast_generation.settings") as mock_settings,
         ):
             mock_settings.AWS_S3_BUCKET = None
+            mock_settings.LOCAL_AUDIO_STORAGE_PATH = str(storage_dir)
             result = self._invoke_finalize(episode_id, generation_result, mock_db)
 
         assert result["status"] == "success"
-        assert episode.file_path == "/tmp/my-podcast.mp3"
+        # No-S3 path persists audio off /tmp; transcript_path is untouched (#292)
+        assert episode.file_path == str(storage_dir / f"episode-{episode_id}.mp3")
+        assert episode.duration_seconds == 450.5
+        assert episode.file_size_bytes == 9_999_999
         assert episode.transcript_path == "/tmp/my-podcast_transcript.txt"
         assert episode.duration_seconds == 450.5
         assert episode.file_size_bytes == 9_999_999

--- a/apps/api/tests/unit/test_download_utils.py
+++ b/apps/api/tests/unit/test_download_utils.py
@@ -8,7 +8,39 @@ Covers filename sanitization, range header parsing, and episode filename generat
 import pytest
 from unittest.mock import MagicMock
 
-from src.utils.download_utils import sanitize_filename, parse_range_header, get_episode_filename, iter_s3_body
+from src.utils.download_utils import (
+	sanitize_filename,
+	parse_range_header,
+	get_episode_filename,
+	iter_s3_body,
+	iter_local_file,
+	is_within_dir,
+)
+
+
+class TestIsWithinDir:
+	"""Cover the download containment guard (issue #292)."""
+
+	def test_file_inside_root(self, tmp_path):
+		f = tmp_path / "audio" / "episode-1.mp3"
+		f.parent.mkdir()
+		f.write_bytes(b"x")
+		assert is_within_dir(str(f), str(tmp_path / "audio")) is True
+
+	def test_file_outside_root(self, tmp_path):
+		root = tmp_path / "audio"
+		root.mkdir()
+		outside = tmp_path / "secret.txt"
+		outside.write_bytes(b"x")
+		assert is_within_dir(str(outside), str(root)) is False
+
+	def test_traversal_escape_blocked(self, tmp_path):
+		root = tmp_path / "audio"
+		root.mkdir()
+		assert is_within_dir(str(root / ".." / "etc-passwd"), str(root)) is False
+
+	def test_empty_path(self, tmp_path):
+		assert is_within_dir("", str(tmp_path)) is False
 
 
 # ============================================================================
@@ -277,3 +309,51 @@ class TestIterS3Body:
 			chunks.append(chunk)
 
 		assert chunks == []
+
+
+# ============================================================================
+# iter_local_file (issue #292)
+# ============================================================================
+
+class TestIterLocalFile:
+	"""Cover the iter_local_file async generator (full + ranged reads)."""
+
+	@pytest.mark.asyncio
+	async def test_full_read(self, tmp_path):
+		"""Without a range, streams the whole file in order."""
+		data = b"ABCDEFGHIJ" * 100  # 1000 bytes
+		path = tmp_path / "audio.mp3"
+		path.write_bytes(data)
+
+		chunks = []
+		async for chunk in iter_local_file(str(path), chunk_size=64):
+			chunks.append(chunk)
+
+		assert b"".join(chunks) == data
+		assert all(len(c) <= 64 for c in chunks)
+
+	@pytest.mark.asyncio
+	async def test_ranged_read(self, tmp_path):
+		"""With start/end (inclusive), streams exactly that byte range."""
+		data = bytes(range(256))
+		path = tmp_path / "audio.mp3"
+		path.write_bytes(data)
+
+		chunks = []
+		async for chunk in iter_local_file(str(path), start=10, end=19, chunk_size=4):
+			chunks.append(chunk)
+
+		assert b"".join(chunks) == data[10:20]
+
+	@pytest.mark.asyncio
+	async def test_range_to_eof(self, tmp_path):
+		"""start with end=None reads from start to end of file."""
+		data = b"0123456789"
+		path = tmp_path / "audio.mp3"
+		path.write_bytes(data)
+
+		chunks = []
+		async for chunk in iter_local_file(str(path), start=5):
+			chunks.append(chunk)
+
+		assert b"".join(chunks) == data[5:]

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -331,6 +331,14 @@ here and on the dev machine → `pm2 restart podcaststudiohub-api` → verify (P
 DeleteObject) → **then** deactivate and delete the old key. Permissions live on the IAM user, not
 the key, so rotation never changes them.
 
+**Enable bucket versioning (required):** versioning protects generated audio against accidental
+overwrite/delete. The app's least-privilege IAM user *cannot* toggle versioning, so this is a
+one-time **administrative** action — run it from AWS CloudShell (admin identity), not the app user:
+
+```bash
+deployment/scripts/enable-s3-versioning.sh podcaststudiohub-audio
+```
+
 ## Nginx Configuration
 
 Nginx reverse proxy configuration is in `deployment/nginx/podcastfy.conf`.

--- a/deployment/scripts/enable-s3-versioning.sh
+++ b/deployment/scripts/enable-s3-versioning.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Enable S3 bucket versioning so generated audio is protected against accidental
+# overwrite/delete (issue #292). Administrative action — run from AWS CloudShell
+# (admin identity); the app's least-privilege IAM user cannot toggle versioning.
+#
+# Usage: enable-s3-versioning.sh <bucket-name>
+set -euo pipefail
+
+BUCKET="${1:?Usage: enable-s3-versioning.sh <bucket-name>}"
+
+aws s3api put-bucket-versioning \
+  --bucket "$BUCKET" \
+  --versioning-configuration Status=Enabled
+
+aws s3api get-bucket-versioning --bucket "$BUCKET"
+echo "Versioning enabled on $BUCKET"


### PR DESCRIPTION
Fixes #292.

## Problem
When `AWS_S3_BUCKET` is unset, `finalize_episode_generation_task` logged a skip and still marked the episode `generation_status='complete'` with only a `/tmp/composed_{id}.mp3` `file_path`. The download endpoint required `s3_key`, so it 404'd. Result: in any no-S3 deployment, episodes were marked complete yet permanently undownloadable, with the only artifact on ephemeral disk.

## Approach
Per the issue's CodeRabbit plan (Design Choice 1 → option 2): a **backed-up local-disk fallback** rather than forcing S3 everywhere. `Episode` already always persists `file_path`, so the data model was ready for it.

## Changes
- **Persist off /tmp** — `finalize_episode_generation_task` copies the audio into `LOCAL_AUDIO_STORAGE_PATH` and points `file_path` there before committing `complete` (no-S3 branch only; S3 path untouched).
- **Local streaming** — new `iter_local_file` iterator (mirrors `iter_s3_body`, `asyncio.to_thread`, range-aware) + a download-endpoint branch that serves from `file_path` with full 200/206/416 range parity and identical headers.
- **Containment guard** — `is_within_dir` restricts local serving to files under the configured store (defense-in-depth; raised in `codex review`).
- **Config** — `LOCAL_AUDIO_STORAGE_PATH` setting (default `storage/audio`), documented in `apps/api/.env.example` and root `.env.example` as needing persistent/backed-up storage.
- **S3 versioning** — `deployment/scripts/enable-s3-versioning.sh` + a required README step (admin action; app IAM user can't toggle versioning).

## Tests
- `test_skips_s3_upload_when_bucket_not_configured` / `test_episode_stores_file_metadata`: assert `file_path` lands in `LOCAL_AUDIO_STORAGE_PATH`, not `/tmp`.
- `test_download_local_file_success` (200) + `test_download_local_file_range_206` (206) over a real on-disk file.
- `test_download_episode_missing_s3_key`: 404 only when **both** `s3_key` and a usable `file_path` are absent.
- `iter_local_file` full/ranged/to-EOF reads; `is_within_dir` inside/outside/traversal/empty.
- All 77 related tests pass; existing S3 download tests unchanged (S3 path behavior preserved).

## Acceptance criteria
- [x] No-S3: episode complete **and** downloadable (no permanent /tmp loss)
- [x] S3 bucket versioning enabled/documented
- [x] Test for the no-S3 path
- [x] S3 path behavior unchanged

## Known limitations
- Versioning is enabled operationally (helper script + README), not via IaC — there is no IaC in the repo, and the app's least-privilege IAM user cannot toggle versioning. It remains a one-time admin action.
- `LOCAL_AUDIO_STORAGE_PATH` durability is the operator's responsibility (must be backed-up storage); documented in both `.env.example` files.

https://claude.ai/code/session_01J5W2mJRAPFNkrC2HeZHVUZ
