### PR TITLE
fix(billing): unique constraint on billing_usage(user_id, period_start) (#296)

### DIFF
--- a/apps/api/alembic/versions/013_add_billing_usage_unique_constraint.py
+++ b/apps/api/alembic/versions/013_add_billing_usage_unique_constraint.py
@@ -1,0 +1,95 @@
+"""Add unique constraint on billing_usage(user_id, period_start)
+
+Revision ID: 013
+Revises: 012
+Create Date: 2026-06-26 00:00:00.000000
+
+Backstops per-period usage uniqueness at the DB level (#296):
+- Deduplicates any existing rows by aggregating metric columns into the
+  earliest-created survivor per (user_id, period_start) group, then deleting
+  the duplicates — so the constraint applies cleanly on dirty databases.
+- Adds UNIQUE(user_id, period_start) so concurrent first-touch metering can
+  never create duplicate rows (which made scalar_one_or_none() raise
+  MultipleResultsFound → 500).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers
+revision: str = "013"
+down_revision: Union[str, None] = "012"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+	# Aggregate metric columns from duplicate rows into the earliest-created
+	# survivor (min created_at, ties broken by id) per (user_id, period_start).
+	op.execute(
+		"""
+		WITH survivors AS (
+			SELECT id AS keep_id, user_id, period_start
+			FROM (
+				SELECT id, user_id, period_start,
+				       ROW_NUMBER() OVER (
+				           PARTITION BY user_id, period_start
+				           ORDER BY created_at, id
+				       ) AS rn
+				FROM billing_usage
+			) ranked
+			WHERE rn = 1
+		),
+		agg AS (
+			SELECT user_id, period_start,
+			       SUM(episodes_created)   AS episodes_created,
+			       SUM(api_calls)          AS api_calls,
+			       SUM(storage_bytes)      AS storage_bytes,
+			       SUM(compute_hours)      AS compute_hours,
+			       SUM(overage_episodes)   AS overage_episodes,
+			       SUM(overage_storage_gb) AS overage_storage_gb,
+			       SUM(overage_cost)       AS overage_cost
+			FROM billing_usage
+			GROUP BY user_id, period_start
+			HAVING COUNT(*) > 1
+		)
+		UPDATE billing_usage t
+		SET episodes_created   = agg.episodes_created,
+		    api_calls          = agg.api_calls,
+		    storage_bytes      = agg.storage_bytes,
+		    compute_hours      = agg.compute_hours,
+		    overage_episodes   = agg.overage_episodes,
+		    overage_storage_gb = agg.overage_storage_gb,
+		    overage_cost       = agg.overage_cost
+		FROM agg
+		JOIN survivors s
+		  ON s.user_id = agg.user_id AND s.period_start = agg.period_start
+		WHERE t.id = s.keep_id;
+		"""
+	)
+
+	# Delete the now-redundant duplicate rows, keeping only the survivors.
+	op.execute(
+		"""
+		DELETE FROM billing_usage b
+		USING (
+			SELECT id,
+			       ROW_NUMBER() OVER (
+			           PARTITION BY user_id, period_start
+			           ORDER BY created_at, id
+			       ) AS rn
+			FROM billing_usage
+		) d
+		WHERE b.id = d.id AND d.rn > 1;
+		"""
+	)
+
+	op.create_unique_constraint(
+		"uq_billing_usage_user_period",
+		"billing_usage",
+		["user_id", "period_start"],
+	)
+
+
+def downgrade() -> None:
+	op.drop_constraint("uq_billing_usage_user_period", "billing_usage", type_="unique")

--- a/apps/api/src/models/billing_usage.py
+++ b/apps/api/src/models/billing_usage.py
@@ -1,7 +1,7 @@
 """Billing usage model for tracking resource consumption"""
 
 from datetime import datetime
-from sqlalchemy import Column, Integer, BigInteger, Float, DateTime, Date, Numeric
+from sqlalchemy import Column, Integer, BigInteger, Float, DateTime, Date, Numeric, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 import uuid
 
@@ -12,6 +12,9 @@ class BillingUsage(Base):
 	"""Track usage for pricing enforcement and overage charges"""
 
 	__tablename__ = "billing_usage"
+	__table_args__ = (
+		UniqueConstraint("user_id", "period_start", name="uq_billing_usage_user_period"),
+	)
 
 	id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
 	user_id = Column(UUID(as_uuid=True), nullable=False, index=True)

--- a/apps/api/src/services/usage_service.py
+++ b/apps/api/src/services/usage_service.py
@@ -5,7 +5,8 @@ from decimal import Decimal
 from typing import Any, Dict
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models.billing_subscription import BillingSubscription
@@ -29,25 +30,28 @@ async def _get_or_create_usage(db: AsyncSession, user_id: UUID, tenant_id: UUID)
 	"""Return usage record for the current period, creating one if needed."""
 	period_start, period_end = _current_period_dates()
 
+	# Concurrency-safe first-touch insert: ON CONFLICT DO NOTHING means two
+	# concurrent requests for the same (user_id, period_start) can never create
+	# duplicate rows. Metric columns rely on their DB defaults.
+	await db.execute(
+		pg_insert(BillingUsage)
+		.values(
+			user_id=user_id,
+			tenant_id=tenant_id,
+			period_start=period_start,
+			period_end=period_end,
+		)
+		.on_conflict_do_nothing(index_elements=["user_id", "period_start"])
+	)
+
+	# Re-select the guaranteed-present row (either ours or the concurrent winner's).
 	result = await db.execute(
 		select(BillingUsage).where(
 			BillingUsage.user_id == user_id,
 			BillingUsage.period_start == period_start,
 		)
 	)
-	usage = result.scalar_one_or_none()
-
-	if usage is None:
-		usage = BillingUsage(
-			user_id=user_id,
-			tenant_id=tenant_id,
-			period_start=period_start,
-			period_end=period_end,
-		)
-		db.add(usage)
-		await db.flush()
-
-	return usage
+	return result.scalar_one()
 
 
 async def _get_user_tier(db: AsyncSession, user_id: UUID) -> str:
@@ -63,17 +67,39 @@ async def _get_user_tier(db: AsyncSession, user_id: UUID) -> str:
 
 async def track_episode_creation(db: AsyncSession, user_id: UUID, tenant_id: UUID) -> None:
 	"""Increment episode count for current billing period."""
-	usage = await _get_or_create_usage(db, user_id, tenant_id)
-	usage.episodes_created += 1
-	usage.updated_at = datetime.utcnow()
+	await _get_or_create_usage(db, user_id, tenant_id)
+	period_start, _ = _current_period_dates()
+	# Atomic server-side increment avoids lost updates under concurrency.
+	await db.execute(
+		update(BillingUsage)
+		.where(
+			BillingUsage.user_id == user_id,
+			BillingUsage.period_start == period_start,
+		)
+		.values(
+			episodes_created=BillingUsage.episodes_created + 1,
+			updated_at=datetime.utcnow(),
+		)
+	)
 	await db.commit()
 
 
 async def track_api_call(db: AsyncSession, user_id: UUID, tenant_id: UUID) -> None:
 	"""Track an API call for the current billing period."""
-	usage = await _get_or_create_usage(db, user_id, tenant_id)
-	usage.api_calls += 1
-	usage.updated_at = datetime.utcnow()
+	await _get_or_create_usage(db, user_id, tenant_id)
+	period_start, _ = _current_period_dates()
+	# Atomic server-side increment avoids lost updates under concurrency.
+	await db.execute(
+		update(BillingUsage)
+		.where(
+			BillingUsage.user_id == user_id,
+			BillingUsage.period_start == period_start,
+		)
+		.values(
+			api_calls=BillingUsage.api_calls + 1,
+			updated_at=datetime.utcnow(),
+		)
+	)
 	await db.commit()
 
 

--- a/apps/api/tests/test_usage_concurrency.py
+++ b/apps/api/tests/test_usage_concurrency.py
@@ -1,0 +1,154 @@
+"""Concurrency regression tests for usage metering (#296).
+
+The shared ``test_db`` fixture isolates each test inside a single rolled-back
+transaction, so it cannot model genuine parallel commits. These tests therefore
+build their own engine and run each concurrent tracker in its *own* session /
+connection (NullPool) so the upsert + atomic-increment paths face a real race
+against the live test database. Committed rows are cleaned up at the end.
+"""
+import asyncio
+import os
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import delete, func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
+
+from src.models.billing_usage import BillingUsage
+from src.models.user import User
+from src.services.usage_service import (
+	_current_period_dates,
+	track_api_call,
+	track_episode_creation,
+)
+
+TEST_DATABASE_URL = os.environ.get(
+	"TEST_DATABASE_URL",
+	"postgresql+asyncpg://podcastfy_app:podcastfy_app_password@localhost:5432/podcastfy",
+)
+
+CONCURRENCY = 12
+
+
+@pytest.fixture
+async def committing_session_factory():
+	"""Engine + session factory whose sessions commit for real (no rollback).
+
+	Yields ``(factory, cleanup)``; ``cleanup`` removes any billing/user rows the
+	test committed so the shared test DB stays clean.
+	"""
+	engine = create_async_engine(TEST_DATABASE_URL, poolclass=NullPool, echo=False)
+	factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+	created_user_ids: list = []
+
+	async def cleanup():
+		async with factory() as session:
+			# billing_usage has no RLS — deletes unconditionally.
+			await session.execute(
+				delete(BillingUsage).where(BillingUsage.user_id.in_(created_user_ids))
+			)
+			# users is FORCE RLS; DELETE needs a matching tenant context.
+			for uid in created_user_ids:
+				row = (
+					await session.execute(select(User).where(User.id == uid))
+				).scalar_one_or_none()
+				if row is not None:
+					await session.execute(
+						text(f"SET LOCAL app.tenant_id = '{row.tenant_id}'")
+					)
+					await session.execute(delete(User).where(User.id == uid))
+					await session.commit()
+			await session.commit()
+		await engine.dispose()
+
+	yield factory, created_user_ids
+
+	await cleanup()
+
+
+async def _make_user(factory) -> tuple:
+	"""Create and commit a real user; return (user_id, tenant_id)."""
+	user_id = uuid4()
+	tenant_id = uuid4()
+	async with factory() as session:
+		# INSERT works without tenant context (permissive insert-only policy).
+		session.add(
+			User(
+				id=user_id,
+				email=f"concurrency_{user_id}@example.com",
+				password_hash="x",
+				tenant_id=tenant_id,
+			)
+		)
+		await session.commit()
+	return user_id, tenant_id
+
+
+async def _count_rows(factory, user_id, period_start) -> int:
+	async with factory() as session:
+		return (
+			await session.execute(
+				select(func.count())
+				.select_from(BillingUsage)
+				.where(
+					BillingUsage.user_id == user_id,
+					BillingUsage.period_start == period_start,
+				)
+			)
+		).scalar_one()
+
+
+async def _get_usage(factory, user_id, period_start) -> BillingUsage:
+	async with factory() as session:
+		# scalar_one() raises MultipleResultsFound if duplicates leaked through.
+		return (
+			await session.execute(
+				select(BillingUsage).where(
+					BillingUsage.user_id == user_id,
+					BillingUsage.period_start == period_start,
+				)
+			)
+		).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_episode_tracking_no_duplicates_or_lost_updates(
+	committing_session_factory,
+):
+	factory, created_user_ids = committing_session_factory
+	user_id, tenant_id = await _make_user(factory)
+	created_user_ids.append(user_id)
+	period_start, _ = _current_period_dates()
+
+	async def track_once():
+		# Independent session/connection per coroutine = genuine parallel commits.
+		async with factory() as session:
+			await track_episode_creation(session, user_id, tenant_id)
+
+	await asyncio.gather(*(track_once() for _ in range(CONCURRENCY)))
+
+	assert await _count_rows(factory, user_id, period_start) == 1
+	usage = await _get_usage(factory, user_id, period_start)
+	assert usage.episodes_created == CONCURRENCY
+
+
+@pytest.mark.asyncio
+async def test_concurrent_api_call_tracking_no_duplicates_or_lost_updates(
+	committing_session_factory,
+):
+	factory, created_user_ids = committing_session_factory
+	user_id, tenant_id = await _make_user(factory)
+	created_user_ids.append(user_id)
+	period_start, _ = _current_period_dates()
+
+	async def track_once():
+		async with factory() as session:
+			await track_api_call(session, user_id, tenant_id)
+
+	await asyncio.gather(*(track_once() for _ in range(CONCURRENCY)))
+
+	assert await _count_rows(factory, user_id, period_start) == 1
+	usage = await _get_usage(factory, user_id, period_start)
+	assert usage.api_calls == CONCURRENCY

--- a/apps/api/tests/unit/test_usage_service.py
+++ b/apps/api/tests/unit/test_usage_service.py
@@ -234,10 +234,12 @@ class TestGetUsageSummary:
 		db = _mock_db()
 		usage = _make_usage(episodes_created=2, api_calls=50, storage_bytes=1024)
 
-		# _get_user_tier call, _get_or_create_usage call (select), then flush if new
+		# _get_user_tier (select), then _get_or_create_usage:
+		# upsert insert (on_conflict_do_nothing) + re-select via scalar_one().
 		results = [
 			MagicMock(scalar_one_or_none=MagicMock(return_value=_make_subscription("free"))),
-			MagicMock(scalar_one_or_none=MagicMock(return_value=usage)),
+			MagicMock(),  # ON CONFLICT DO NOTHING insert
+			MagicMock(scalar_one=MagicMock(return_value=usage)),
 		]
 		db.execute.side_effect = results
 
@@ -257,7 +259,8 @@ class TestGetUsageSummary:
 
 		results = [
 			MagicMock(scalar_one_or_none=MagicMock(return_value=_make_subscription("free"))),
-			MagicMock(scalar_one_or_none=MagicMock(return_value=usage)),
+			MagicMock(),  # ON CONFLICT DO NOTHING insert
+			MagicMock(scalar_one=MagicMock(return_value=usage)),
 		]
 		db.execute.side_effect = results
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,56 +1,34 @@
-# Issue #295 — Idempotency guard for generate_podcast_task (P0.5)
+# Issue #296 — billing_usage unique constraint on (user_id, period_start)
 
-**Problem:** `generate_podcast_task` runs under at-least-once delivery
-(`task_acks_late=True` + `task_reject_on_worker_lost=True`) with no entry-time
-idempotency check. Abrupt worker loss (OOM, deploy, SIGKILL) re-queues and
-re-runs the entire **paid** LLM/TTS pipeline → duplicate billing + duplicate
-artifacts.
+## Problem
+`_get_or_create_usage` does check-then-insert with no DB uniqueness backstop. Concurrent
+same-month requests both insert → `scalar_one_or_none()` raises MultipleResultsFound (500),
+counts split across rows. Increments are also non-atomic (lost updates).
 
-**Dependency:** P0.4 (#294 terminal-status handling) — already merged.
+## Plan (TDD)
 
-## Adapted plan (verified against current code)
+### 1. Model — `src/models/billing_usage.py`
+- Add `__table_args__ = (UniqueConstraint("user_id", "period_start", name="uq_billing_usage_user_period"),)`
+- Keep existing `index=True` on `user_id`.
 
-### 1. Fail-fast the expensive root task — `worker.py` untouched
-- On `@celery_app.task(... name="generate_podcast")` decorator
-  (`podcast_generation.py:103`), add `acks_late=False, reject_on_worker_lost=False`
-  with a comment: paid, non-idempotent work must not be broker-redelivered.
-- Leave global `worker.py:47-48` settings as-is (downstream tasks stay at-least-once).
+### 2. Migration — `alembic/versions/013_add_billing_usage_unique_constraint.py`
+- `revision = "013"`, `down_revision = "012"` (bare numbers, matching repo convention).
+- `upgrade()`: dedup existing rows per `(user_id, period_start)` (aggregate metric cols into one
+  surviving row, delete rest) via `op.execute`, then
+  `op.create_unique_constraint("uq_billing_usage_user_period", "billing_usage", ["user_id", "period_start"])`.
+- `downgrade()`: drop the constraint.
 
-### 2. New `apps/api/src/tasks/idempotency.py` — Redis episode lock
-- `_redis()` → `Redis.from_url(settings.REDIS_URL, decode_responses=True)`
-  (mirrors `distribution_target_service.py` / `rate_limiter.py`).
-- `acquire_generation_lock(episode_id, task_id)`: `SET NX EX` with
-  `ttl = CELERY_TASK_TIME_LIMIT + 60`, key `podcast_generation_lock:{episode_id}`,
-  value `task_id`. **Re-entrant**: if key already holds *our* task_id (a Celery
-  retry keeps the same id), return True. Fail-open (return True) on Redis error.
-- `release_generation_lock(episode_id, task_id)`: atomic compare-and-delete via
-  Lua eval (only deletes if we still own it). Fail-open on error.
+### 3. Service — `src/services/usage_service.py`
+- `_get_or_create_usage`: use `insert(BillingUsage).values(...).on_conflict_do_nothing(index_elements=["user_id","period_start"])`
+  (postgresql dialect), then re-select and return the guaranteed row.
+- `track_episode_creation` / `track_api_call`: after ensuring row exists, atomic
+  `update(BillingUsage).where(...).values(col=BillingUsage.col + 1, updated_at=...)`. Drop Python-side `+=`.
 
-### 3. Entry guard in `generate_podcast_task` (top of `try`, before podcastfy import)
-- `_load_generation_status(episode_id)` helper (patchable; fail-open → None).
-- `status == "complete"` → return early "already complete" (no chain, no paid work).
-- `status` in active in-progress set
-  {extracting,generating,synthesizing,uploading,composing,distributing} **and not
-  a retry** → short-circuit as duplicate.
-- queued / failed / draft / unknown(None) → proceed.
-- `acquire_generation_lock(...)`; if not acquired → short-circuit (concurrent duplicate).
-- Persist `generation_status="generating"` via existing `_update_episode`.
+### 4. Test — `tests/test_usage_concurrency.py`
+- Independent sessions/engine per coroutine (test_db rolls back, can't model parallel commits).
+- `asyncio.gather` N concurrent `track_episode_creation` for same `(user_id, period_start)`.
+- Assert: exactly one row, counter == N, no MultipleResultsFound. Clean up committed rows.
 
-### 4. Release lock on every terminal exit (lock-held paths only)
-- success return (`:354`), workflow-skip return (`:300`), soft-timeout return
-  (`:382`), max-retries-exhausted return (`:433`).
-- **Not** on the `self.retry()` path — same task_id re-runs and re-owns the lock;
-  TTL is the crash backstop.
-
-### 5. Tests — `tests/unit/test_generation_idempotency.py`
-- acquire: first True / second-other-task False / re-entrant same-task True / fail-open True.
-- release: compare-and-delete (owner only).
-- task entry: complete → early return + podcastfy NOT called; in-progress dup →
-  short-circuit; lock-held → short-circuit; queued → proceeds.
-- decorator carries `acks_late=False` / `reject_on_worker_lost=False`.
-
-## Acceptance criteria mapping
-- [ ] complete/in-progress short-circuit before paid `generate_podcast(...)`
-- [ ] only proceeds from queued/failed (unknown fail-open; retries re-own)
-- [ ] Redis lock blocks concurrent/duplicate in-flight runs, self-heals via TTL
-- [ ] `acks_late=False` so abrupt loss surfaces as failure, not a re-run
+## Notes
+- Test DB is real PostgreSQL (asyncpg) → `on_conflict_do_nothing` works.
+- billing_usage has no RLS policy → concurrency test needs no tenant context.


### PR DESCRIPTION
## Summary

Fixes #296 — `billing_usage` had no DB-level uniqueness on `(user_id, period_start)`, so two concurrent same-month metering requests both passed the check-then-insert race and inserted duplicate rows. Afterward every `scalar_one_or_none()` over that period raised `MultipleResultsFound` (500), and counts were split across the duplicate rows. Read-modify-write increments were also non-atomic (lost updates).

## Changes

- **Model** (`models/billing_usage.py`): add `UniqueConstraint("user_id", "period_start", name="uq_billing_usage_user_period")`.
- **Migration 013**: deduplicate any existing rows first (aggregate metric columns into the earliest-created survivor per group, delete the rest), then add the unique constraint — applies cleanly on databases that already contain duplicates. `downgrade()` drops the constraint.
- **Service** (`services/usage_service.py`):
  - `_get_or_create_usage` → PostgreSQL `INSERT ... ON CONFLICT DO NOTHING` upsert + re-select, so concurrent first-touch requests can never create duplicates and the row is always guaranteed present.
  - `track_episode_creation` / `track_api_call` → atomic `col = col + 1` SQL updates instead of Python-side `+=`, eliminating lost updates.
- **Test** (`tests/test_usage_concurrency.py`): real-concurrency regression using independent committing sessions (the shared rollback-isolated `test_db` can't model parallel commits) — fires 12 concurrent trackers via `asyncio.gather` and asserts exactly one row and an exact counter total, with no `MultipleResultsFound`.

## Acceptance criteria (all met)

- [x] `UNIQUE(user_id, period_start)` via migration + model
- [x] get-or-create is an upsert (`ON CONFLICT DO NOTHING` + re-select)
- [x] atomic `col = col + 1` updates
- [x] concurrency test

## Verification

- New concurrency tests pass against the real Postgres test DB (genuine parallel commits).
- Migration `013` upgrades, downgrades, and re-upgrades cleanly; constraint confirmed present.
- Full billing + usage suites green: 76 passed. `ruff` clean. Pre-commit hooks passed.

## Known limitations

- Increments commit one row per call (unchanged from before); the upsert adds one extra round-trip on first touch per period, which is negligible.
- `compute_hours` / storage / overage counters are not yet wired to atomic increments because no caller mutates them today; when metering is extended, follow the same `col = col + 1` pattern.
