### PR TITLE
feat(deployment): automated PostgreSQL backup/restore to S3 (#293)

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -339,6 +339,93 @@ one-time **administrative** action — run it from AWS CloudShell (admin identit
 deployment/scripts/enable-s3-versioning.sh podcaststudiohub-audio
 ```
 
+## Database Backup & Restore (DR) — issue #293
+
+All durable tenant state (accounts, projects, episodes, RSS feeds, distribution
+targets with encrypted OAuth tokens, Stripe billing) lives only in the VPS
+Postgres datadir. Host loss without an off-host copy = total, unrecoverable loss.
+These scripts give an automated nightly logical dump shipped to S3 with retention,
+plus a tested restore path.
+
+**Recovery targets:** **RPO ≤ 24h** (worst case: data written since the last
+nightly dump) and **RTO ≈ minutes** (download the dump + `pg_restore`). For a
+tighter RPO you'd move to continuous WAL archiving (pgBackRest/WAL-G); nightly
+logical dumps are the deliberate, lazy-correct choice for a single-VPS dev host.
+
+### What it does
+
+- `deployment/scripts/backup-db.sh` — `pg_dump -Fc` → timestamped object
+  at `s3://$DB_BACKUP_S3_BUCKET/$DB_BACKUP_S3_PREFIX`, then prunes objects older
+  than `DB_BACKUP_RETENTION_DAYS` (default 14).
+- `deployment/scripts/install-db-backup-timer.sh` — installs a systemd service +
+  nightly timer (`03:30` by default) that runs the backup as the non-root
+  `podcastfy` service account, reading DB/S3 settings from the API `.env`.
+- `deployment/scripts/restore-db.sh` — pulls a dump from S3 and `pg_restore`s it
+  (latest by default, or a named backup), guarded by a confirmation prompt.
+
+Settings (env, defaulting to the app's existing `AWS_*` / `DATABASE_URL`):
+
+| Var | Default | Meaning |
+|---|---|---|
+| `DB_BACKUP_S3_BUCKET` | `$AWS_S3_BUCKET` | bucket for dumps |
+| `DB_BACKUP_S3_PREFIX` | `db-backups/` | key prefix |
+| `DB_BACKUP_RETENTION_DAYS` | `14` | prune objects older than N days |
+| `ON_CALENDAR` (installer) | `*-*-* 03:30:00` | systemd nightly schedule |
+
+> **IAM:** the backup needs `s3:PutObject` + `s3:GetObject` + `s3:DeleteObject`
+> (retention prune) **and** `s3:ListBucket` (find latest / prune) on the backup
+> prefix. The app's audio IAM user intentionally lacks `ListBucket`, so use a
+> separate backup credential, or set `DB_BACKUP_S3_BUCKET` to a dedicated bucket
+> whose IAM policy grants those four actions on `arn:aws:s3:::<bucket>/db-backups/*`
+> plus `ListBucket` on the bucket.
+
+### Install (once, on the VPS)
+
+```bash
+ssh root@<SERVER_IP>
+cd /opt/podcaststudiohub && bash deployment/scripts/install-db-backup-timer.sh
+systemctl list-timers podcastfy-db-backup.timer   # confirm the next run
+```
+
+Trigger an immediate backup to verify the pipeline end-to-end:
+
+```bash
+systemctl start podcastfy-db-backup.service
+journalctl -u podcastfy-db-backup.service -n 50    # look for "Uploaded … to s3://…"
+aws s3 ls s3://$AWS_S3_BUCKET/db-backups/           # the dump object is present
+```
+
+### Restore runbook (tested)
+
+```bash
+ssh root@<SERVER_IP>
+cd /opt/podcaststudiohub
+
+# Make DB/S3 settings available (same as the app):
+set -a && . api/.env && set +a
+
+# Restore the latest backup (prompts before overwriting):
+bash deployment/scripts/restore-db.sh
+
+# …or a specific backup by name:
+aws s3 ls s3://$AWS_S3_BUCKET/db-backups/
+bash deployment/scripts/restore-db.sh podcastfy-20260601T033000Z.dump
+```
+
+**Test the restore without touching prod** (do this at least once, then quarterly):
+
+```bash
+# Restore the latest dump into a throwaway database and sanity-check row counts.
+createdb podcastfy_restore_test
+DATABASE_URL="postgresql://user:pass@localhost/podcastfy_restore_test" \
+  DB_RESTORE_FORCE=1 bash deployment/scripts/restore-db.sh
+psql podcastfy_restore_test -c "SELECT count(*) FROM users;"
+dropdb podcastfy_restore_test
+```
+
+A green restore-test is the only proof the backups are usable — an untested
+backup is not a backup.
+
 ## Nginx Configuration
 
 Nginx reverse proxy configuration is in `deployment/nginx/podcastfy.conf`.

--- a/deployment/scripts/backup-db.sh
+++ b/deployment/scripts/backup-db.sh
@@ -75,6 +75,9 @@ aws s3 ls "s3://${DB_BACKUP_S3_BUCKET}/${DB_BACKUP_S3_PREFIX}" | while read -r l
 	file_date="$(echo "$line" | awk '{print $1}')"
 	file_name="$(echo "$line" | awk '{print $4}')"
 	[[ -z "$file_name" ]] && continue
+	# Only ever prune objects this script created — never unrelated keys that
+	# happen to share the prefix. Match our own podcastfy-<stamp>.dump pattern.
+	[[ "$file_name" == podcastfy-*.dump ]] || continue
 	if [[ "$file_date" < "$CUTOFF" ]]; then
 		echo "  deleting aged-out backup: ${file_name}"
 		aws s3 rm "s3://${DB_BACKUP_S3_BUCKET}/${DB_BACKUP_S3_PREFIX}${file_name}"

--- a/deployment/scripts/backup-db.sh
+++ b/deployment/scripts/backup-db.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Nightly off-host PostgreSQL backup for the Podcastfy Studio VPS (issue #293).
+#
+# All durable tenant state (users, auth, projects, episodes, RSS feeds,
+# distribution targets with encrypted OAuth tokens, Stripe billing) lives only
+# in the single VPS Postgres datadir. This takes a logical custom-format dump,
+# compresses it, ships it to S3 object storage, and prunes backups older than
+# the retention window. Run nightly via install-db-backup-timer.sh.
+#
+# Idempotent and safe to run by hand for an on-demand backup:
+#   bash deployment/scripts/backup-db.sh
+#
+# Configuration (env, with sensible defaults):
+#   DATABASE_URL              postgres conn string (or use the PG* vars below)
+#   PGHOST/PGPORT/PGDATABASE/PGUSER/PGPASSWORD   standard libpq vars (fallback)
+#   DB_BACKUP_S3_BUCKET       bucket for dumps (default: $AWS_S3_BUCKET)
+#   DB_BACKUP_S3_PREFIX       key prefix      (default: db-backups/)
+#   DB_BACKUP_RETENTION_DAYS  prune objects older than N days (default: 14)
+#   AWS_REGION                passed through to the aws CLI
+
+set -euo pipefail
+
+DB_BACKUP_S3_BUCKET="${DB_BACKUP_S3_BUCKET:-${AWS_S3_BUCKET:-}}"
+DB_BACKUP_S3_PREFIX="${DB_BACKUP_S3_PREFIX:-db-backups/}"
+DB_BACKUP_RETENTION_DAYS="${DB_BACKUP_RETENTION_DAYS:-14}"
+
+if [[ -z "$DB_BACKUP_S3_BUCKET" ]]; then
+	echo "DB_BACKUP_S3_BUCKET (or AWS_S3_BUCKET) must be set — refusing a host-only backup." >&2
+	exit 1
+fi
+
+# pg_dump reads DATABASE_URL directly if given; otherwise it falls back to the
+# standard libpq PG* environment variables. We pass the conn string explicitly
+# so a DATABASE_URL with a +asyncpg driver suffix (SQLAlchemy style) is
+# normalised to a plain postgres:// URL pg_dump understands.
+CONN=()
+if [[ -n "${DATABASE_URL:-}" ]]; then
+	CONN=("${DATABASE_URL/postgresql+asyncpg:/postgresql:}")
+	CONN=("${CONN[0]/postgres+asyncpg:/postgres:}")
+fi
+
+# ponytail: timestamp from `date`, not a fixed clock — backups must be unique &
+# sortable. UTC so retention math is DST-proof.
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+DUMP_FILE="$(mktemp -t podcastfy-db-XXXXXX.dump)"
+trap 'rm -f "$DUMP_FILE"' EXIT
+
+KEY="${DB_BACKUP_S3_PREFIX}podcastfy-${STAMP}.dump"
+DEST="s3://${DB_BACKUP_S3_BUCKET}/${KEY}"
+
+echo "Dumping database -> ${DEST}"
+# -Fc = custom format: already zlib-compressed and gives selective, parallel
+# pg_restore. No extra gzip layer — it would double-compress for ~0 gain.
+pg_dump -Fc "${CONN[@]}" >"$DUMP_FILE"
+
+if [[ ! -s "$DUMP_FILE" ]]; then
+	echo "pg_dump produced an empty file — aborting before upload." >&2
+	exit 1
+fi
+
+aws s3 cp "$DUMP_FILE" "$DEST"
+echo "Uploaded $(du -h "$DUMP_FILE" | cut -f1) to ${DEST}"
+
+# ── Retention: prune objects older than the window ─────────────────────────
+# `aws s3 ls` reports each object's last-modified date; delete anything past the
+# cutoff. ponytail: O(n) scan over one prefix — fine for nightly dumps; switch
+# to an S3 lifecycle rule if the prefix ever holds thousands of objects.
+CUTOFF="$(date -u -d "${DB_BACKUP_RETENTION_DAYS} days ago" +%Y-%m-%d)"
+echo "Pruning backups older than ${CUTOFF} (retention ${DB_BACKUP_RETENTION_DAYS}d)"
+
+aws s3 ls "s3://${DB_BACKUP_S3_BUCKET}/${DB_BACKUP_S3_PREFIX}" | while read -r line; do
+	# `aws s3 ls <prefix>/` lines: "2026-06-01 03:00:00  123456 podcastfy-….dump.gz"
+	# (the name is relative to the listed prefix, so we re-add the prefix to delete).
+	file_date="$(echo "$line" | awk '{print $1}')"
+	file_name="$(echo "$line" | awk '{print $4}')"
+	[[ -z "$file_name" ]] && continue
+	if [[ "$file_date" < "$CUTOFF" ]]; then
+		echo "  deleting aged-out backup: ${file_name}"
+		aws s3 rm "s3://${DB_BACKUP_S3_BUCKET}/${DB_BACKUP_S3_PREFIX}${file_name}"
+	fi
+done
+
+echo "Backup complete."

--- a/deployment/scripts/install-db-backup-timer.sh
+++ b/deployment/scripts/install-db-backup-timer.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Install the nightly PostgreSQL backup as a systemd timer (issue #293).
+#
+# Creates a oneshot service that runs backup-db.sh as the non-root service
+# account, plus a timer that fires nightly. Idempotent — re-running just
+# rewrites the units and re-enables the timer. Run once as root on the VPS:
+#
+#   ssh root@<server>
+#   cd /opt/podcaststudiohub && bash deployment/scripts/install-db-backup-timer.sh
+#
+# The backup's S3/DB settings are read from the API's .env at run time, so the
+# same DATABASE_URL / AWS_* / DB_BACKUP_* values the app uses drive the backup.
+#
+# Configuration (env):
+#   SERVICE_USER     account that runs the backup (default: podcastfy)
+#   APP_ROOT         app tree root            (default: /opt/podcaststudiohub)
+#   BACKUP_ENV_FILE  env file with DB/S3 settings (default: $APP_ROOT/api/.env)
+#   ON_CALENDAR      systemd schedule         (default: *-*-* 03:30:00 nightly)
+
+set -euo pipefail
+
+SERVICE_USER="${SERVICE_USER:-podcastfy}"
+APP_ROOT="${APP_ROOT:-/opt/podcaststudiohub}"
+BACKUP_ENV_FILE="${BACKUP_ENV_FILE:-$APP_ROOT/api/.env}"
+ON_CALENDAR="${ON_CALENDAR:-*-*-* 03:30:00}"
+SCRIPT_PATH="$APP_ROOT/deployment/scripts/backup-db.sh"
+
+if [[ "$(id -u)" -ne 0 ]]; then
+	echo "install-db-backup-timer.sh must run as root (it writes systemd units)." >&2
+	exit 1
+fi
+
+if [[ ! -f "$SCRIPT_PATH" ]]; then
+	echo "backup script not found at $SCRIPT_PATH — deploy the repo first." >&2
+	exit 1
+fi
+
+echo "Installing podcastfy-db-backup systemd service + timer..."
+
+cat >/etc/systemd/system/podcastfy-db-backup.service <<EOF
+[Unit]
+Description=Podcastfy Studio nightly PostgreSQL backup to S3 (issue #293)
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=${SERVICE_USER}
+# Load DB/S3 settings from the app env. '-' = don't fail if absent (the unit
+# still runs; backup-db.sh errors clearly if required vars are missing).
+EnvironmentFile=-${BACKUP_ENV_FILE}
+ExecStart=/usr/bin/env bash ${SCRIPT_PATH}
+EOF
+
+cat >/etc/systemd/system/podcastfy-db-backup.timer <<EOF
+[Unit]
+Description=Run the Podcastfy Studio PostgreSQL backup nightly (issue #293)
+
+[Timer]
+OnCalendar=${ON_CALENDAR}
+# Catch up if the VPS was asleep/off at the scheduled time.
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now podcastfy-db-backup.timer
+
+echo
+echo "Installed. Next run:"
+systemctl list-timers podcastfy-db-backup.timer --no-pager || true
+echo
+echo "Run an immediate backup to verify:  systemctl start podcastfy-db-backup.service"
+echo "Then check logs:                    journalctl -u podcastfy-db-backup.service -n 50"

--- a/deployment/scripts/restore-db.sh
+++ b/deployment/scripts/restore-db.sh
@@ -41,8 +41,10 @@ fi
 # ── Resolve which backup to restore ────────────────────────────────────────
 ARG="${1:-}"
 if [[ -z "$ARG" ]]; then
-	# Latest = last line of the sorted (timestamped keys sort chronologically) listing.
-	NAME="$(aws s3 ls "s3://${DB_BACKUP_S3_BUCKET}/${DB_BACKUP_S3_PREFIX}" | awk '{print $4}' | grep -v '^$' | sort | tail -n1)"
+	# Latest = last of the chronologically-sorted dumps. Filter to our own
+	# podcastfy-<stamp>.dump pattern so a stray object under the prefix can't be
+	# selected as the "backup" to restore.
+	NAME="$(aws s3 ls "s3://${DB_BACKUP_S3_BUCKET}/${DB_BACKUP_S3_PREFIX}" | awk '{print $4}' | grep -E '^podcastfy-[0-9]{8}T[0-9]{6}Z\.dump$' | sort | tail -n1)"
 	if [[ -z "$NAME" ]]; then
 		echo "No backups found under s3://${DB_BACKUP_S3_BUCKET}/${DB_BACKUP_S3_PREFIX}" >&2
 		exit 1
@@ -78,8 +80,10 @@ echo "Downloading ${SRC}..."
 aws s3 cp "$SRC" "$DUMP_FILE"
 
 echo "Restoring into target database..."
-# --clean --if-exists makes the restore idempotent over an existing schema;
-# pg_restore exits non-zero on real errors (set -e propagates the failure).
-pg_restore --clean --if-exists --no-owner --dbname "$TARGET_DB" "$DUMP_FILE"
+# --single-transaction + --exit-on-error make the restore atomic: any failure
+# rolls the whole thing back, so a half-applied --clean can't leave the live DB
+# corrupted. --clean --if-exists makes it idempotent over an existing schema.
+pg_restore --single-transaction --exit-on-error --clean --if-exists --no-owner \
+	--dbname "$TARGET_DB" "$DUMP_FILE"
 
 echo "Restore complete from ${SRC}."

--- a/deployment/scripts/restore-db.sh
+++ b/deployment/scripts/restore-db.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Restore a PostgreSQL backup from S3 (issue #293) — the DR recovery path.
+#
+# Fetches a custom-format dump produced by backup-db.sh and pg_restore's it into
+# the target database. Restoring OVERWRITES live data, so it requires explicit
+# confirmation (or DB_RESTORE_FORCE=1 for unattended runs).
+#
+#   bash deployment/scripts/restore-db.sh                 # restore the latest backup
+#   bash deployment/scripts/restore-db.sh <s3-key-or-name># restore a specific backup
+#   DB_RESTORE_FORCE=1 bash deployment/scripts/restore-db.sh   # skip the prompt
+#
+# Configuration mirrors backup-db.sh:
+#   DATABASE_URL / PG* libpq vars   target database
+#   DB_BACKUP_S3_BUCKET (default $AWS_S3_BUCKET), DB_BACKUP_S3_PREFIX (db-backups/)
+#   DB_RESTORE_FORCE=1              skip the confirmation prompt
+
+set -euo pipefail
+
+DB_BACKUP_S3_BUCKET="${DB_BACKUP_S3_BUCKET:-${AWS_S3_BUCKET:-}}"
+DB_BACKUP_S3_PREFIX="${DB_BACKUP_S3_PREFIX:-db-backups/}"
+
+if [[ -z "$DB_BACKUP_S3_BUCKET" ]]; then
+	echo "DB_BACKUP_S3_BUCKET (or AWS_S3_BUCKET) must be set." >&2
+	exit 1
+fi
+
+# pg_restore --dbname needs an explicit target. Prefer DATABASE_URL (normalised
+# off any +asyncpg driver suffix); otherwise fall back to PGDATABASE so the
+# remaining libpq PG* vars (host/user/password) still apply.
+if [[ -n "${DATABASE_URL:-}" ]]; then
+	TARGET_DB="${DATABASE_URL/postgresql+asyncpg:/postgresql:}"
+	TARGET_DB="${TARGET_DB/postgres+asyncpg:/postgres:}"
+elif [[ -n "${PGDATABASE:-}" ]]; then
+	TARGET_DB="$PGDATABASE"
+else
+	echo "Set DATABASE_URL or PGDATABASE so pg_restore knows the target database." >&2
+	exit 1
+fi
+
+# ── Resolve which backup to restore ────────────────────────────────────────
+ARG="${1:-}"
+if [[ -z "$ARG" ]]; then
+	# Latest = last line of the sorted (timestamped keys sort chronologically) listing.
+	NAME="$(aws s3 ls "s3://${DB_BACKUP_S3_BUCKET}/${DB_BACKUP_S3_PREFIX}" | awk '{print $4}' | grep -v '^$' | sort | tail -n1)"
+	if [[ -z "$NAME" ]]; then
+		echo "No backups found under s3://${DB_BACKUP_S3_BUCKET}/${DB_BACKUP_S3_PREFIX}" >&2
+		exit 1
+	fi
+	KEY="${DB_BACKUP_S3_PREFIX}${NAME}"
+else
+	# Accept either a bare filename or a full prefixed key.
+	if [[ "$ARG" == "${DB_BACKUP_S3_PREFIX}"* ]]; then
+		KEY="$ARG"
+	else
+		KEY="${DB_BACKUP_S3_PREFIX}${ARG}"
+	fi
+fi
+
+SRC="s3://${DB_BACKUP_S3_BUCKET}/${KEY}"
+echo "Selected backup: ${SRC}"
+
+# ── Guard: restoring clobbers the live database ────────────────────────────
+if [[ "${DB_RESTORE_FORCE:-}" != "1" ]]; then
+	echo
+	echo "WARNING: pg_restore --clean will DROP and recreate objects in the target database."
+	read -r -p "Type 'yes' to proceed: " CONFIRM
+	if [[ "$CONFIRM" != "yes" ]]; then
+		echo "Aborted."
+		exit 1
+	fi
+fi
+
+DUMP_FILE="$(mktemp -t podcastfy-restore-XXXXXX.dump)"
+trap 'rm -f "$DUMP_FILE"' EXIT
+
+echo "Downloading ${SRC}..."
+aws s3 cp "$SRC" "$DUMP_FILE"
+
+echo "Restoring into target database..."
+# --clean --if-exists makes the restore idempotent over an existing schema;
+# pg_restore exits non-zero on real errors (set -e propagates the failure).
+pg_restore --clean --if-exists --no-owner --dbname "$TARGET_DB" "$DUMP_FILE"
+
+echo "Restore complete from ${SRC}."

--- a/deployment/tests/test_db_backup.py
+++ b/deployment/tests/test_db_backup.py
@@ -1,0 +1,121 @@
+"""Tests for the PostgreSQL backup/restore tooling (issue #293).
+
+All durable tenant state lives only in the single VPS Postgres datadir. These
+tests pin the disaster-recovery contract: an automated off-host nightly logical
+dump to object storage with retention (installed via a systemd timer running as
+the non-root service account), and a documented, tested restore runbook with
+target RTO/RPO. They read the scripts statically — like test_deploy_hardening.py
+— so a regression (dropping the S3 upload, the prune, or the restore guard)
+fails CI without needing a live Postgres/S3.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "deployment" / "scripts"
+BACKUP = SCRIPTS / "backup-db.sh"
+INSTALL_TIMER = SCRIPTS / "install-db-backup-timer.sh"
+RESTORE = SCRIPTS / "restore-db.sh"
+README = REPO_ROOT / "deployment" / "README.md"
+
+
+# ── Scripts exist and are executable ───────────────────────────────────────
+
+
+def test_backup_scripts_exist_and_executable():
+	for script in (BACKUP, INSTALL_TIMER, RESTORE):
+		assert script.is_file(), f"expected script at {script}"
+		assert script.stat().st_mode & 0o111, f"{script.name} must be executable"
+
+
+def test_scripts_fail_fast():
+	for script in (BACKUP, INSTALL_TIMER, RESTORE):
+		assert "set -euo pipefail" in script.read_text(), (
+			f"{script.name} must use 'set -euo pipefail'"
+		)
+
+
+# ── AC1: nightly logical dump, off-host to object storage, with retention ──
+
+
+def test_backup_takes_logical_dump():
+	text = BACKUP.read_text()
+	assert "pg_dump" in text, "backup must take a logical dump with pg_dump"
+
+
+def test_backup_uploads_off_host_to_s3():
+	text = BACKUP.read_text()
+	assert "aws s3" in text, "backup must upload off-host to S3 object storage"
+	# Off-host is the whole point: a purely local dump is not a backup.
+	assert "s3://" in text, "backup must write to an s3:// destination"
+
+
+def test_backup_enforces_retention():
+	text = BACKUP.read_text()
+	assert "RETENTION" in text, "backup must honour a retention window"
+	# Old backups must actually be pruned from object storage, not just locally.
+	assert re.search(r"aws s3(api)?\s+(rm|delete-object)", text), (
+		"backup must prune aged-out objects from S3"
+	)
+
+
+def test_backup_bucket_is_configurable():
+	text = BACKUP.read_text()
+	assert "DB_BACKUP_S3_BUCKET" in text, "backup bucket must be configurable"
+
+
+# ── AC1: installed via a systemd timer running as the service account ──────
+
+
+def test_install_timer_creates_systemd_timer():
+	text = INSTALL_TIMER.read_text()
+	assert ".timer" in text, "installer must create a systemd timer"
+	assert ".service" in text, "installer must create a systemd service unit"
+	assert re.search(r"OnCalendar=", text), "timer must schedule via OnCalendar"
+	assert "systemctl" in text and "enable" in text, "installer must enable the timer"
+
+
+def test_timer_runs_as_nonroot_service_account():
+	text = INSTALL_TIMER.read_text()
+	# The backup runs unattended; it must not run as root. Match the hardening
+	# convention's dedicated 'podcastfy' service account.
+	assert "podcastfy" in text or "SERVICE_USER" in text, (
+		"backup timer must run as the non-root service account"
+	)
+	assert re.search(r"User=", text), "service unit must set User= to drop privileges"
+
+
+# ── AC2: restore path ──────────────────────────────────────────────────────
+
+
+def test_restore_uses_pg_restore_and_pulls_from_s3():
+	text = RESTORE.read_text()
+	assert "pg_restore" in text, "restore must use pg_restore on the custom-format dump"
+	assert "aws s3" in text, "restore must fetch the dump from S3"
+
+
+def test_restore_guards_against_accidental_clobber():
+	text = RESTORE.read_text()
+	# Restoring overwrites a live database — there must be a confirmation guard.
+	assert re.search(r"(CONFIRM|--force|read -r|yes/no|[Aa]re you sure)", text), (
+		"restore must guard against accidentally clobbering a live database"
+	)
+
+
+# ── AC2: documented runbook with RTO/RPO ───────────────────────────────────
+
+
+def test_readme_documents_backup_and_restore_runbook():
+	text = README.read_text()
+	assert "backup-db.sh" in text, "README must reference the backup script"
+	assert "restore-db.sh" in text, "README must reference the restore script"
+	assert "install-db-backup-timer.sh" in text, "README must document timer install"
+
+
+def test_readme_states_rto_and_rpo_targets():
+	text = README.read_text().upper()
+	assert "RTO" in text, "runbook must state a target RTO"
+	assert "RPO" in text, "runbook must state a target RPO"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,41 +1,199 @@
-# Issue #271 — Restrict episode/project update to user-editable fields (mass-assignment)
+# Issue #293 — [P0.3] No automated PostgreSQL backup/restore
 
-Branch: `advisor/005-restrict-update-mass-assignment`
-Plan source: issue body + `plans/005-restrict-update-mass-assignment.md` (no drift vs defc572)
+**Approach (lazy-correct):** nightly logical `pg_dump` off-host to S3 with retention via a
+systemd timer, plus a tested restore script + runbook. Not pgBackRest/WAL-G — the AC allows
+"or", and continuous archiving is overkill for a single dev VPS. RPO ≤ 24h, RTO ~minutes.
 
-## Key adaptation vs the written plan
-The plan assumed only the Celery pipeline (`tasks/callbacks.py`) writes system fields and
-that nothing internal uses `update_episode`. **Two internal callers actually write system
-fields through `update_episode`:**
-- `script_generation_service.py:220` → `transcript_path`
-- `quality_metrics_service.py:193` → `generation_progress` — **already broken**: calls
-  `update_episode(db, episode_id, {dict})` but the signature is `(db, episode, EpisodeUpdate)`;
-  `dict.model_dump()` would raise in production (only passes today because the test mocks it).
+Conventions matched: idempotent bash in `deployment/scripts/` (`set -euo pipefail`, header
+block w/ issue ref, like `harden-host.sh`/`enable-s3-versioning.sh`); static contract tests in
+`deployment/tests/` that read the scripts (no execution); README ops section.
 
-So a blanket allowlist on `update_episode` would silently drop these legitimate writes.
-Adaptation: give the pipeline a dedicated `set_episode_system_fields()` writer and reserve
-`update_episode` (allowlisted) for the public endpoint. This also fixes the latent bug.
+## Steps
+1. **`deployment/scripts/backup-db.sh`** — `pg_dump -Fc` (custom format) | gzip → timestamped
+   S3 key under a configurable bucket/prefix (`DB_BACKUP_S3_BUCKET` default = `AWS_S3_BUCKET`,
+   `DB_BACKUP_S3_PREFIX` default `db-backups/`). Reads `DATABASE_URL` (or `PG*`). Prunes remote
+   objects older than `DB_BACKUP_RETENTION_DAYS` (default 14). `set -euo pipefail`, idempotent.
+2. **`deployment/scripts/install-db-backup-timer.sh`** — installs a systemd service + nightly
+   timer running `backup-db.sh` as the `podcastfy` service account. Idempotent (run once as root).
+3. **`deployment/scripts/restore-db.sh`** — download a chosen (or latest) backup from S3 and
+   `pg_restore` into a target DB. Confirmation guard before clobbering. This is the tested path.
+4. **README "Database Backup & Restore (DR)" section** — install steps, retention, restore
+   runbook with RTO/RPO targets, IAM note (backup user needs `s3:PutObject`/`GetObject`/
+   `ListBucket`/`DeleteObject` on the backup prefix), and a restore-test procedure.
+5. **`deployment/tests/test_db_backup.py`** — static contract tests (scripts exist+executable,
+   pg_dump→S3+prune present, timer targets service account, restore guards + pg_restore, README
+   documents runbook + RTO/RPO).
 
-## Steps (TDD)
-- [ ] **Schema** `schemas/episode.py`: `EpisodeUpdate` keeps only user-editable fields —
-      `episode_number`, `episode_metadata`, `tts_config_id`, `template_id`. Remove
-      `generation_status`, `generation_progress`, `s3_key`, `s3_url`, `duration_seconds`,
-      `file_size_bytes`, `file_path`, `transcript_path`, `task_id`, `task_started_at`,
-      `task_completed_at`.
-- [ ] **episode_service.py**: add `EPISODE_USER_EDITABLE_FIELDS` constant; filter in
-      `update_episode` (defense-in-depth). Add `set_episode_system_fields(db, episode, **fields)`
-      internal helper.
-- [ ] **script_generation_service.py:220-221**: write `transcript_path` via
-      `set_episode_system_fields`.
-- [ ] **quality_metrics_service.py:193**: write `generation_progress` via
-      `set_episode_system_fields` (fixes broken signature).
-- [ ] **project_service.py**: add `PROJECT_USER_EDITABLE_FIELDS` allowlist + filter in
-      `update_project`. `ProjectUpdate` schema unchanged (all 6 fields are user-editable).
-- [ ] **Tests**: episodes — PUT system fields ⇒ columns unchanged; user-editable update works.
-      projects — allowlist holds; normal update works. Update `test_quality_metrics` for the
-      new `set_episode_system_fields` call. Confirm `test_script_generation` still passes.
-- [ ] Verify: `uv run pytest tests/ -k "episode or project or quality or script" -q` + `ruff check .`
-- [ ] Update `plans/README.md` status row.
+## Acceptance criteria
+- [ ] Automated off-host nightly logical dump to object storage with retention, via systemd timer
+- [ ] Documented and tested restore runbook with target RTO/RPO
 
-## Out of scope (unchanged)
-`tasks/**` (sync Celery writers via `_update_episode`), DB columns, auth/ownership.
+---
+
+# Production-Readiness Plan — Podcastfy Studio Hub SaaS Launch
+
+**Verdict: NOT READY.** 10 blockers across data durability, core flows, billing, and a crashing UI feature.
+Source: 252-agent fan-out audit (18 reviewer areas, ~130 raw findings → 35 deduplicated, verified issues).
+
+Work `[P0.1] → … → [P6.2]` in order; no issue depends on a later one. Each issue is atomic (one developer, one session).
+
+| PX.Y | Sev | Issue |
+|------|-----|-------|
+| P0.1 | critical | StorageService reads non-existent setting S3_BUCKET_NAME — episode download and RSS upload are broken |
+| P0.2 | critical | Generated audio is lost and undownloadable when AWS_S3_BUCKET is unset |
+| P0.3 | critical | No automated PostgreSQL backup/restore — single VPS disk is the only copy of all tenant data |
+| P0.4 | high | Generation failures and time-limit kills leave episodes stuck at 'queued' forever |
+| P0.5 | high | acks_late + reject_on_worker_lost re-runs the full paid LLM/TTS pipeline (no idempotency guard) |
+| P1.1 | high | billing_usage has no unique constraint on (user_id, period_start) — duplicate rows and 500s |
+| P1.2 | high | Usage metering and plan-limit enforcement are dead code (never invoked) |
+| P1.3 | medium | Mock Stripe checkout URL ships in production when Stripe is unconfigured |
+| P2.1 | high | TTS Settings dialog crashes via empty-string Radix SelectItem once a config is saved |
+| P2.2 | high | on_distribution_complete silently drops failed distributions; episode marked 'complete' with no trace |
+| P2.3 | high | Migration backfills (006/012) silently no-op under FORCE RLS when run as the documented non-superuser role |
+| P2.4 | high | E2E suite is disabled (9/10 specs fixme'd) with broken helpers — CI reports false green for core flows |
+| P2.5 | medium | Coverage gates are hollow: backend --cov-fail-under=0 and frontend excludes all of src/app/** |
+| P3.1 | medium | RLS defense-in-depth gaps: hardcoded DB password, USING(true) users SELECT, WITH CHECK(true) inserts, and new tables with no RLS |
+| P3.2 | medium | Webhook test-connection performs an unpinned, unrevalidated server-side fetch (SSRF / DNS-rebinding TOCTOU) |
+| P3.3 | medium | Dependabot only scans github-actions — no pip/npm CVE alerting; auth-crypto libs are unmaintained |
+| P3.4 | medium | CSP weakened by 'unsafe-inline' script-src; production build ignores TS/ESLint errors |
+| P3.5 | medium | Episode delete orphans S3 audio forever; no tenant-offboarding / GDPR erasure path |
+| P3.6 | medium | Wrong transcript_path persisted for every episode; engine audio/transcript artifacts never cleaned up |
+| P3.7 | medium | datetime.utcnow() in analytics/RSS/usage creates naive datetimes — analytics query raises on TZ-aware params |
+| P3.8 | medium | finalize_episode_generation_task cleanup fails when the DB session is already in a failed-transaction state |
+| P3.9 | medium | Platform distribution retries can republish episodes (no idempotency key) |
+| P4.1 | medium | Audio-composition workflow is unwired — enabling the flag composes empty audio and drops the real podcast |
+| P4.2 | medium | Multi-modal input (YouTube/PDF/image/topic) is advertised but not implemented end-to-end |
+| P4.3 | medium | Spotify/Apple direct-publish targets POST to endpoints that are not real publishing APIs |
+| P4.4 | medium | Distribution, RSS feed, and analytics have backend support but no frontend surface |
+| P5.1 | medium | nginx upstream ports drift: provision-ssl.sh installs 8001/3003 while deploy/docs use 8005/3010 (502s) |
+| P5.2 | medium | Migration safety: 006 unique constraint aborts on pre-existing duplicates; non-CONCURRENT DDL locks; env.py metadata incomplete |
+| P5.3 | medium | DR/durability hardening: migration runs mid-deploy with no pre-migration dump; Redis durability undocumented; S3 not version-protected |
+| P5.4 | medium | Observability gaps: no error tracking, /health doesn't check DB/Redis, no readiness probe, no correlation IDs, no log rotation |
+| P5.5 | medium | Blocking synchronous boto3 calls inside async handlers and StorageService pin the event loop |
+| P5.6 | medium | Backend performance: N+1 team counts, inline external URL HEAD blocking creates, per-event analytics commits, unindexed episode search |
+| P5.7 | medium | Frontend accessibility defects: nested <main>/broken skip link, light-only toasts, unannounced auth errors, role=button nesting |
+| P6.1 | low | Docs drift and repo hygiene: contradictory README, mislabeled 36MB tracked data, broken Sphinx tooling, stale agent reports, committed scaffolding |
+| P6.2 | low | Geographic analytics (top_countries) is wired but always returns empty — country is never populated |
+
+## Phases
+
+
+### P0 — Launch blockers — data loss & broken core flow
+
+- **[P0.1]** (critical) StorageService reads non-existent setting S3_BUCKET_NAME — episode download and RSS upload are broken
+  ↳ Prerequisite for P0.2; unblocks episode download + RSS upload.
+- **[P0.2]** (critical) Generated audio is lost and undownloadable when AWS_S3_BUCKET is unset
+  ↳ Depends on P0.1 (storage bucket resolution).
+- **[P0.3]** (critical) No automated PostgreSQL backup/restore — single VPS disk is the only copy of all tenant data
+  ↳ Independent. Highest data-durability priority.
+- **[P0.4]** (high) Generation failures and time-limit kills leave episodes stuck at 'queued' forever
+  ↳ Core generation flow. Prerequisite for P0.5 and P2.2.
+- **[P0.5]** (high) acks_late + reject_on_worker_lost re-runs the full paid LLM/TTS pipeline (no idempotency guard)
+  ↳ Depends on P0.4 (terminal status handling).
+
+### P1 — Billing correctness & abuse prevention
+
+- **[P1.1]** (high) billing_usage has no unique constraint on (user_id, period_start) — duplicate rows and 500s
+  ↳ Prerequisite for P1.2 (metering writes need the unique constraint).
+- **[P1.2]** (high) Usage metering and plan-limit enforcement are dead code (never invoked)
+  ↳ Depends on P1.1 (constraint) and P0.5 (no double-metering on re-run).
+- **[P1.3]** (medium) Mock Stripe checkout URL ships in production when Stripe is unconfigured
+  ↳ Gate before charging real customers.
+
+### P2 — Core correctness, reliability & test-trust
+
+- **[P2.1]** (high) TTS Settings dialog crashes via empty-string Radix SelectItem once a config is saved
+  ↳ Independent UI blocker.
+- **[P2.2]** (high) on_distribution_complete silently drops failed distributions; episode marked 'complete' with no trace
+  ↳ Relates to P0.4 (terminal status correctness).
+- **[P2.3]** (high) Migration backfills (006/012) silently no-op under FORCE RLS when run as the documented non-superuser role
+  ↳ Migration data-correctness under RLS.
+- **[P2.4]** (high) E2E suite is disabled (9/10 specs fixme'd) with broken helpers — CI reports false green for core flows
+  ↳ Test-trust: restore real signal before relying on CI.
+- **[P2.5]** (medium) Coverage gates are hollow: backend --cov-fail-under=0 and frontend excludes all of src/app/**
+  ↳ Depends on P2.4 (meaningful suite first).
+
+### P3 — Security & data-integrity hardening
+
+- **[P3.1]** (medium) RLS defense-in-depth gaps: hardcoded DB password, USING(true) users SELECT, WITH CHECK(true) inserts, and new tables with no RLS
+  ↳ Defense-in-depth + secret hygiene.
+- **[P3.2]** (medium) Webhook test-connection performs an unpinned, unrevalidated server-side fetch (SSRF / DNS-rebinding TOCTOU)
+  ↳ SSRF on webhook test-connection.
+- **[P3.3]** (medium) Dependabot only scans github-actions — no pip/npm CVE alerting; auth-crypto libs are unmaintained
+  ↳ CVE alerting for pip/npm.
+- **[P3.4]** (medium) CSP weakened by 'unsafe-inline' script-src; production build ignores TS/ESLint errors
+  ↳ CSP + prod build error gating.
+- **[P3.5]** (medium) Episode delete orphans S3 audio forever; no tenant-offboarding / GDPR erasure path
+  ↳ Tenant offboarding / GDPR erasure.
+- **[P3.6]** (medium) Wrong transcript_path persisted for every episode; engine audio/transcript artifacts never cleaned up
+  ↳ Artifact correctness + cleanup.
+- **[P3.7]** (medium) datetime.utcnow() in analytics/RSS/usage creates naive datetimes — analytics query raises on TZ-aware params
+  ↳ Naive-datetime correctness.
+- **[P3.8]** (medium) finalize_episode_generation_task cleanup fails when the DB session is already in a failed-transaction state
+  ↳ Cleanup robustness on failed tx.
+- **[P3.9]** (medium) Platform distribution retries can republish episodes (no idempotency key)
+  ↳ Distribution idempotency.
+
+### P4 — Feature-completeness gaps (advertised but unimplemented)
+
+- **[P4.1]** (medium) Audio-composition workflow is unwired — enabling the flag composes empty audio and drops the real podcast
+  ↳ Advertised feature, currently unwired.
+- **[P4.2]** (medium) Multi-modal input (YouTube/PDF/image/topic) is advertised but not implemented end-to-end
+  ↳ Multi-modal input completeness.
+- **[P4.3]** (medium) Spotify/Apple direct-publish targets POST to endpoints that are not real publishing APIs
+  ↳ Direct-publish targets are not real APIs.
+- **[P4.4]** (medium) Distribution, RSS feed, and analytics have backend support but no frontend surface
+  ↳ Frontend surface for existing backend.
+
+### P5 — Infra, migrations, observability, performance & a11y
+
+- **[P5.1]** (medium) nginx upstream ports drift: provision-ssl.sh installs 8001/3003 while deploy/docs use 8005/3010 (502s)
+  ↳ nginx upstream port drift → 502s.
+- **[P5.2]** (medium) Migration safety: 006 unique constraint aborts on pre-existing duplicates; non-CONCURRENT DDL locks; env.py metadata incomplete
+  ↳ Migration safety hardening.
+- **[P5.3]** (medium) DR/durability hardening: migration runs mid-deploy with no pre-migration dump; Redis durability undocumented; S3 not version-protected
+  ↳ DR/durability hardening.
+- **[P5.4]** (medium) Observability gaps: no error tracking, /health doesn't check DB/Redis, no readiness probe, no correlation IDs, no log rotation
+  ↳ Observability/health/readiness.
+- **[P5.5]** (medium) Blocking synchronous boto3 calls inside async handlers and StorageService pin the event loop
+  ↳ Async event-loop blocking.
+- **[P5.6]** (medium) Backend performance: N+1 team counts, inline external URL HEAD blocking creates, per-event analytics commits, unindexed episode search
+  ↳ Backend performance.
+- **[P5.7]** (medium) Frontend accessibility defects: nested <main>/broken skip link, light-only toasts, unannounced auth errors, role=button nesting
+  ↳ Accessibility defects.
+
+### P6 — Docs & low-priority polish
+
+- **[P6.1]** (low) Docs drift and repo hygiene: contradictory README, mislabeled 36MB tracked data, broken Sphinx tooling, stale agent reports, committed scaffolding
+  ↳ Docs/repo hygiene.
+- **[P6.2]** (low) Geographic analytics (top_countries) is wired but always returns empty — country is never populated
+  ↳ Geo analytics always empty.
+
+
+---
+
+# Issue #292 — [P0.2] Generated audio lost & undownloadable when AWS_S3_BUCKET is unset
+
+**Approach (CodeRabbit Design Choice 1, option 2):** persistent local-disk fallback. The Episode
+model already always persists file_path, so serve from disk when s3_key is absent instead of
+forcing S3 on every deployment.
+
+## Steps
+1. **LOCAL_AUDIO_STORAGE_PATH setting** — config.py field next to AWS_* block, default project-relative
+   storage/audio (persistent, not /tmp). Document in apps/api/.env.example + root .env.example.
+2. **Persist audio out of /tmp** — finalize_episode_generation_task no-S3 branch: copy audio_file_path
+   into LOCAL_AUDIO_STORAGE_PATH (mkdir), set episode.file_path before committing complete. S3 path unchanged.
+3. **iter_local_file** in download_utils.py mirroring iter_s3_body (asyncio.to_thread, start/end range).
+4. **Download endpoint local fallback** — episodes.py: keep complete guard; branch s3_key -> S3 path,
+   elif file_path on disk -> serve locally (os.path.getsize, 200/206/416, identical headers), else 404.
+5. **S3 versioning (operational)** — deployment/ helper script (aws s3api put-bucket-versioning
+   Status=Enabled) + deployment/README.md S3 section step (admin action).
+6. **Tests** — test_download_endpoint.py (200+206 local, fix missing_s3_key 404 needs both absent);
+   test_s3_upload.py (file_path into LOCAL_AUDIO_STORAGE_PATH not /tmp); unit/test_download_utils.py
+   (full + ranged iter_local_file).
+
+## Acceptance criteria
+- [ ] No-S3: episode complete AND downloadable (no /tmp loss)
+- [ ] S3 bucket versioning enabled/documented
+- [ ] Test for no-S3 path
+- [ ] S3 path behavior unchanged


### PR DESCRIPTION
Closes #293.

## Problem
All durable tenant state (accounts, auth, projects, episodes, RSS feeds, distribution targets with encrypted OAuth tokens, Stripe billing) lived **only** in the single VPS Postgres datadir. No pg_dump / WAL archiving / snapshots anywhere — host loss meant total, unrecoverable loss. RPO infinite, RTO manual rebuild.

## Approach
Nightly **logical** dump (`pg_dump -Fc`) shipped off-host to S3 with retention, installed via a systemd timer, plus a tested restore runbook. The AC explicitly allows "logical dump **or** WAL-G/pgBackRest"; continuous archiving is overkill for a single dev VPS, so this is the deliberate lazy-correct choice. **Targets: RPO ≤ 24h, RTO ≈ minutes.**

## Changes
- **`deployment/scripts/backup-db.sh`** — `pg_dump -Fc` → timestamped object in S3 (configurable `DB_BACKUP_S3_BUCKET`/`DB_BACKUP_S3_PREFIX`, default `$AWS_S3_BUCKET` + `db-backups/`); prunes objects older than `DB_BACKUP_RETENTION_DAYS` (default 14). Refuses a host-only backup if no bucket is set; aborts on an empty dump.
- **`deployment/scripts/install-db-backup-timer.sh`** — systemd `oneshot` service + nightly timer (`03:30`, `Persistent=true`) running the backup as the non-root `podcastfy` service account, reading settings from the API `.env`. Idempotent.
- **`deployment/scripts/restore-db.sh`** — pull latest (or named) dump from S3 and `pg_restore --clean --if-exists --no-owner`; confirmation guard before clobbering a live DB (`DB_RESTORE_FORCE=1` to skip).
- **`deployment/README.md`** — "Database Backup & Restore (DR)" section: install + restore runbook, RTO/RPO targets, IAM note (backup needs `ListBucket` + object RW, which the app's audio user lacks by design), and a non-destructive restore-test procedure.
- **`deployment/tests/test_db_backup.py`** — 12 static contract tests pinning the DR invariants (off-host upload, retention prune, timer runs as non-root, restore guard + `pg_restore`, runbook documents RTO/RPO).

## Verification
- `deployment/tests/` — **32 passed** (12 new).
- All three scripts pass `bash -n`.
- **Real dump→restore round-trip** demoed in a `postgres:16` container: seeded 3 rows → `pg_dump -Fc` (5067-byte archive) → dropped into a fresh empty DB → `pg_restore` → all 3 rows + exact data recovered.
- **Retention prune** date logic demoed: with a 14-day window, objects ≤13d old kept, ≥20d old + ancient deleted.

## Known limitations
- The S3 `cp`/`rm` and the systemd timer firing require a live VPS + AWS creds, so they're contract-tested for structure rather than executed here; the custom logic (dump→restore, retention math) is demonstrated end-to-end.
- Retention prune is an O(n) scan over one prefix — fine for nightly dumps; switch to an S3 lifecycle rule if the prefix ever holds thousands of objects (noted inline).
