### PR TITLE
fix(generation): idempotency guard so worker loss never re-runs paid pipeline (#295)

### DIFF
--- a/apps/api/src/routers/generation.py
+++ b/apps/api/src/routers/generation.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import logging
 from datetime import datetime, timezone
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
@@ -279,38 +279,63 @@ async def generate_podcast(
                 episode_id, episode.project_id,
             )
 
-    # Start Celery task. apply_async (not .delay) so we can attach a link_error:
-    # if the task is hard-killed (time limit) or crashes before its own except
-    # handler runs, on_workflow_failure still flips the episode to 'failed' instead
-    # of leaving it stuck at 'queued' forever (issue #294).
-    task = generate_podcast_task.apply_async(
-        kwargs={
-            "episode_id": str(episode_id),
-            "urls": urls if urls else None,
-            "text_content": "\n\n".join(text_content) if text_content else None,
-            "enable_composition": use_composition,
-            "enable_distribution": use_distribution,
-            **extra_kwargs,
-        },
-        link_error=on_workflow_failure.s(
-            episode_id=str(episode_id), task_name="generate_podcast"
-        ),
-    )
+    # Commit 'queued' BEFORE dispatch so the worker's #295 idempotency guard never
+    # observes the pre-regeneration status (e.g. 'complete') and skip a legitimate
+    # run. The task id is pre-generated and passed to apply_async so the status can
+    # be persisted with celery_task_id ahead of enqueue. Stamp task_started_at so
+    # the beat reaper can detect a genuinely-stuck run by age (issue #294).
+    # Snapshot the prior (restartable) state so an enqueue failure can restore it
+    # rather than clobbering a still-valid 'complete' episode (issue #295).
+    prior_status = episode.generation_status
+    prior_progress = episode.generation_progress
 
-    # Update episode status. Stamp task_started_at so the beat reaper can detect a
-    # genuinely-stuck run by age (issue #294).
+    new_task_id = str(uuid4())
     episode.generation_status = "queued"
     episode.task_started_at = datetime.now(timezone.utc)
     episode.generation_progress = {
         "stage": "queued",
         "progress": 0,
-        "celery_task_id": task.id,
+        "celery_task_id": new_task_id,
     }
     await db.commit()
 
+    # Start Celery task. apply_async (not .delay) so we can attach a link_error:
+    # if the task is hard-killed (time limit) or crashes before its own except
+    # handler runs, on_workflow_failure still flips the episode to 'failed' instead
+    # of leaving it stuck at 'queued' forever (issue #294).
+    try:
+        generate_podcast_task.apply_async(
+            kwargs={
+                "episode_id": str(episode_id),
+                "urls": urls if urls else None,
+                "text_content": "\n\n".join(text_content) if text_content else None,
+                "enable_composition": use_composition,
+                "enable_distribution": use_distribution,
+                **extra_kwargs,
+            },
+            task_id=new_task_id,
+            link_error=on_workflow_failure.s(
+                episode_id=str(episode_id), task_name="generate_podcast"
+            ),
+        )
+    except Exception as exc:
+        # Enqueue failed (broker down/rejected) AFTER we committed 'queued'. Restore
+        # the prior restartable status so the episode is immediately retryable and a
+        # still-valid 'complete' episode stays downloadable — not stuck 'queued'
+        # until the reaper, nor wrongly marked 'failed' (issue #295).
+        logger.error("Failed to enqueue generation for episode %s: %s", episode_id, exc)
+        episode.generation_status = prior_status
+        episode.generation_progress = prior_progress
+        episode.task_started_at = None
+        await db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Could not start generation (task queue unavailable); please retry.",
+        )
+
     return {
         "episode_id": str(episode_id),
-        "task_id": task.id,
+        "task_id": new_task_id,
         "status": "queued",
         "message": "Podcast generation started",
     }

--- a/apps/api/src/tasks/idempotency.py
+++ b/apps/api/src/tasks/idempotency.py
@@ -1,0 +1,77 @@
+"""Redis distributed lock for podcast generation idempotency (issue #295).
+
+``generate_podcast_task`` performs paid, non-idempotent LLM/TTS work. The lock
+blocks concurrent/duplicate in-flight runs (e.g. a broker-redelivered message or
+a double-dispatch) from re-running the paid pipeline, and self-heals after a
+crash via TTL expiry so a genuinely failed run can still be retried later.
+
+Mirrors the Redis-access convention in ``services/distribution_target_service.py``
+and ``services/rate_limiter.py`` (``Redis.from_url(..., decode_responses=True)``).
+"""
+import logging
+
+from redis import Redis
+
+from src.config import settings
+
+logger = logging.getLogger(__name__)
+
+_LOCK_PREFIX = "podcast_generation_lock:"
+
+# TTL is set just above the hard task time limit so a lock outlives the longest
+# legitimate run, then auto-expires if the worker is killed before release.
+_LOCK_TTL_BUFFER_SECONDS = 60
+
+# Atomic compare-and-delete: only release the lock if we still own it, so a lock
+# already re-acquired by a later run is never deleted out from under it.
+_RELEASE_SCRIPT = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('del', KEYS[1])
+else
+    return 0
+end
+"""
+
+
+def _redis() -> Redis:
+    """Redis client from settings.REDIS_URL (same instance as rate limiter / OAuth state)."""
+    return Redis.from_url(settings.REDIS_URL, decode_responses=True)
+
+
+def _lock_key(episode_id: str) -> str:
+    return f"{_LOCK_PREFIX}{episode_id}"
+
+
+def acquire_generation_lock(episode_id: str, task_id: str) -> bool:
+    """Acquire the per-episode generation lock.
+
+    Returns True if this task may proceed. Re-entrant: a Celery retry keeps the
+    same ``task_id``, so re-acquiring our own lock returns True rather than
+    deadlocking the retry. Fail-open on Redis errors so a Redis outage cannot
+    permanently block generation.
+    """
+    key = _lock_key(episode_id)
+    ttl = settings.CELERY_TASK_TIME_LIMIT + _LOCK_TTL_BUFFER_SECONDS
+    try:
+        client = _redis()
+        if client.set(key, task_id, nx=True, ex=ttl):
+            return True
+        # Key already held — only this task's own retry may proceed.
+        return client.get(key) == task_id
+    except Exception as exc:
+        logger.warning(
+            "Redis lock acquire failed for episode %s; proceeding without lock "
+            "(fail-open): %s",
+            episode_id, exc,
+        )
+        return True
+
+
+def release_generation_lock(episode_id: str, task_id: str) -> None:
+    """Release the lock iff this task still owns it. Fail-open on Redis errors."""
+    try:
+        _redis().eval(_RELEASE_SCRIPT, 1, _lock_key(episode_id), task_id)
+    except Exception as exc:
+        logger.warning(
+            "Redis lock release failed for episode %s: %s", episode_id, exc
+        )

--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -17,10 +17,46 @@ from src.config import settings
 from src.database import SyncSessionLocal
 from src.models.episode import Episode
 from src.tasks.callbacks import _update_episode, _utcnow_iso
+from src.tasks.idempotency import acquire_generation_lock, release_generation_lock
 from src.tasks.s3_upload import upload_to_s3_task
 from src.tasks.retry_utils import calculate_backoff
 
 logger = logging.getLogger(__name__)
+
+# Active (non-terminal, non-queued) statuses. Seeing one of these at task entry
+# means a run is already in flight, so a fresh delivery is a duplicate (issue #295).
+_IN_PROGRESS_STATUSES = frozenset(
+    {"extracting", "generating", "synthesizing", "uploading", "composing", "distributing"}
+)
+
+
+def _load_generation_status(episode_id: str) -> Optional[str]:
+    """Read an episode's current generation_status. Returns None on missing row or
+    DB error so the idempotency guard fails open (proceeds) rather than wedging."""
+    try:
+        with SyncSessionLocal() as db:
+            episode = db.get(Episode, uuid_module.UUID(episode_id))
+            return episode.generation_status if episode is not None else None
+    except Exception as exc:
+        logger.warning(
+            "Could not read generation_status for episode %s; proceeding: %s",
+            episode_id, exc,
+        )
+        return None
+
+
+def _skipped_result(reason: str) -> Dict[str, Any]:
+    """Result for an idempotency short-circuit — no paid work was run (issue #295)."""
+    return {
+        "status": "skipped",
+        "skipped": True,
+        "reason": reason,
+        "audio_file_path": None,
+        "transcript_path": None,
+        "duration_seconds": 0,
+        "file_size_bytes": 0,
+        "error": None,
+    }
 
 
 def build_podcast_s3_key(user_id: str, episode_id: str) -> str:
@@ -106,6 +142,12 @@ def _upload_to_s3_with_retries(
     time_limit=settings.CELERY_TASK_TIME_LIMIT,
     soft_time_limit=settings.CELERY_TASK_SOFT_TIME_LIMIT,
     max_retries=3,
+    # Fail-fast override of the global at-least-once settings (worker.py:47-48):
+    # this task runs paid, non-idempotent LLM/TTS work, so a crashed worker must
+    # NOT re-queue and re-run it. Abrupt loss surfaces as a failed/stuck episode
+    # (handled by the #294 reaper) instead of duplicate billing (issue #295).
+    acks_late=False,
+    reject_on_worker_lost=False,
 )
 def generate_podcast_task(
     self: Task,
@@ -159,7 +201,35 @@ def generate_podcast_task(
             "error": Optional[str]
         }
     """
+    task_id = self.request.id or "unknown"
+    is_retry = (self.request.retries or 0) > 0
+    lock_held = False
+
     try:
+        # Idempotency guard (issue #295): short-circuit before any paid work so a
+        # broker-redelivered duplicate or double-dispatch cannot re-run the paid
+        # LLM/TTS pipeline. A genuine retry (same task_id) is allowed through.
+        status = _load_generation_status(episode_id)
+        if status == "complete":
+            logger.info("Episode %s already complete; skipping duplicate generation", episode_id)
+            return _skipped_result("already complete")
+        if status in _IN_PROGRESS_STATUSES and not is_retry:
+            logger.warning(
+                "Episode %s already in progress (status=%s); skipping duplicate run",
+                episode_id, status,
+            )
+            return _skipped_result(f"already in progress ({status})")
+        if not acquire_generation_lock(episode_id, task_id):
+            logger.warning(
+                "Episode %s generation lock held by another run; skipping concurrent duplicate",
+                episode_id,
+            )
+            return _skipped_result("concurrent run in progress")
+        lock_held = True
+        # Record in-progress state so subsequent deliveries observe in-flight work
+        # and the status no longer jumps straight from 'queued' to a terminal value.
+        _update_episode(episode_id, {"generation_status": "generating"})
+
         # Stage 1: Content Extraction (0-33%)
         self.update_state(
             state='PROGRESS',
@@ -297,6 +367,8 @@ def generate_podcast_task(
                     "resolved, refusing to upload outside the tenant prefix",
                     episode_id,
                 )
+                if lock_held:
+                    release_generation_lock(episode_id, task_id)
                 return generation_result
 
             # Trigger the full workflow: S3 upload → [composition] → [distribution]
@@ -351,6 +423,8 @@ def generate_podcast_task(
                         episode_id, sync_err,
                     )
 
+        if lock_held:
+            release_generation_lock(episode_id, task_id)
         return generation_result
 
     except SoftTimeLimitExceeded:
@@ -379,6 +453,8 @@ def generate_podcast_task(
                 'status': f'Generation failed: {msg}',
             },
         )
+        if lock_held:
+            release_generation_lock(episode_id, task_id)
         return {
             "status": "failed",
             "audio_file_path": None,
@@ -430,6 +506,8 @@ def generate_podcast_task(
                     'status': f'Generation failed: {str(e)}'
                 }
             )
+            if lock_held:
+                release_generation_lock(episode_id, task_id)
             return {
                 "status": "failed",
                 "audio_file_path": None,

--- a/apps/api/tests/test_celery_workflow.py
+++ b/apps/api/tests/test_celery_workflow.py
@@ -893,7 +893,9 @@ class TestFailurePathsWriteDbStatus:
             result = pg.generate_podcast_task.run(episode_id=ep_id)
 
         assert result["status"] == "failed"
-        mock_upd.assert_called_once()
+        # Entry guard now writes 'generating' first (issue #295); the failure path
+        # write is the last call, validated below.
+        mock_upd.assert_called()
         assert mock_upd.call_args.kwargs["updates"]["generation_status"] == "failed"
 
     def test_retry_exhaustion_writes_failed(self):
@@ -912,5 +914,7 @@ class TestFailurePathsWriteDbStatus:
             result = task.run(episode_id=ep_id)
 
         assert result["status"] == "failed"
-        mock_upd.assert_called_once()
+        # Entry guard now writes 'generating' first (issue #295); the failure path
+        # write is the last call, validated below.
+        mock_upd.assert_called()
         assert mock_upd.call_args.kwargs["updates"]["generation_status"] == "failed"

--- a/apps/api/tests/test_generation_router.py
+++ b/apps/api/tests/test_generation_router.py
@@ -457,6 +457,59 @@ async def test_generate_allowed_from_restartable_status(restartable_status):
     # flips the episode to 'failed', and task_started_at is stamped for the reaper.
     assert mock_delay.call_args.kwargs["link_error"] is not None
     assert episode.task_started_at is not None
+    # Issue #295: 'queued' is committed BEFORE dispatch (so the worker's idempotency
+    # guard can't see the pre-regeneration 'complete' and skip the run), and the
+    # pre-generated task_id is both dispatched and returned.
+    assert db.commit.called
+    dispatched_task_id = mock_delay.call_args.kwargs["task_id"]
+    assert dispatched_task_id == result["task_id"]
+    assert episode.generation_progress["celery_task_id"] == dispatched_task_id
+
+
+@pytest.mark.asyncio
+async def test_generate_enqueue_failure_restores_prior_status():
+    """If apply_async raises after committing 'queued', the episode is restored to its
+    prior restartable status (a still-valid 'complete' stays complete, not stuck
+    'queued' nor wrongly 'failed') and a 503 is returned (issue #295)."""
+    from src.routers.generation import generate_podcast
+
+    episode = MagicMock()
+    episode.generation_status = "complete"
+    episode.tts_config = None
+    episode.template = None
+    episode.project = None
+
+    source = MagicMock()
+    source.source_type = "text"
+    source.extraction_status = "complete"
+    source.extracted_content = _TEXT_BODY
+
+    episode_result = MagicMock()
+    episode_result.unique.return_value.scalar_one_or_none.return_value = episode
+    content_result = MagicMock()
+    content_result.scalars.return_value.all.return_value = [source]
+
+    db = AsyncMock()
+    db.execute.side_effect = [episode_result, content_result]
+
+    current_user = MagicMock()
+    current_user.tenant_id = uuid4()
+
+    with patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
+        mock_delay.side_effect = ConnectionError("broker down")
+        with pytest.raises(HTTPException) as exc_info:
+            await generate_podcast(
+                episode_id=uuid4(),
+                enable_composition=False,
+                enable_distribution=False,
+                current_user=current_user,
+                db=db,
+            )
+
+    assert exc_info.value.status_code == 503
+    # Prior 'complete' restored: still-valid audio stays downloadable and retryable.
+    assert episode.generation_status == "complete"
+    assert episode.task_started_at is None
 
 
 @pytest.mark.parametrize(

--- a/apps/api/tests/unit/test_generation_idempotency.py
+++ b/apps/api/tests/unit/test_generation_idempotency.py
@@ -1,0 +1,170 @@
+"""Tests for the generate_podcast_task idempotency guard (issue #295).
+
+The root task runs paid LLM/TTS work. Under at-least-once delivery a worker loss
+(OOM/deploy/SIGKILL) would re-queue and re-run the whole paid pipeline. The guard
+must: (1) make the task fail-fast (acks_late=False), (2) short-circuit
+already-complete or in-flight episodes before any paid call, and (3) use a Redis
+lock to block concurrent/duplicate in-flight runs while self-healing via TTL.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock, create_autospec, patch
+from uuid import uuid4
+
+from podcastfy.client import generate_podcast as real_generate_podcast
+
+from src.tasks import idempotency
+from src.tasks.podcast_generation import generate_podcast_task
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: fail-fast decorator config
+# ---------------------------------------------------------------------------
+
+def test_root_task_overrides_acks_late_false():
+    """The expensive root task must ack early so abrupt loss is not redelivered."""
+    assert generate_podcast_task.acks_late is False
+
+
+def test_root_task_overrides_reject_on_worker_lost_false():
+    """Worker-lost must not re-queue the paid task."""
+    assert generate_podcast_task.reject_on_worker_lost is False
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Redis lock helper
+# ---------------------------------------------------------------------------
+
+def test_acquire_returns_true_on_fresh_key():
+    """A fresh SET NX succeeds → lock acquired."""
+    client = MagicMock()
+    client.set.return_value = True
+    with patch.object(idempotency, "_redis", return_value=client):
+        assert idempotency.acquire_generation_lock("ep1", "task-a") is True
+    # NX + EX must both be set
+    _, kwargs = client.set.call_args
+    assert kwargs.get("nx") is True
+    assert kwargs.get("ex") and kwargs["ex"] > idempotency.settings.CELERY_TASK_TIME_LIMIT
+
+
+def test_acquire_false_when_held_by_other_task():
+    """If the key is held by a different task, acquisition fails (concurrent dup)."""
+    client = MagicMock()
+    client.set.return_value = None
+    client.get.return_value = "task-other"
+    with patch.object(idempotency, "_redis", return_value=client):
+        assert idempotency.acquire_generation_lock("ep1", "task-a") is False
+
+
+def test_acquire_reentrant_for_same_task():
+    """A Celery retry keeps the same task_id → re-acquiring our own lock succeeds."""
+    client = MagicMock()
+    client.set.return_value = None
+    client.get.return_value = "task-a"
+    with patch.object(idempotency, "_redis", return_value=client):
+        assert idempotency.acquire_generation_lock("ep1", "task-a") is True
+
+
+def test_acquire_fails_open_on_redis_error():
+    """A Redis outage must never permanently block generation (fail-open)."""
+    client = MagicMock()
+    client.set.side_effect = ConnectionError("redis down")
+    with patch.object(idempotency, "_redis", return_value=client):
+        assert idempotency.acquire_generation_lock("ep1", "task-a") is True
+
+
+def test_release_compare_and_deletes_atomically():
+    """Release runs a compare-and-delete so a lock re-acquired by a later run is safe."""
+    client = MagicMock()
+    with patch.object(idempotency, "_redis", return_value=client):
+        idempotency.release_generation_lock("ep1", "task-a")
+    client.eval.assert_called_once()
+    args = client.eval.call_args.args
+    # KEYS[1] = lock key, ARGV[1] = owning task id
+    assert "ep1" in args[2]
+    assert args[3] == "task-a"
+
+
+def test_release_fails_open_on_redis_error():
+    """A Redis error during release is swallowed (never raises)."""
+    client = MagicMock()
+    client.eval.side_effect = ConnectionError("redis down")
+    with patch.object(idempotency, "_redis", return_value=client):
+        idempotency.release_generation_lock("ep1", "task-a")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: entry guard short-circuits before any paid work
+# ---------------------------------------------------------------------------
+
+def _mock_podcastfy(return_value="/tmp/out.mp3"):
+    mock_client = MagicMock()
+    mock_client.generate_podcast = create_autospec(
+        real_generate_podcast, return_value=return_value
+    )
+    mod = types.ModuleType("podcastfy")
+    mod.client = mock_client
+    return mock_client, {"podcastfy": mod, "podcastfy.client": mock_client}
+
+
+def _run_with_status(status, *, retries=0, acquire=True):
+    """Run the task with a stubbed DB status / lock and return (result, mock_gen)."""
+    mock_client, mock_modules = _mock_podcastfy()
+    mock_gen = mock_client.generate_podcast
+
+    audio = MagicMock()
+    audio.__len__ = MagicMock(return_value=60000)
+
+    generate_podcast_task.push_request(id="task-a", retries=retries)
+    try:
+        with patch.object(generate_podcast_task, "update_state"), \
+             patch("src.tasks.podcast_generation._load_generation_status", return_value=status), \
+             patch("src.tasks.podcast_generation.acquire_generation_lock", return_value=acquire), \
+             patch("src.tasks.podcast_generation.release_generation_lock"), \
+             patch("src.tasks.podcast_generation._update_episode"), \
+             patch.dict(sys.modules, mock_modules), \
+             patch("src.tasks.podcast_generation.os.path.getsize", return_value=1024), \
+             patch("src.tasks.podcast_generation.AudioSegment") as mock_audio, \
+             patch("src.tasks.podcast_generation.finalize_episode_generation_task"):
+            mock_audio.from_file.return_value = audio
+            result = generate_podcast_task.run(episode_id=str(uuid4()), urls=["https://x.com"])
+    finally:
+        generate_podcast_task.pop_request()
+    return result, mock_gen
+
+
+def test_complete_episode_short_circuits_without_paid_work():
+    """A 'complete' episode must return early and never call generate_podcast()."""
+    result, mock_gen = _run_with_status("complete")
+    mock_gen.assert_not_called()
+    assert result["status"] in ("skipped", "success")
+    assert result.get("skipped") is True
+
+
+def test_in_progress_episode_short_circuits_as_duplicate():
+    """An in-flight status (e.g. 'generating') is a redelivered duplicate → skip."""
+    result, mock_gen = _run_with_status("generating")
+    mock_gen.assert_not_called()
+    assert result.get("skipped") is True
+
+
+def test_held_lock_short_circuits_as_concurrent_duplicate():
+    """If the Redis lock is already held, skip without running paid work."""
+    result, mock_gen = _run_with_status("queued", acquire=False)
+    mock_gen.assert_not_called()
+    assert result.get("skipped") is True
+
+
+def test_queued_episode_proceeds():
+    """A normal 'queued' episode runs the paid pipeline."""
+    result, mock_gen = _run_with_status("queued")
+    mock_gen.assert_called_once()
+    assert result["status"] == "success"
+
+
+def test_retry_of_in_progress_run_proceeds():
+    """A Celery retry (same task_id, status now 'generating') must NOT short-circuit."""
+    result, mock_gen = _run_with_status("generating", retries=1)
+    mock_gen.assert_called_once()
+    assert result["status"] == "success"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,199 +1,56 @@
-# Issue #293 — [P0.3] No automated PostgreSQL backup/restore
+# Issue #295 — Idempotency guard for generate_podcast_task (P0.5)
 
-**Approach (lazy-correct):** nightly logical `pg_dump` off-host to S3 with retention via a
-systemd timer, plus a tested restore script + runbook. Not pgBackRest/WAL-G — the AC allows
-"or", and continuous archiving is overkill for a single dev VPS. RPO ≤ 24h, RTO ~minutes.
+**Problem:** `generate_podcast_task` runs under at-least-once delivery
+(`task_acks_late=True` + `task_reject_on_worker_lost=True`) with no entry-time
+idempotency check. Abrupt worker loss (OOM, deploy, SIGKILL) re-queues and
+re-runs the entire **paid** LLM/TTS pipeline → duplicate billing + duplicate
+artifacts.
 
-Conventions matched: idempotent bash in `deployment/scripts/` (`set -euo pipefail`, header
-block w/ issue ref, like `harden-host.sh`/`enable-s3-versioning.sh`); static contract tests in
-`deployment/tests/` that read the scripts (no execution); README ops section.
+**Dependency:** P0.4 (#294 terminal-status handling) — already merged.
 
-## Steps
-1. **`deployment/scripts/backup-db.sh`** — `pg_dump -Fc` (custom format) | gzip → timestamped
-   S3 key under a configurable bucket/prefix (`DB_BACKUP_S3_BUCKET` default = `AWS_S3_BUCKET`,
-   `DB_BACKUP_S3_PREFIX` default `db-backups/`). Reads `DATABASE_URL` (or `PG*`). Prunes remote
-   objects older than `DB_BACKUP_RETENTION_DAYS` (default 14). `set -euo pipefail`, idempotent.
-2. **`deployment/scripts/install-db-backup-timer.sh`** — installs a systemd service + nightly
-   timer running `backup-db.sh` as the `podcastfy` service account. Idempotent (run once as root).
-3. **`deployment/scripts/restore-db.sh`** — download a chosen (or latest) backup from S3 and
-   `pg_restore` into a target DB. Confirmation guard before clobbering. This is the tested path.
-4. **README "Database Backup & Restore (DR)" section** — install steps, retention, restore
-   runbook with RTO/RPO targets, IAM note (backup user needs `s3:PutObject`/`GetObject`/
-   `ListBucket`/`DeleteObject` on the backup prefix), and a restore-test procedure.
-5. **`deployment/tests/test_db_backup.py`** — static contract tests (scripts exist+executable,
-   pg_dump→S3+prune present, timer targets service account, restore guards + pg_restore, README
-   documents runbook + RTO/RPO).
+## Adapted plan (verified against current code)
 
-## Acceptance criteria
-- [ ] Automated off-host nightly logical dump to object storage with retention, via systemd timer
-- [ ] Documented and tested restore runbook with target RTO/RPO
+### 1. Fail-fast the expensive root task — `worker.py` untouched
+- On `@celery_app.task(... name="generate_podcast")` decorator
+  (`podcast_generation.py:103`), add `acks_late=False, reject_on_worker_lost=False`
+  with a comment: paid, non-idempotent work must not be broker-redelivered.
+- Leave global `worker.py:47-48` settings as-is (downstream tasks stay at-least-once).
 
----
+### 2. New `apps/api/src/tasks/idempotency.py` — Redis episode lock
+- `_redis()` → `Redis.from_url(settings.REDIS_URL, decode_responses=True)`
+  (mirrors `distribution_target_service.py` / `rate_limiter.py`).
+- `acquire_generation_lock(episode_id, task_id)`: `SET NX EX` with
+  `ttl = CELERY_TASK_TIME_LIMIT + 60`, key `podcast_generation_lock:{episode_id}`,
+  value `task_id`. **Re-entrant**: if key already holds *our* task_id (a Celery
+  retry keeps the same id), return True. Fail-open (return True) on Redis error.
+- `release_generation_lock(episode_id, task_id)`: atomic compare-and-delete via
+  Lua eval (only deletes if we still own it). Fail-open on error.
 
-# Production-Readiness Plan — Podcastfy Studio Hub SaaS Launch
+### 3. Entry guard in `generate_podcast_task` (top of `try`, before podcastfy import)
+- `_load_generation_status(episode_id)` helper (patchable; fail-open → None).
+- `status == "complete"` → return early "already complete" (no chain, no paid work).
+- `status` in active in-progress set
+  {extracting,generating,synthesizing,uploading,composing,distributing} **and not
+  a retry** → short-circuit as duplicate.
+- queued / failed / draft / unknown(None) → proceed.
+- `acquire_generation_lock(...)`; if not acquired → short-circuit (concurrent duplicate).
+- Persist `generation_status="generating"` via existing `_update_episode`.
 
-**Verdict: NOT READY.** 10 blockers across data durability, core flows, billing, and a crashing UI feature.
-Source: 252-agent fan-out audit (18 reviewer areas, ~130 raw findings → 35 deduplicated, verified issues).
+### 4. Release lock on every terminal exit (lock-held paths only)
+- success return (`:354`), workflow-skip return (`:300`), soft-timeout return
+  (`:382`), max-retries-exhausted return (`:433`).
+- **Not** on the `self.retry()` path — same task_id re-runs and re-owns the lock;
+  TTL is the crash backstop.
 
-Work `[P0.1] → … → [P6.2]` in order; no issue depends on a later one. Each issue is atomic (one developer, one session).
+### 5. Tests — `tests/unit/test_generation_idempotency.py`
+- acquire: first True / second-other-task False / re-entrant same-task True / fail-open True.
+- release: compare-and-delete (owner only).
+- task entry: complete → early return + podcastfy NOT called; in-progress dup →
+  short-circuit; lock-held → short-circuit; queued → proceeds.
+- decorator carries `acks_late=False` / `reject_on_worker_lost=False`.
 
-| PX.Y | Sev | Issue |
-|------|-----|-------|
-| P0.1 | critical | StorageService reads non-existent setting S3_BUCKET_NAME — episode download and RSS upload are broken |
-| P0.2 | critical | Generated audio is lost and undownloadable when AWS_S3_BUCKET is unset |
-| P0.3 | critical | No automated PostgreSQL backup/restore — single VPS disk is the only copy of all tenant data |
-| P0.4 | high | Generation failures and time-limit kills leave episodes stuck at 'queued' forever |
-| P0.5 | high | acks_late + reject_on_worker_lost re-runs the full paid LLM/TTS pipeline (no idempotency guard) |
-| P1.1 | high | billing_usage has no unique constraint on (user_id, period_start) — duplicate rows and 500s |
-| P1.2 | high | Usage metering and plan-limit enforcement are dead code (never invoked) |
-| P1.3 | medium | Mock Stripe checkout URL ships in production when Stripe is unconfigured |
-| P2.1 | high | TTS Settings dialog crashes via empty-string Radix SelectItem once a config is saved |
-| P2.2 | high | on_distribution_complete silently drops failed distributions; episode marked 'complete' with no trace |
-| P2.3 | high | Migration backfills (006/012) silently no-op under FORCE RLS when run as the documented non-superuser role |
-| P2.4 | high | E2E suite is disabled (9/10 specs fixme'd) with broken helpers — CI reports false green for core flows |
-| P2.5 | medium | Coverage gates are hollow: backend --cov-fail-under=0 and frontend excludes all of src/app/** |
-| P3.1 | medium | RLS defense-in-depth gaps: hardcoded DB password, USING(true) users SELECT, WITH CHECK(true) inserts, and new tables with no RLS |
-| P3.2 | medium | Webhook test-connection performs an unpinned, unrevalidated server-side fetch (SSRF / DNS-rebinding TOCTOU) |
-| P3.3 | medium | Dependabot only scans github-actions — no pip/npm CVE alerting; auth-crypto libs are unmaintained |
-| P3.4 | medium | CSP weakened by 'unsafe-inline' script-src; production build ignores TS/ESLint errors |
-| P3.5 | medium | Episode delete orphans S3 audio forever; no tenant-offboarding / GDPR erasure path |
-| P3.6 | medium | Wrong transcript_path persisted for every episode; engine audio/transcript artifacts never cleaned up |
-| P3.7 | medium | datetime.utcnow() in analytics/RSS/usage creates naive datetimes — analytics query raises on TZ-aware params |
-| P3.8 | medium | finalize_episode_generation_task cleanup fails when the DB session is already in a failed-transaction state |
-| P3.9 | medium | Platform distribution retries can republish episodes (no idempotency key) |
-| P4.1 | medium | Audio-composition workflow is unwired — enabling the flag composes empty audio and drops the real podcast |
-| P4.2 | medium | Multi-modal input (YouTube/PDF/image/topic) is advertised but not implemented end-to-end |
-| P4.3 | medium | Spotify/Apple direct-publish targets POST to endpoints that are not real publishing APIs |
-| P4.4 | medium | Distribution, RSS feed, and analytics have backend support but no frontend surface |
-| P5.1 | medium | nginx upstream ports drift: provision-ssl.sh installs 8001/3003 while deploy/docs use 8005/3010 (502s) |
-| P5.2 | medium | Migration safety: 006 unique constraint aborts on pre-existing duplicates; non-CONCURRENT DDL locks; env.py metadata incomplete |
-| P5.3 | medium | DR/durability hardening: migration runs mid-deploy with no pre-migration dump; Redis durability undocumented; S3 not version-protected |
-| P5.4 | medium | Observability gaps: no error tracking, /health doesn't check DB/Redis, no readiness probe, no correlation IDs, no log rotation |
-| P5.5 | medium | Blocking synchronous boto3 calls inside async handlers and StorageService pin the event loop |
-| P5.6 | medium | Backend performance: N+1 team counts, inline external URL HEAD blocking creates, per-event analytics commits, unindexed episode search |
-| P5.7 | medium | Frontend accessibility defects: nested <main>/broken skip link, light-only toasts, unannounced auth errors, role=button nesting |
-| P6.1 | low | Docs drift and repo hygiene: contradictory README, mislabeled 36MB tracked data, broken Sphinx tooling, stale agent reports, committed scaffolding |
-| P6.2 | low | Geographic analytics (top_countries) is wired but always returns empty — country is never populated |
-
-## Phases
-
-
-### P0 — Launch blockers — data loss & broken core flow
-
-- **[P0.1]** (critical) StorageService reads non-existent setting S3_BUCKET_NAME — episode download and RSS upload are broken
-  ↳ Prerequisite for P0.2; unblocks episode download + RSS upload.
-- **[P0.2]** (critical) Generated audio is lost and undownloadable when AWS_S3_BUCKET is unset
-  ↳ Depends on P0.1 (storage bucket resolution).
-- **[P0.3]** (critical) No automated PostgreSQL backup/restore — single VPS disk is the only copy of all tenant data
-  ↳ Independent. Highest data-durability priority.
-- **[P0.4]** (high) Generation failures and time-limit kills leave episodes stuck at 'queued' forever
-  ↳ Core generation flow. Prerequisite for P0.5 and P2.2.
-- **[P0.5]** (high) acks_late + reject_on_worker_lost re-runs the full paid LLM/TTS pipeline (no idempotency guard)
-  ↳ Depends on P0.4 (terminal status handling).
-
-### P1 — Billing correctness & abuse prevention
-
-- **[P1.1]** (high) billing_usage has no unique constraint on (user_id, period_start) — duplicate rows and 500s
-  ↳ Prerequisite for P1.2 (metering writes need the unique constraint).
-- **[P1.2]** (high) Usage metering and plan-limit enforcement are dead code (never invoked)
-  ↳ Depends on P1.1 (constraint) and P0.5 (no double-metering on re-run).
-- **[P1.3]** (medium) Mock Stripe checkout URL ships in production when Stripe is unconfigured
-  ↳ Gate before charging real customers.
-
-### P2 — Core correctness, reliability & test-trust
-
-- **[P2.1]** (high) TTS Settings dialog crashes via empty-string Radix SelectItem once a config is saved
-  ↳ Independent UI blocker.
-- **[P2.2]** (high) on_distribution_complete silently drops failed distributions; episode marked 'complete' with no trace
-  ↳ Relates to P0.4 (terminal status correctness).
-- **[P2.3]** (high) Migration backfills (006/012) silently no-op under FORCE RLS when run as the documented non-superuser role
-  ↳ Migration data-correctness under RLS.
-- **[P2.4]** (high) E2E suite is disabled (9/10 specs fixme'd) with broken helpers — CI reports false green for core flows
-  ↳ Test-trust: restore real signal before relying on CI.
-- **[P2.5]** (medium) Coverage gates are hollow: backend --cov-fail-under=0 and frontend excludes all of src/app/**
-  ↳ Depends on P2.4 (meaningful suite first).
-
-### P3 — Security & data-integrity hardening
-
-- **[P3.1]** (medium) RLS defense-in-depth gaps: hardcoded DB password, USING(true) users SELECT, WITH CHECK(true) inserts, and new tables with no RLS
-  ↳ Defense-in-depth + secret hygiene.
-- **[P3.2]** (medium) Webhook test-connection performs an unpinned, unrevalidated server-side fetch (SSRF / DNS-rebinding TOCTOU)
-  ↳ SSRF on webhook test-connection.
-- **[P3.3]** (medium) Dependabot only scans github-actions — no pip/npm CVE alerting; auth-crypto libs are unmaintained
-  ↳ CVE alerting for pip/npm.
-- **[P3.4]** (medium) CSP weakened by 'unsafe-inline' script-src; production build ignores TS/ESLint errors
-  ↳ CSP + prod build error gating.
-- **[P3.5]** (medium) Episode delete orphans S3 audio forever; no tenant-offboarding / GDPR erasure path
-  ↳ Tenant offboarding / GDPR erasure.
-- **[P3.6]** (medium) Wrong transcript_path persisted for every episode; engine audio/transcript artifacts never cleaned up
-  ↳ Artifact correctness + cleanup.
-- **[P3.7]** (medium) datetime.utcnow() in analytics/RSS/usage creates naive datetimes — analytics query raises on TZ-aware params
-  ↳ Naive-datetime correctness.
-- **[P3.8]** (medium) finalize_episode_generation_task cleanup fails when the DB session is already in a failed-transaction state
-  ↳ Cleanup robustness on failed tx.
-- **[P3.9]** (medium) Platform distribution retries can republish episodes (no idempotency key)
-  ↳ Distribution idempotency.
-
-### P4 — Feature-completeness gaps (advertised but unimplemented)
-
-- **[P4.1]** (medium) Audio-composition workflow is unwired — enabling the flag composes empty audio and drops the real podcast
-  ↳ Advertised feature, currently unwired.
-- **[P4.2]** (medium) Multi-modal input (YouTube/PDF/image/topic) is advertised but not implemented end-to-end
-  ↳ Multi-modal input completeness.
-- **[P4.3]** (medium) Spotify/Apple direct-publish targets POST to endpoints that are not real publishing APIs
-  ↳ Direct-publish targets are not real APIs.
-- **[P4.4]** (medium) Distribution, RSS feed, and analytics have backend support but no frontend surface
-  ↳ Frontend surface for existing backend.
-
-### P5 — Infra, migrations, observability, performance & a11y
-
-- **[P5.1]** (medium) nginx upstream ports drift: provision-ssl.sh installs 8001/3003 while deploy/docs use 8005/3010 (502s)
-  ↳ nginx upstream port drift → 502s.
-- **[P5.2]** (medium) Migration safety: 006 unique constraint aborts on pre-existing duplicates; non-CONCURRENT DDL locks; env.py metadata incomplete
-  ↳ Migration safety hardening.
-- **[P5.3]** (medium) DR/durability hardening: migration runs mid-deploy with no pre-migration dump; Redis durability undocumented; S3 not version-protected
-  ↳ DR/durability hardening.
-- **[P5.4]** (medium) Observability gaps: no error tracking, /health doesn't check DB/Redis, no readiness probe, no correlation IDs, no log rotation
-  ↳ Observability/health/readiness.
-- **[P5.5]** (medium) Blocking synchronous boto3 calls inside async handlers and StorageService pin the event loop
-  ↳ Async event-loop blocking.
-- **[P5.6]** (medium) Backend performance: N+1 team counts, inline external URL HEAD blocking creates, per-event analytics commits, unindexed episode search
-  ↳ Backend performance.
-- **[P5.7]** (medium) Frontend accessibility defects: nested <main>/broken skip link, light-only toasts, unannounced auth errors, role=button nesting
-  ↳ Accessibility defects.
-
-### P6 — Docs & low-priority polish
-
-- **[P6.1]** (low) Docs drift and repo hygiene: contradictory README, mislabeled 36MB tracked data, broken Sphinx tooling, stale agent reports, committed scaffolding
-  ↳ Docs/repo hygiene.
-- **[P6.2]** (low) Geographic analytics (top_countries) is wired but always returns empty — country is never populated
-  ↳ Geo analytics always empty.
-
-
----
-
-# Issue #292 — [P0.2] Generated audio lost & undownloadable when AWS_S3_BUCKET is unset
-
-**Approach (CodeRabbit Design Choice 1, option 2):** persistent local-disk fallback. The Episode
-model already always persists file_path, so serve from disk when s3_key is absent instead of
-forcing S3 on every deployment.
-
-## Steps
-1. **LOCAL_AUDIO_STORAGE_PATH setting** — config.py field next to AWS_* block, default project-relative
-   storage/audio (persistent, not /tmp). Document in apps/api/.env.example + root .env.example.
-2. **Persist audio out of /tmp** — finalize_episode_generation_task no-S3 branch: copy audio_file_path
-   into LOCAL_AUDIO_STORAGE_PATH (mkdir), set episode.file_path before committing complete. S3 path unchanged.
-3. **iter_local_file** in download_utils.py mirroring iter_s3_body (asyncio.to_thread, start/end range).
-4. **Download endpoint local fallback** — episodes.py: keep complete guard; branch s3_key -> S3 path,
-   elif file_path on disk -> serve locally (os.path.getsize, 200/206/416, identical headers), else 404.
-5. **S3 versioning (operational)** — deployment/ helper script (aws s3api put-bucket-versioning
-   Status=Enabled) + deployment/README.md S3 section step (admin action).
-6. **Tests** — test_download_endpoint.py (200+206 local, fix missing_s3_key 404 needs both absent);
-   test_s3_upload.py (file_path into LOCAL_AUDIO_STORAGE_PATH not /tmp); unit/test_download_utils.py
-   (full + ranged iter_local_file).
-
-## Acceptance criteria
-- [ ] No-S3: episode complete AND downloadable (no /tmp loss)
-- [ ] S3 bucket versioning enabled/documented
-- [ ] Test for no-S3 path
-- [ ] S3 path behavior unchanged
+## Acceptance criteria mapping
+- [ ] complete/in-progress short-circuit before paid `generate_podcast(...)`
+- [ ] only proceeds from queued/failed (unknown fail-open; retries re-own)
+- [ ] Redis lock blocks concurrent/duplicate in-flight runs, self-heals via TTL
+- [ ] `acks_late=False` so abrupt loss surfaces as failure, not a re-run


### PR DESCRIPTION
Closes #295

## Problem
`generate_podcast_task` ran under at-least-once delivery (`task_acks_late=True` + `task_reject_on_worker_lost=True`) with **no entry-time idempotency check**. Any abrupt worker loss (OOM from in-memory pydub audio, deploy restart, SIGKILL) re-queued and re-ran the entire **paid** LLM/TTS pipeline (and re-dispatched the downstream chain) → duplicate billing and duplicate artifacts.

## Changes
1. **Fail-fast the expensive root task.** `generate_podcast_task` now overrides `acks_late=False, reject_on_worker_lost=False` so abrupt loss surfaces as a failed/stuck episode (handled by the #294 reaper) instead of a silent paid re-run. Global `worker.py` settings are untouched — cheap downstream tasks keep at-least-once semantics.
2. **New `src/tasks/idempotency.py`** — a per-episode Redis lock (`SET NX EX`, TTL = `CELERY_TASK_TIME_LIMIT + 60`, keyed `podcast_generation_lock:{episode_id}`). Re-entrant by `task_id` so a Celery retry doesn't deadlock itself; atomic compare-and-delete release via Lua; fail-open on Redis outage.
3. **Entry guard** in `generate_podcast_task`: short-circuit `complete`/in-flight episodes before any paid call, acquire the lock, persist `generating`. Lock released on every terminal exit — **not** on the `self.retry()` path (same task re-owns it; TTL is the crash backstop).
4. **Router race fix.** The dispatch previously committed `queued` *after* `apply_async`, so a fast worker could read the pre-regeneration status (`complete`) and skip a legitimate run. Now `queued` is committed with a pre-generated `task_id` **before** dispatch. If enqueue fails, the prior restartable status is restored (a still-valid `complete` episode stays downloadable) and a `503` is returned.

## Acceptance criteria
- [x] Short-circuit if status is already `complete` (or in-progress) — before paid `generate_podcast(...)`
- [x] Only proceed from `queued`/`failed` (unknown = fail-open; retries re-own the lock)
- [x] Redis lock blocks concurrent/duplicate in-flight runs, self-heals via TTL
- [x] `acks_late=False` so abrupt loss surfaces as failure, not a re-run

## Tests
`tests/unit/test_generation_idempotency.py` (13) — lock acquire/release (fresh/held/re-entrant/fail-open), entry-guard short-circuits (complete/in-progress/lock-held), retry passthrough, decorator config. Plus router tests for commit-before-dispatch ordering and enqueue-failure rollback. Full backend suite green (727 passed).

## Review
Local cross-family `codex review` run; surfaced and fixed a regenerate-race P1 and two enqueue-failure P2s before opening. Final pass clean.

## Known limitations
- The lock is best-effort (fail-open on Redis errors) by design — availability over strictness; the DB status check + #294 reaper are the durable backstops.
- A worker killed between acquiring the lock and a terminal exit relies on TTL expiry (~time_limit+60s) before a manual retry can re-acquire.