### PR TITLE
fix(generation): never leave episodes stuck at 'queued' on failure/timeout (#294)

### DIFF
--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -3,7 +3,7 @@ Configuration management for Podcastfy API
 Loads environment variables and provides application settings
 """
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from typing import Optional
 
 
@@ -72,6 +72,13 @@ class Settings(BaseSettings):
     CELERY_BROKER_URL: Optional[str] = None
     CELERY_RESULT_BACKEND: Optional[str] = None
     CELERY_TASK_ALWAYS_EAGER: bool = False
+    # Long-form generation can run for many minutes. Ordering invariant must hold:
+    # soft < hard < visibility_timeout < reaper threshold (issue #294).
+    CELERY_TASK_SOFT_TIME_LIMIT: int = 1500   # 25m — in-task SoftTimeLimitExceeded fires
+    CELERY_TASK_TIME_LIMIT: int = 1800        # 30m — hard kill ceiling
+    CELERY_BROKER_VISIBILITY_TIMEOUT: int = 2400  # 40m — keep in-flight msgs from redelivering
+    EPISODE_REAP_THRESHOLD_SECONDS: int = 2700    # 45m — reaper fails genuinely-stuck episodes
+    REAP_STUCK_EPISODES_INTERVAL_SECONDS: int = 300  # reaper cadence
 
     # Spotify OAuth
     SPOTIFY_CLIENT_ID: Optional[str] = None
@@ -131,6 +138,29 @@ class Settings(BaseSettings):
                 "ENCRYPTION_KEY must be at least 32 characters for secure AES encryption"
             )
         return v
+
+    @model_validator(mode="after")
+    def validate_celery_timeout_ordering(self) -> "Settings":
+        """Enforce soft < hard < visibility_timeout < reaper threshold (issue #294).
+
+        The ordering is what guarantees the in-task SoftTimeLimitExceeded handler
+        fires before the hard kill, the broker does not redeliver in-flight
+        messages, and the reaper only catches genuinely-stuck rows. Env overrides
+        could otherwise silently break it and reintroduce stuck/duplicate episodes.
+        """
+        ordered = [
+            ("CELERY_TASK_SOFT_TIME_LIMIT", self.CELERY_TASK_SOFT_TIME_LIMIT),
+            ("CELERY_TASK_TIME_LIMIT", self.CELERY_TASK_TIME_LIMIT),
+            ("CELERY_BROKER_VISIBILITY_TIMEOUT", self.CELERY_BROKER_VISIBILITY_TIMEOUT),
+            ("EPISODE_REAP_THRESHOLD_SECONDS", self.EPISODE_REAP_THRESHOLD_SECONDS),
+        ]
+        for (lo_name, lo), (hi_name, hi) in zip(ordered, ordered[1:]):
+            if not lo < hi:
+                raise ValueError(
+                    f"{lo_name} ({lo}) must be < {hi_name} ({hi}): "
+                    "required invariant soft < hard < visibility_timeout < reaper"
+                )
+        return self
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/apps/api/src/routers/generation.py
+++ b/apps/api/src/routers/generation.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+from datetime import datetime, timezone
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -22,6 +23,7 @@ from ..services.distribution_target_service import (
     get_active_distribution_targets_for_project,
 )
 from ..tasks.podcast_generation import generate_podcast_task
+from ..tasks.callbacks import on_workflow_failure
 
 logger = logging.getLogger(__name__)
 
@@ -277,18 +279,28 @@ async def generate_podcast(
                 episode_id, episode.project_id,
             )
 
-    # Start Celery task
-    task = generate_podcast_task.delay(
-        episode_id=str(episode_id),
-        urls=urls if urls else None,
-        text_content="\n\n".join(text_content) if text_content else None,
-        enable_composition=use_composition,
-        enable_distribution=use_distribution,
-        **extra_kwargs,
+    # Start Celery task. apply_async (not .delay) so we can attach a link_error:
+    # if the task is hard-killed (time limit) or crashes before its own except
+    # handler runs, on_workflow_failure still flips the episode to 'failed' instead
+    # of leaving it stuck at 'queued' forever (issue #294).
+    task = generate_podcast_task.apply_async(
+        kwargs={
+            "episode_id": str(episode_id),
+            "urls": urls if urls else None,
+            "text_content": "\n\n".join(text_content) if text_content else None,
+            "enable_composition": use_composition,
+            "enable_distribution": use_distribution,
+            **extra_kwargs,
+        },
+        link_error=on_workflow_failure.s(
+            episode_id=str(episode_id), task_name="generate_podcast"
+        ),
     )
 
-    # Update episode status
+    # Update episode status. Stamp task_started_at so the beat reaper can detect a
+    # genuinely-stuck run by age (issue #294).
     episode.generation_status = "queued"
+    episode.task_started_at = datetime.now(timezone.utc)
     episode.generation_progress = {
         "stage": "queued",
         "progress": 0,

--- a/apps/api/src/tasks/callbacks.py
+++ b/apps/api/src/tasks/callbacks.py
@@ -259,9 +259,9 @@ def on_workflow_complete(self: Task, result: Dict[str, Any], episode_id: str) ->
 def on_workflow_failure(
 	self: Task,
 	task_id: str,
-	exc: Any,
-	traceback: Any,
-	episode_id: str,
+	exc: Any = None,
+	traceback: Any = None,
+	episode_id: str = "",
 	task_name: str = "unknown",
 ) -> None:
 	"""
@@ -270,8 +270,12 @@ def on_workflow_failure(
 	Sets Episode.generation_status = 'failed' and records the error in
 	generation_progress.
 
-	This task uses Celery's link_error signature: the first three positional
-	arguments after ``self`` are task_id, exc, and traceback as passed by Celery.
+	Celery invokes ``bind=True`` error callbacks "old style": only the failed
+	task's id is passed positionally — ``exc``/``traceback`` are *not* (see
+	``BaseBackend._call_task_errbacks``, which routes bound errbacks via the
+	single-arg path). They therefore default to None and are recovered from the
+	result backend below, so this works both as a ``link_error`` on a real task
+	and when called directly with explicit args (issue #294).
 
 	Args:
 		self: Celery task instance.
@@ -281,6 +285,18 @@ def on_workflow_failure(
 		episode_id: UUID string of the episode.
 		task_name: Human-readable name of the task that failed.
 	"""
+	if exc is None and task_id:
+		# Old-style errback: pull the failure detail from the result backend so
+		# the recorded message is meaningful rather than "... failed: None".
+		try:
+			from celery.result import AsyncResult
+
+			ar = AsyncResult(str(task_id), app=self.app)
+			exc = ar.result
+			traceback = traceback or ar.traceback
+		except Exception:  # pragma: no cover - backend best-effort
+			logger.debug("Could not fetch failure detail for task %s", task_id)
+
 	error_message = f"Task '{task_name}' failed: {exc}"
 	updated = _update_episode(
 		episode_id,

--- a/apps/api/src/tasks/maintenance.py
+++ b/apps/api/src/tasks/maintenance.py
@@ -1,0 +1,83 @@
+"""
+Periodic maintenance tasks.
+
+``reap_stuck_episodes`` is the final safety net for issue #294: if a generation
+run slips past every in-task guard (worker crash, broker loss, OOM kill) the
+episode can sit in a non-terminal ``generation_status`` forever and the UI shows
+a perpetual 'queued'. This beat task fails any episode whose run started longer
+ago than ``EPISODE_REAP_THRESHOLD_SECONDS``.
+"""
+import logging
+from datetime import datetime, timedelta, timezone
+
+from celery import Task
+from sqlalchemy import and_, or_, select
+
+from src.config import settings
+from src.database import SyncSessionLocal
+from src.models.episode import Episode
+from src.tasks.callbacks import _update_episode, _utcnow_iso
+from src.worker import celery_app
+
+logger = logging.getLogger(__name__)
+
+# Statuses that represent an in-flight run. 'draft' is excluded (not started),
+# as are the terminal 'complete'/'failed'.
+NON_TERMINAL_STATUSES = (
+    "queued",
+    "extracting",
+    "generating",
+    "synthesizing",
+    "uploading",
+    "composing",
+    "distributing",
+)
+
+
+@celery_app.task(bind=True, name="reap_stuck_episodes")
+def reap_stuck_episodes(self: Task) -> int:
+    """Fail episodes stuck in a non-terminal status past the reap threshold.
+
+    Returns the number of episodes reaped.
+    """
+    threshold = settings.EPISODE_REAP_THRESHOLD_SECONDS
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=threshold)
+    # task_started_at is tz-aware; updated_at is naive UTC. Compare each against a
+    # matching-kind cutoff. Prefer task_started_at (stamped at dispatch); fall back
+    # to updated_at for rows predating that stamp.
+    cutoff_naive = cutoff.replace(tzinfo=None)
+
+    with SyncSessionLocal() as db:
+        stuck = db.execute(
+            select(Episode.id).where(
+                Episode.generation_status.in_(NON_TERMINAL_STATUSES),
+                or_(
+                    and_(
+                        Episode.task_started_at.isnot(None),
+                        Episode.task_started_at < cutoff,
+                    ),
+                    and_(
+                        Episode.task_started_at.is_(None),
+                        Episode.updated_at < cutoff_naive,
+                    ),
+                ),
+            )
+        ).scalars().all()
+
+    reaped = 0
+    for episode_id in stuck:
+        updated = _update_episode(
+            str(episode_id),
+            updates={"generation_status": "failed"},
+            progress_updates={
+                "status": "failed",
+                "error_message": f"Reaped: exceeded max runtime ({threshold}s)",
+                "failed_at": _utcnow_iso(),
+            },
+        )
+        if updated:
+            reaped += 1
+
+    if reaped:
+        logger.warning("Reaped %d stuck episode(s) past %ds threshold", reaped, threshold)
+    return reaped

--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -8,6 +8,7 @@ import time
 import uuid as uuid_module
 import logging
 from celery import Task, chain
+from celery.exceptions import SoftTimeLimitExceeded
 from typing import Optional, List, Dict, Any
 from pydub import AudioSegment
 
@@ -15,6 +16,7 @@ from src.worker import celery_app
 from src.config import settings
 from src.database import SyncSessionLocal
 from src.models.episode import Episode
+from src.tasks.callbacks import _update_episode, _utcnow_iso
 from src.tasks.s3_upload import upload_to_s3_task
 from src.tasks.retry_utils import calculate_backoff
 
@@ -98,7 +100,13 @@ def _upload_to_s3_with_retries(
     }
 
 
-@celery_app.task(bind=True, name="generate_podcast", time_limit=600, max_retries=3)
+@celery_app.task(
+    bind=True,
+    name="generate_podcast",
+    time_limit=settings.CELERY_TASK_TIME_LIMIT,
+    soft_time_limit=settings.CELERY_TASK_SOFT_TIME_LIMIT,
+    max_retries=3,
+)
 def generate_podcast_task(
     self: Task,
     episode_id: str,
@@ -345,6 +353,41 @@ def generate_podcast_task(
 
         return generation_result
 
+    except SoftTimeLimitExceeded:
+        # Hit the soft time limit (e.g. a long-form run exceeding the ceiling).
+        # SoftTimeLimitExceeded subclasses BaseException, so it bypasses the broad
+        # `except Exception` below; catch it explicitly and treat it as terminal —
+        # retrying would just hit the limit again. Persist 'failed' to the DB so the
+        # episode does not stay stuck at 'queued' (issue #294).
+        msg = "Generation exceeded the soft time limit"
+        logger.error("Podcast generation soft-timeout for episode %s", episode_id)
+        _update_episode(
+            episode_id,
+            updates={"generation_status": "failed"},
+            progress_updates={
+                "status": "failed",
+                "error_message": msg,
+                "failed_at": _utcnow_iso(),
+            },
+        )
+        self.update_state(
+            state='FAILURE',
+            meta={
+                'episode_id': episode_id,
+                'stage': 'failed',
+                'progress': 0,
+                'status': f'Generation failed: {msg}',
+            },
+        )
+        return {
+            "status": "failed",
+            "audio_file_path": None,
+            "transcript_path": None,
+            "duration_seconds": 0,
+            "file_size_bytes": 0,
+            "error": msg,
+        }
+
     except Exception as e:
         logger.warning(
             f"Podcast generation error for episode {episode_id}, "
@@ -366,6 +409,18 @@ def generate_podcast_task(
                 f"Podcast generation failed after {self.max_retries} retries "
                 f"for episode {episode_id}: {e}"
             )
+            # Persist 'failed' to the DB. update_state() below only writes the
+            # ephemeral result backend; without this the episode stays stuck at
+            # 'queued' once retries are exhausted (issue #294).
+            _update_episode(
+                episode_id,
+                updates={"generation_status": "failed"},
+                progress_updates={
+                    "status": "failed",
+                    "error_message": f"Generation failed after retries: {e}",
+                    "failed_at": _utcnow_iso(),
+                },
+            )
             self.update_state(
                 state='FAILURE',
                 meta={
@@ -385,7 +440,13 @@ def generate_podcast_task(
             }
 
 
-@celery_app.task(bind=True, name="finalize_episode_generation", time_limit=360, max_retries=3)
+@celery_app.task(
+    bind=True,
+    name="finalize_episode_generation",
+    time_limit=settings.CELERY_TASK_TIME_LIMIT,
+    soft_time_limit=settings.CELERY_TASK_SOFT_TIME_LIMIT,
+    max_retries=3,
+)
 def finalize_episode_generation_task(
     self: Task,
     episode_id: str,

--- a/apps/api/src/worker.py
+++ b/apps/api/src/worker.py
@@ -2,6 +2,7 @@
 Celery worker configuration for background tasks
 """
 from celery import Celery
+from datetime import timedelta
 
 from src.config import settings
 
@@ -17,6 +18,7 @@ celery_app = Celery(
         "src.tasks.platform_distribution",
         "src.tasks.content_extraction",
         "src.tasks.callbacks",
+        "src.tasks.maintenance",
     ]
 )
 
@@ -31,8 +33,15 @@ celery_app.conf.update(
     timezone="UTC",
     enable_utc=True,
     task_always_eager=settings.CELERY_TASK_ALWAYS_EAGER,  # For testing
-    task_time_limit=600,  # 10 minutes max
-    task_soft_time_limit=540,  # 9 minutes soft limit
+    # Long-form generation needs a high ceiling. Invariant: soft < hard <
+    # visibility_timeout so the in-task SoftTimeLimitExceeded handler fires (and
+    # writes DB 'failed') before the hard kill, and the broker does not redeliver
+    # an in-flight message as a duplicate before it finishes/is killed (issue #294).
+    task_time_limit=settings.CELERY_TASK_TIME_LIMIT,
+    task_soft_time_limit=settings.CELERY_TASK_SOFT_TIME_LIMIT,
+    broker_transport_options={
+        "visibility_timeout": settings.CELERY_BROKER_VISIBILITY_TIMEOUT,
+    },
     worker_prefetch_multiplier=1,  # Take one task at a time
     worker_max_tasks_per_child=50,  # Restart workers after 50 tasks
     task_acks_late=True,  # Acknowledge tasks after completion
@@ -56,15 +65,17 @@ celery_app.conf.task_routes = {
     "on_distribution_complete": {"queue": "callbacks"},
     "on_workflow_complete": {"queue": "callbacks"},
     "on_workflow_failure": {"queue": "callbacks"},
+    "reap_stuck_episodes": {"queue": "callbacks"},
 }
 
-# Beat schedule (optional - for periodic tasks)
+# Beat schedule — periodic reaper that fails episodes stuck in a non-terminal
+# status past EPISODE_REAP_THRESHOLD_SECONDS, a final safety net for runs that
+# slip past every in-task guard (worker crash, broker loss) (issue #294).
 celery_app.conf.beat_schedule = {
-    # Example: Clean up old temporary files every day
-    # "cleanup-temp-files": {
-    #     "task": "src.tasks.maintenance.cleanup_temp_files",
-    #     "schedule": crontab(hour=2, minute=0),  # 2 AM daily
-    # },
+    "reap-stuck-episodes": {
+        "task": "reap_stuck_episodes",
+        "schedule": timedelta(seconds=settings.REAP_STUCK_EPISODES_INTERVAL_SECONDS),
+    },
 }
 
 if __name__ == "__main__":

--- a/apps/api/tests/test_celery_workflow.py
+++ b/apps/api/tests/test_celery_workflow.py
@@ -873,3 +873,44 @@ class TestGeneratePodcastTaskWorkflowParameters:
         assert sig.parameters["enable_distribution"].default is False
         assert sig.parameters["platforms"].default is None
         assert sig.parameters["composition_timeline"].default is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #294: every in-task failure path must write a terminal DB status so the
+# episode never stays stuck at 'queued'.
+# ---------------------------------------------------------------------------
+class TestFailurePathsWriteDbStatus:
+    def test_soft_time_limit_writes_failed(self):
+        """SoftTimeLimitExceeded persists generation_status='failed' to the DB."""
+        from celery.exceptions import SoftTimeLimitExceeded
+        from src.tasks import podcast_generation as pg
+
+        ep_id = str(uuid.uuid4())
+        pg.generate_podcast_task.request.update(id="soft-tl", retries=0)
+        with patch("podcastfy.client.generate_podcast", side_effect=SoftTimeLimitExceeded()), \
+             patch.object(pg.generate_podcast_task, "update_state", MagicMock()), \
+             patch("src.tasks.podcast_generation._update_episode") as mock_upd:
+            result = pg.generate_podcast_task.run(episode_id=ep_id)
+
+        assert result["status"] == "failed"
+        mock_upd.assert_called_once()
+        assert mock_upd.call_args.kwargs["updates"]["generation_status"] == "failed"
+
+    def test_retry_exhaustion_writes_failed(self):
+        """When retries are exhausted, the episode is marked 'failed' in the DB."""
+        from src.tasks import podcast_generation as pg
+
+        ep_id = str(uuid.uuid4())
+        task = pg.generate_podcast_task
+        task.request.update(id="retry-exh")
+        # Force retry() to signal exhaustion so we exercise the MaxRetriesExceeded
+        # branch directly (eager retry would otherwise re-invoke the task inline).
+        with patch("podcastfy.client.generate_podcast", side_effect=RuntimeError("boom")), \
+             patch.object(task, "update_state", MagicMock()), \
+             patch.object(task, "retry", side_effect=task.MaxRetriesExceededError()), \
+             patch("src.tasks.podcast_generation._update_episode") as mock_upd:
+            result = task.run(episode_id=ep_id)
+
+        assert result["status"] == "failed"
+        mock_upd.assert_called_once()
+        assert mock_upd.call_args.kwargs["updates"]["generation_status"] == "failed"

--- a/apps/api/tests/test_distribution_wiring.py
+++ b/apps/api/tests/test_distribution_wiring.py
@@ -197,7 +197,7 @@ async def test_generate_forwards_platforms_when_distribution_enabled(client):
 
     with patch.object(generation_router.settings, "ENABLE_PLATFORM_DISTRIBUTION", True), \
          patch.object(generation_router.settings, "AWS_S3_BUCKET", "test-bucket"), \
-         patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+         patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         mock_delay.return_value = MagicMock(id="task-dist")
         resp = await client.post(
             f"/generation/episodes/{episode_id}/generate?enable_distribution=true",
@@ -206,7 +206,7 @@ async def test_generate_forwards_platforms_when_distribution_enabled(client):
 
     assert resp.status_code == 202, resp.text
     mock_delay.assert_called_once()
-    kwargs = mock_delay.call_args.kwargs
+    kwargs = mock_delay.call_args.kwargs["kwargs"]
     assert kwargs["enable_distribution"] is True
     platforms = kwargs["platforms"]
     assert "webhook" in platforms
@@ -230,7 +230,7 @@ async def test_generate_keeps_one_target_per_type(client):
 
     with patch.object(generation_router.settings, "ENABLE_PLATFORM_DISTRIBUTION", True), \
          patch.object(generation_router.settings, "AWS_S3_BUCKET", "test-bucket"), \
-         patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+         patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         mock_delay.return_value = MagicMock(id="task-dup")
         resp = await client.post(
             f"/generation/episodes/{episode_id}/generate?enable_distribution=true",
@@ -238,7 +238,7 @@ async def test_generate_keeps_one_target_per_type(client):
         )
 
     assert resp.status_code == 202, resp.text
-    platforms = mock_delay.call_args.kwargs["platforms"]
+    platforms = mock_delay.call_args.kwargs["kwargs"]["platforms"]
     # Exactly one webhook entry, and it is one of the two configured URLs.
     assert list(platforms.keys()) == ["webhook"]
     assert platforms["webhook"]["url"] in (
@@ -255,7 +255,7 @@ async def test_generate_omits_platforms_when_no_targets(client):
     await _create_text_source(client, episode_id, headers)
 
     with patch.object(generation_router.settings, "ENABLE_PLATFORM_DISTRIBUTION", True), \
-         patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+         patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         mock_delay.return_value = MagicMock(id="task-nodist")
         resp = await client.post(
             f"/generation/episodes/{episode_id}/generate?enable_distribution=true",
@@ -264,7 +264,7 @@ async def test_generate_omits_platforms_when_no_targets(client):
 
     assert resp.status_code == 202, resp.text
     mock_delay.assert_called_once()
-    assert "platforms" not in mock_delay.call_args.kwargs
+    assert "platforms" not in mock_delay.call_args.kwargs["kwargs"]
 
 
 @pytest.mark.asyncio
@@ -282,7 +282,7 @@ async def test_generate_skips_distribution_without_s3_bucket(client):
 
     with patch.object(generation_router.settings, "ENABLE_PLATFORM_DISTRIBUTION", True), \
          patch.object(generation_router.settings, "AWS_S3_BUCKET", ""), \
-         patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+         patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         mock_delay.return_value = MagicMock(id="task-nobucket")
         resp = await client.post(
             f"/generation/episodes/{episode_id}/generate?enable_distribution=true",
@@ -290,7 +290,7 @@ async def test_generate_skips_distribution_without_s3_bucket(client):
         )
 
     assert resp.status_code == 202, resp.text
-    kwargs = mock_delay.call_args.kwargs
+    kwargs = mock_delay.call_args.kwargs["kwargs"]
     assert "platforms" not in kwargs
     # Distribution disabled because no bucket → task won't take the workflow path.
     assert kwargs["enable_distribution"] is False
@@ -308,7 +308,7 @@ async def test_generate_omits_platforms_when_distribution_disabled(client):
     )
 
     with patch.object(generation_router.settings, "ENABLE_PLATFORM_DISTRIBUTION", True), \
-         patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+         patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         mock_delay.return_value = MagicMock(id="task-off")
         # enable_distribution defaults to false here.
         resp = await client.post(
@@ -318,5 +318,5 @@ async def test_generate_omits_platforms_when_distribution_disabled(client):
 
     assert resp.status_code == 202, resp.text
     mock_delay.assert_called_once()
-    assert "platforms" not in mock_delay.call_args.kwargs
-    assert mock_delay.call_args.kwargs["enable_distribution"] is False
+    assert "platforms" not in mock_delay.call_args.kwargs["kwargs"]
+    assert mock_delay.call_args.kwargs["kwargs"]["enable_distribution"] is False

--- a/apps/api/tests/test_generation_router.py
+++ b/apps/api/tests/test_generation_router.py
@@ -179,7 +179,7 @@ async def test_generate_forwards_episode_tts_provider(client, episode_project_an
     )
     assert upd.status_code == 200, upd.text
 
-    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+    with patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         mock_delay.return_value = MagicMock(id="task-tts")
         resp = await client.post(
             f"/generation/episodes/{episode_id}/generate", headers=headers
@@ -187,7 +187,7 @@ async def test_generate_forwards_episode_tts_provider(client, episode_project_an
 
     assert resp.status_code == 202, resp.text
     mock_delay.assert_called_once()
-    assert mock_delay.call_args.kwargs["tts_model"] == "elevenlabs"
+    assert mock_delay.call_args.kwargs["kwargs"]["tts_model"] == "elevenlabs"
 
 
 @pytest.mark.asyncio
@@ -202,7 +202,7 @@ async def test_generate_falls_back_to_project_default_tts(client, episode_projec
     )
     assert upd.status_code == 200, upd.text
 
-    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+    with patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         mock_delay.return_value = MagicMock(id="task-gemini")
         resp = await client.post(
             f"/generation/episodes/{episode_id}/generate", headers=headers
@@ -210,7 +210,7 @@ async def test_generate_falls_back_to_project_default_tts(client, episode_projec
 
     assert resp.status_code == 202, resp.text
     mock_delay.assert_called_once()
-    assert mock_delay.call_args.kwargs["tts_model"] == "gemini"
+    assert mock_delay.call_args.kwargs["kwargs"]["tts_model"] == "gemini"
 
 
 @pytest.mark.asyncio
@@ -225,14 +225,14 @@ async def test_generate_normalizes_gemini_multi_provider(client, episode_project
     )
     assert upd.status_code == 200, upd.text
 
-    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+    with patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         mock_delay.return_value = MagicMock(id="task-gm")
         resp = await client.post(
             f"/generation/episodes/{episode_id}/generate", headers=headers
         )
 
     assert resp.status_code == 202, resp.text
-    kwargs = mock_delay.call_args.kwargs
+    kwargs = mock_delay.call_args.kwargs["kwargs"]
     assert kwargs["tts_model"] == "geminimulti"
     # The nested text_to_speech block is keyed by the normalized provider name.
     assert "geminimulti" in kwargs["conversation_config"]["text_to_speech"]
@@ -264,14 +264,14 @@ async def test_generate_forwards_conversation_config(client, episode_project_and
     )
     assert upd.status_code == 200, upd.text
 
-    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+    with patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         mock_delay.return_value = MagicMock(id="task-cfg")
         resp = await client.post(
             f"/generation/episodes/{episode_id}/generate", headers=headers
         )
 
     assert resp.status_code == 202, resp.text
-    conv = mock_delay.call_args.kwargs["conversation_config"]
+    conv = mock_delay.call_args.kwargs["kwargs"]["conversation_config"]
     # Template fields are forwarded at the top level (podcastfy reads them there).
     assert conv["word_count"] == 300
     # The flat TTS config is translated into podcastfy's nested text_to_speech
@@ -291,14 +291,14 @@ async def test_generate_without_config_uses_task_default(client, episode_project
     episode_id, _project_id, headers = episode_project_and_auth
     await _create_text_source(client, episode_id, headers)
 
-    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+    with patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         mock_delay.return_value = MagicMock(id="task-default")
         resp = await client.post(
             f"/generation/episodes/{episode_id}/generate", headers=headers
         )
 
     assert resp.status_code == 202, resp.text
-    call_kwargs = mock_delay.call_args.kwargs
+    call_kwargs = mock_delay.call_args.kwargs["kwargs"]
     # Not passed → task default tts_model="openai" / conversation_config=None applies.
     assert "tts_model" not in call_kwargs
     assert "conversation_config" not in call_kwargs
@@ -310,7 +310,7 @@ async def test_generate_rejects_unextracted_file_source(client, episode_and_auth
     episode_id, headers = episode_and_auth
     source = await _create_pdf_source(client, episode_id, headers)
 
-    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+    with patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         resp = await client.post(
             f"/generation/episodes/{episode_id}/generate", headers=headers
         )
@@ -327,7 +327,7 @@ async def test_generate_passes_extracted_pdf_as_text(client, episode_and_auth):
     source = await _create_pdf_source(client, episode_id, headers)
     await _mark_complete(client, source["id"], headers, "Extracted PDF body.")
 
-    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+    with patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         mock_delay.return_value = MagicMock(id="task-123")
         resp = await client.post(
             f"/generation/episodes/{episode_id}/generate", headers=headers
@@ -335,7 +335,7 @@ async def test_generate_passes_extracted_pdf_as_text(client, episode_and_auth):
 
     assert resp.status_code == 202, resp.text
     mock_delay.assert_called_once()
-    call_kwargs = mock_delay.call_args.kwargs
+    call_kwargs = mock_delay.call_args.kwargs["kwargs"]
     assert "file_paths" not in call_kwargs
     assert call_kwargs["text_content"] == "Extracted PDF body."
 
@@ -360,14 +360,14 @@ async def test_generate_passes_url_source_via_urls(client, episode_and_auth):
         )
     assert resp.status_code == 201, resp.text
 
-    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+    with patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         mock_delay.return_value = MagicMock(id="task-456")
         resp = await client.post(
             f"/generation/episodes/{episode_id}/generate", headers=headers
         )
 
     assert resp.status_code == 202, resp.text
-    call_kwargs = mock_delay.call_args.kwargs
+    call_kwargs = mock_delay.call_args.kwargs["kwargs"]
     assert "file_paths" not in call_kwargs
     assert "https://example.com/a" in call_kwargs["urls"]
 
@@ -385,7 +385,7 @@ async def test_generate_rejects_when_already_in_progress(client, episode_and_aut
     episode_id, headers = episode_and_auth
     await _create_text_source(client, episode_id, headers)
 
-    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+    with patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         mock_delay.return_value = MagicMock(id="task-1")
         first = await client.post(
             f"/generation/episodes/{episode_id}/generate", headers=headers
@@ -439,7 +439,7 @@ async def test_generate_allowed_from_restartable_status(restartable_status):
     current_user = MagicMock()
     current_user.tenant_id = uuid4()
 
-    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+    with patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         mock_delay.return_value = MagicMock(id="task-restart")
         result = await generate_podcast(
             episode_id=uuid4(),
@@ -453,6 +453,10 @@ async def test_generate_allowed_from_restartable_status(restartable_status):
     mock_delay.assert_called_once()
     assert result["status"] == "queued"
     assert episode.generation_status == "queued"
+    # Issue #294: a link_error catch-all is attached so a hard-kill/crash still
+    # flips the episode to 'failed', and task_started_at is stamped for the reaper.
+    assert mock_delay.call_args.kwargs["link_error"] is not None
+    assert episode.task_started_at is not None
 
 
 @pytest.mark.parametrize(
@@ -476,7 +480,7 @@ async def test_generate_rejects_each_in_progress_status(in_progress_status):
     current_user = MagicMock()
     current_user.tenant_id = uuid4()
 
-    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+    with patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         with pytest.raises(HTTPException) as exc_info:
             await generate_podcast(
                 episode_id=uuid4(),
@@ -521,7 +525,7 @@ async def test_generate_rejects_when_no_usable_content(client, episode_and_auth)
     )
     assert upd.status_code == 200, upd.text
 
-    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+    with patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         resp = await client.post(
             f"/generation/episodes/{episode_id}/generate", headers=headers
         )

--- a/apps/api/tests/test_maintenance.py
+++ b/apps/api/tests/test_maintenance.py
@@ -1,0 +1,56 @@
+"""
+Unit tests for the stuck-episode reaper (issue #294).
+
+The reaper uses a sync Celery session (SyncSessionLocal), which is independent of
+the async test-DB transaction, so — following the existing Celery test convention
+— the session is mocked and the reaper's selection/marking logic is exercised
+directly.
+"""
+import uuid
+from unittest.mock import MagicMock, patch
+
+
+def _session_yielding_ids(ids):
+    """Mock a SyncSessionLocal context manager whose query returns ``ids``."""
+    session = MagicMock()
+    session.execute.return_value.scalars.return_value.all.return_value = ids
+    session.__enter__ = MagicMock(return_value=session)
+    session.__exit__ = MagicMock(return_value=False)
+    return session
+
+
+def test_reaper_marks_stuck_episodes_failed():
+    from src.tasks import maintenance
+
+    stuck_ids = [uuid.uuid4(), uuid.uuid4()]
+    session = _session_yielding_ids(stuck_ids)
+    with patch("src.tasks.maintenance.SyncSessionLocal", return_value=session), \
+         patch("src.tasks.maintenance._update_episode", return_value=True) as mock_upd:
+        count = maintenance.reap_stuck_episodes.run()
+
+    assert count == 2
+    assert mock_upd.call_count == 2
+    assert mock_upd.call_args.kwargs["updates"]["generation_status"] == "failed"
+
+
+def test_reaper_noop_when_nothing_stuck():
+    from src.tasks import maintenance
+
+    session = _session_yielding_ids([])
+    with patch("src.tasks.maintenance.SyncSessionLocal", return_value=session), \
+         patch("src.tasks.maintenance._update_episode") as mock_upd:
+        count = maintenance.reap_stuck_episodes.run()
+
+    assert count == 0
+    mock_upd.assert_not_called()
+
+
+def test_reaper_only_targets_non_terminal_statuses():
+    """Terminal/never-started statuses must not be in the reap set."""
+    from src.tasks.maintenance import NON_TERMINAL_STATUSES
+
+    assert "draft" not in NON_TERMINAL_STATUSES
+    assert "complete" not in NON_TERMINAL_STATUSES
+    assert "failed" not in NON_TERMINAL_STATUSES
+    assert "queued" in NON_TERMINAL_STATUSES
+    assert "generating" in NON_TERMINAL_STATUSES

--- a/apps/api/tests/test_pdf_pipeline_integration.py
+++ b/apps/api/tests/test_pdf_pipeline_integration.py
@@ -104,14 +104,14 @@ async def test_pdf_upload_extract_generate_pipeline(client, test_db, episode_and
 
     # ---- 3. Generate: source resolves to text, engine gets text_content ----
     with patch("src.routers.generation.generate_podcast_task") as mock_task:
-        mock_task.delay.return_value.id = "celery-task-123"
+        mock_task.apply_async.return_value.id = "celery-task-123"
         gen = await client.post(
             f"/generation/episodes/{episode_id}/generate", headers=headers
         )
 
     assert gen.status_code == 202
-    mock_task.delay.assert_called_once()
-    kwargs = mock_task.delay.call_args.kwargs
+    mock_task.apply_async.assert_called_once()
+    kwargs = mock_task.apply_async.call_args.kwargs["kwargs"]
     # The PDF was resolved to extracted text — not rejected as an unextracted file
     assert kwargs["text_content"] is not None
     assert "Extracted whitepaper body" in kwargs["text_content"]

--- a/apps/api/tests/test_regenerate_endpoint.py
+++ b/apps/api/tests/test_regenerate_endpoint.py
@@ -81,7 +81,7 @@ async def test_regenerate_happy_path(client, episode_with_content):
     """POST /regenerate queues generation and returns 202 with the episode id."""
     episode_id, headers = episode_with_content
 
-    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+    with patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         mock_delay.return_value = MagicMock(id="task-regen-123")
         resp = await client.post(
             f"/generation/episodes/{episode_id}/regenerate", headers=headers
@@ -148,7 +148,7 @@ async def test_regenerate_does_not_degrade_episode_on_failure():
     current_user = MagicMock()
     current_user.tenant_id = uuid4()
 
-    with patch("src.routers.generation.generate_podcast_task.delay") as mock_delay:
+    with patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
         with pytest.raises(HTTPException) as exc_info:
             await regenerate_podcast(
                 episode_id=uuid4(), current_user=current_user, db=db

--- a/apps/api/tests/unit/test_celery_callbacks.py
+++ b/apps/api/tests/unit/test_celery_callbacks.py
@@ -423,6 +423,32 @@ class TestOnWorkflowFailure:
 
 		mock_session.commit.assert_not_called()
 
+	def test_old_style_errback_marks_failed(self):
+		"""Celery invokes bound errbacks with only task_id (exc/traceback omitted).
+
+		Regression for issue #294: previously exc/traceback were required, so this
+		invocation raised TypeError and the episode was never marked failed.
+		"""
+		episode_id = str(uuid.uuid4())
+		episode = _mock_episode(episode_id)
+		mock_ctx, _ = _make_sync_session(episode)
+
+		from src.tasks.callbacks import on_workflow_failure
+
+		fake_result = MagicMock(result=RuntimeError("kaboom"), traceback="tb")
+		with patch("src.tasks.callbacks.SyncSessionLocal", return_value=mock_ctx), \
+			patch("celery.result.AsyncResult", return_value=fake_result):
+			# Old-style: task_id positional only, exc/traceback NOT passed.
+			_invoke_task(
+				on_workflow_failure,
+				task_id="failed-task-id",
+				episode_id=episode_id,
+				task_name="generate_podcast",
+			)
+
+		assert episode.generation_status == "failed"
+		assert "kaboom" in episode.generation_progress.get("error_message", "")
+
 
 # ---------------------------------------------------------------------------
 # build_generation_workflow


### PR DESCRIPTION
Closes #294 (P0.4 launch blocker).

## Problem
Three converging defects stranded episodes in a non-terminal `generation_status` forever (UI showed perpetual "queued"), breaking the core generation flow and the headline long-form capability.

## Fix
**Phase 1 — every in-task failure path writes a terminal DB status**
- Explicit `SoftTimeLimitExceeded` handler (caught before the broad `except`, since it subclasses `BaseException`) writes `generation_status='failed'` via the existing `_update_episode` helper; no retry.
- The `MaxRetriesExceeded` branch now also writes `failed` to the DB (previously only `update_state(FAILURE)` — the ephemeral result backend).
- Router dispatch `.delay()` → `apply_async(kwargs={...}, link_error=on_workflow_failure.s(...))` so a hard-kill/crash before the task's own handler still marks the episode failed. `task_started_at` is stamped at dispatch for the reaper.

**Phase 2 — raise time limits + align broker visibility**
- Soft/hard limits and `broker_transport_options.visibility_timeout` now come from settings (`1500 < 1800 < 2400`), env-overridable. The per-task `time_limit=600` on `generate_podcast` (the real long-form killer) is raised too.
- A `model_validator` enforces the `soft < hard < visibility < reaper` invariant so env overrides can't silently reintroduce the bug.

**Phase 3 — beat reaper**
- New `tasks/maintenance.py:reap_stuck_episodes` runs every 5 min and fails any episode stuck in a non-terminal status past `EPISODE_REAP_THRESHOLD_SECONDS` (2700s), registered in `beat_schedule` + `task_routes`.

## Pre-existing bug found & fixed
`on_workflow_failure` is `bind=True`; Celery dispatches **bound** errbacks "old-style" with only `task_id` (verified in `BaseBackend._call_task_errbacks`). The required `exc`/`traceback` params therefore raised `TypeError`, so the episode was **never** marked failed — this also silently broke the existing `build_generation_workflow` `link_error`. `exc`/`traceback` are now optional and recovered from the result backend.

## Tests
- New: soft-timeout & retry-exhaustion DB-status tests; reaper tests; old-style-errback regression test.
- Migrated all router/distribution/regenerate/pdf tests from `.delay` → `.apply_async` (kwargs now nested under `kwargs={...}`).
- Full backend suite: **1531 passed**, 1 pre-existing unrelated failure (`test_audio_snippets.py::test_download_url_no_s3_config`, documented S3 download-URL issue, untouched by this PR).

## Demo (outcome evidence)
All 5 acceptance criteria exercised against the real code paths:
- AC1 soft-timeout → DB `failed` ✓
- AC2 retry-exhaustion → DB `failed` ✓
- AC3 `link_error` attached + old-style errback (hard-kill) → `failed` with exc detail ✓
- AC4 `soft 1500 < hard 1800 < vis 2400 < reap 2700` ✓
- AC5 beat reaper registered, reaps stuck rows → `failed` ✓

## Known limitations
- The reaper threshold/limits are time-based heuristics; tune via env per deployment workload.
- No DB migration needed (`task_started_at` column already existed, was just never written).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for stalled generation jobs, so stuck episodes are marked failed after exceeding a runtime threshold.
  * Generation jobs now record when they start, improving progress tracking.

* **Bug Fixes**
  * Improved failure handling so job errors are captured more reliably and episode status updates are saved consistently.
  * Generation tasks now respect configurable time limits and handle soft timeouts as terminal failures.
  * Dispatch now includes better error callbacks to help surface failed workflow details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->