### PR TITLE
fix(billing): wire usage metering & plan-limit enforcement (#297)

### DIFF
--- a/apps/api/src/dependencies.py
+++ b/apps/api/src/dependencies.py
@@ -5,15 +5,75 @@ This module provides authentication and tenant context dependencies.
 """
 import logging
 from fastapi import Depends, HTTPException, Request, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 from uuid import UUID
 
 # Re-export authentication dependencies from middleware
-from src.middleware.auth import get_current_user, get_active_user
+from src.middleware.auth import (
+	extract_token_from_header,
+	get_active_user,
+	get_current_user,
+	get_user_id_from_token,
+)
+from src.middleware.tenant import TenantContextMiddleware
+from src.services import usage_service
 
 # Database dependency
 from src.database import get_db
 
 logger = logging.getLogger(__name__)
+
+
+async def meter_api_call(
+	request: Request, db: AsyncSession = Depends(get_db)
+) -> None:
+	"""Global boundary hook: enforce and record the per-period API-call quota.
+
+	Runs on every route via the app-level dependency. It is a no-op for public
+	paths and unauthenticated requests, so it never forces auth. For authenticated
+	requests it reuses the RLS-aware, test-overridable ``get_db`` session to check
+	``check_api_limit`` (→ 402 when over) and then ``track_api_call``.
+
+	ponytail: depends on get_db so it opens a session even on public paths; kept
+	this way for test-overridability — swap to a lazy session if health-check DB
+	load ever matters.
+	"""
+	if request.url.path in TenantContextMiddleware.PUBLIC_PATHS:
+		return
+
+	token = await extract_token_from_header(request)
+	if not token:
+		return
+
+	user_id = get_user_id_from_token(token)
+	tenant_id = getattr(request.state, "tenant_id", None)
+	if not user_id or not tenant_id:
+		# Unauthenticated / unresolved tenant — let the route's auth handle it.
+		return
+
+	try:
+		uid = UUID(user_id)
+		tid = UUID(tenant_id)
+	except (ValueError, TypeError):
+		return
+
+	# Always meter the call. Enforce the cap everywhere EXCEPT the billing
+	# endpoints — otherwise an over-quota user is bricked: they could neither see
+	# their usage nor upgrade to escape the cap (the recovery path itself 402s).
+	try:
+		if not request.url.path.startswith("/billing"):
+			if not await usage_service.check_api_limit(db, uid):
+				raise HTTPException(
+					status_code=status.HTTP_402_PAYMENT_REQUIRED,
+					detail="Monthly API call limit reached for your plan. Please upgrade.",
+				)
+		await usage_service.track_api_call(db, uid, tid)
+	except IntegrityError:
+		# billing_usage's only FK is user_id, so this means the token's subject no
+		# longer exists (user deleted after token issue). That is an auth condition,
+		# not a billing failure — roll back and let get_current_user return 401.
+		await db.rollback()
 
 
 def create_rate_limit_dependency(key_prefix: str, max_requests: int, window_minutes: int):
@@ -144,4 +204,5 @@ __all__ = [
     "get_current_tenant",
     "get_current_tenant_from_user",
     "create_rate_limit_dependency",
+    "meter_api_call",
 ]

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -1,11 +1,12 @@
 """
 Main FastAPI application for Podcastfy GUI API
 """
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.responses import JSONResponse
 import logging
 
 from src.config import settings
+from src.dependencies import meter_api_call
 from src.middleware.cors import setup_cors
 from src.middleware.tenant import TenantContextMiddleware
 
@@ -24,6 +25,9 @@ app = FastAPI(
     docs_url="/docs",
     redoc_url="/redoc",
     openapi_url="/openapi.json",
+    # Boundary metering: count + enforce per-period API quota on every request
+    # (no-op for public/unauthenticated paths). See dependencies.meter_api_call.
+    dependencies=[Depends(meter_api_call)],
 )
 
 # Setup CORS middleware

--- a/apps/api/src/middleware/auth.py
+++ b/apps/api/src/middleware/auth.py
@@ -58,6 +58,29 @@ def get_tenant_id_from_token(token: str) -> Optional[str]:
     return payload.get("tenant_id")
 
 
+def get_user_id_from_token(token: str) -> Optional[str]:
+    """
+    Softly extract the user id (``sub`` claim) from a JWT **access** token.
+
+    Tolerant variant for boundary metering: returns None on any failure
+    (invalid/expired token, wrong token type, missing claim) instead of raising,
+    so it can run on every request without forcing authentication on public
+    routes. Uses ``verify_access_token`` (not ``verify_jwt_token``) so refresh /
+    verification tokens are not metered — they would be rejected with 401 by the
+    route's ``get_current_user``, and metering must not pre-empt that with a 402.
+
+    Args:
+        token: JWT token string
+
+    Returns:
+        User ID string, or None if the token is not a valid access token.
+    """
+    try:
+        return verify_access_token(token).get("sub")
+    except Exception:
+        return None
+
+
 async def get_current_user(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
     db: AsyncSession = Depends(get_db)

--- a/apps/api/src/routers/episodes.py
+++ b/apps/api/src/routers/episodes.py
@@ -36,6 +36,7 @@ from ..services.episode_service import (
 	VALID_SORT_ORDERS,
 )
 from ..services.storage_service import StorageService
+from ..services import usage_service
 from ..config import settings
 from ..utils.download_utils import (
 	get_episode_filename,
@@ -69,14 +70,23 @@ async def create_episode_endpoint(
 		Created episode with all fields
 
 	Raises:
+		HTTPException: 402 if the plan's monthly episode limit is reached
 		HTTPException: 404 if project not found
 	"""
+	# Quota gate before any write; tracking happens only after a successful create.
+	if not await usage_service.check_episode_limit(db, current_user.id):
+		raise HTTPException(
+			status_code=status.HTTP_402_PAYMENT_REQUIRED,
+			detail="Monthly episode limit reached for your plan. Please upgrade to create more episodes.",
+		)
+
 	episode = await create_episode(
 		db=db,
 		user_id=current_user.id,
 		tenant_id=current_user.tenant_id,
 		episode_data=episode_data
 	)
+	await usage_service.track_episode_creation(db, current_user.id, current_user.tenant_id)
 	return episode
 
 
@@ -193,12 +203,26 @@ async def batch_create_episodes_endpoint(
 
 	Returns:
 		Batch result with batch_id, status, counts, and per-episode results
+
+	Raises:
+		HTTPException: 402 if the batch would exceed the plan's monthly episode limit
 	"""
+	# Gate the whole batch up front (conservative: counts every requested episode),
+	# then track only those that actually succeeded.
+	if not await usage_service.check_episode_quota(db, current_user.id, len(batch_data.episodes)):
+		raise HTTPException(
+			status_code=status.HTTP_402_PAYMENT_REQUIRED,
+			detail="This batch would exceed your plan's monthly episode limit. Please upgrade.",
+		)
+
 	result = await batch_create_episodes(
 		db=db,
 		user_id=current_user.id,
 		tenant_id=current_user.tenant_id,
 		batch_data=batch_data
+	)
+	await usage_service.track_episode_creation(
+		db, current_user.id, current_user.tenant_id, count=result["created_count"]
 	)
 	return result
 

--- a/apps/api/src/services/usage_service.py
+++ b/apps/api/src/services/usage_service.py
@@ -65,8 +65,12 @@ async def _get_user_tier(db: AsyncSession, user_id: UUID) -> str:
 	return sub.tier
 
 
-async def track_episode_creation(db: AsyncSession, user_id: UUID, tenant_id: UUID) -> None:
-	"""Increment episode count for current billing period."""
+async def track_episode_creation(
+	db: AsyncSession, user_id: UUID, tenant_id: UUID, count: int = 1
+) -> None:
+	"""Increment episode count for current billing period (by ``count``)."""
+	if count <= 0:
+		return
 	await _get_or_create_usage(db, user_id, tenant_id)
 	period_start, _ = _current_period_dates()
 	# Atomic server-side increment avoids lost updates under concurrency.
@@ -77,7 +81,7 @@ async def track_episode_creation(db: AsyncSession, user_id: UUID, tenant_id: UUI
 			BillingUsage.period_start == period_start,
 		)
 		.values(
-			episodes_created=BillingUsage.episodes_created + 1,
+			episodes_created=BillingUsage.episodes_created + count,
 			updated_at=datetime.utcnow(),
 		)
 	)
@@ -103,8 +107,8 @@ async def track_api_call(db: AsyncSession, user_id: UUID, tenant_id: UUID) -> No
 	await db.commit()
 
 
-async def check_episode_limit(db: AsyncSession, user_id: UUID) -> bool:
-	"""Return True if user can create another episode this period."""
+async def check_episode_quota(db: AsyncSession, user_id: UUID, count: int = 1) -> bool:
+	"""Return True if ``count`` more episodes fit within this period's limit."""
 	tier = await _get_user_tier(db, user_id)
 	if is_unlimited(tier, "episodes_per_month"):
 		return True
@@ -120,7 +124,12 @@ async def check_episode_limit(db: AsyncSession, user_id: UUID) -> bool:
 	)
 	usage = result.scalar_one_or_none()
 	current = usage.episodes_created if usage else 0
-	return current < limit
+	return current + count <= limit
+
+
+async def check_episode_limit(db: AsyncSession, user_id: UUID) -> bool:
+	"""Return True if user can create another episode this period."""
+	return await check_episode_quota(db, user_id, 1)
 
 
 async def check_api_limit(db: AsyncSession, user_id: UUID) -> bool:

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -111,7 +111,7 @@ async def client(test_db):
     Create an async HTTP client for testing FastAPI endpoints with test database.
     This fixture properly handles tenant context for RLS by accepting the Request parameter.
     """
-    from fastapi import Request
+    from fastapi import HTTPException, Request
     from src.database import set_tenant_context
 
     # Override the database dependency with proper tenant context support
@@ -123,6 +123,14 @@ async def client(test_db):
                 await set_tenant_context(test_db, str(request.state.tenant_id))
 
             yield test_db
+        except HTTPException:
+            # Expected control-flow responses (402/404/409, …) are NOT database
+            # failures. Production uses a session-per-request, so an HTTPException
+            # there never rolls back other requests' data. The test session is
+            # shared across all requests in a test, so rolling back here would
+            # wipe earlier writes (e.g. the registered user) and break any
+            # assertion made after a rejected request. Re-raise without rollback.
+            raise
         except Exception:
             await test_db.rollback()
             raise

--- a/apps/api/tests/test_billing.py
+++ b/apps/api/tests/test_billing.py
@@ -77,13 +77,18 @@ async def test_get_subscription_new_user_defaults_to_free(client):
 
 @pytest.mark.asyncio
 async def test_get_subscription_usage_starts_at_zero(client):
-	"""New user's usage should be zero."""
+	"""New user has no episodes; api_calls reflect boundary metering (#297).
+
+	Since wiring up usage metering, every authenticated request is counted — so
+	this very `GET /billing/subscription` increments api_calls. episodes_created
+	stays 0 because no episode has been created.
+	"""
 	headers = await register_and_login(client)
 	response = await client.get("/billing/subscription", headers=headers)
 	assert response.status_code == 200
 	data = response.json()
 	assert data["usage"]["episodes_created"] == 0
-	assert data["usage"]["api_calls"] == 0
+	assert data["usage"]["api_calls"] >= 1
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_episodes.py
+++ b/apps/api/tests/test_episodes.py
@@ -9,10 +9,19 @@ import pytest
 from datetime import datetime, timezone
 from uuid import uuid4
 
+from src.models.billing_subscription import BillingSubscription
+from src.services.auth_service import verify_jwt_token
+
 
 @pytest.fixture
-async def project_and_auth(client):
-	"""Create user and project, return (project_id, auth_headers)."""
+async def project_and_auth(client, test_db):
+	"""Create user and project, return (project_id, auth_headers).
+
+	The user is seeded with an enterprise (unlimited) subscription so the
+	episode-quota gate (#297) never trips for the CRUD/pagination tests that
+	create many episodes. Quota enforcement itself is covered by
+	test_usage_enforcement.py with fresh free-tier users.
+	"""
 	# Register user
 	reg_response = await client.post("/auth/register", json={
 		"email": f"test_{uuid4()}@example.com",
@@ -22,6 +31,13 @@ async def project_and_auth(client):
 	assert reg_response.status_code == 201
 	token = reg_response.json()["access_token"]
 	headers = {"Authorization": f"Bearer {token}"}
+
+	# Seed an enterprise subscription (billing tables have no RLS).
+	claims = verify_jwt_token(token)
+	test_db.add(BillingSubscription(
+		user_id=claims["sub"], tenant_id=claims["tenant_id"], tier="enterprise",
+	))
+	await test_db.flush()
 
 	# Create project
 	proj_response = await client.post("/projects", headers=headers, json={

--- a/apps/api/tests/test_usage_enforcement.py
+++ b/apps/api/tests/test_usage_enforcement.py
@@ -1,0 +1,255 @@
+"""Integration tests for usage metering and plan-limit enforcement (#297).
+
+Proves the previously-dead `usage_service` functions are now wired at the request
+boundary: episode/API counters increment, free-tier limits return 402, and
+unlimited (enterprise) tiers are never blocked. Uses the real-DB `test_db`/`client`
+fixtures with per-test transaction rollback.
+"""
+
+import pytest
+from uuid import uuid4
+
+from src.models.billing_subscription import BillingSubscription
+from src.models.billing_usage import BillingUsage
+from src.services.auth_service import verify_jwt_token
+from src.services.usage_service import _current_period_dates
+from src.utils.pricing import get_tier_limit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def register(client, email=None):
+	"""Register a free-tier user; return (headers, user_id, tenant_id)."""
+	if email is None:
+		email = f"usage_{uuid4()}@example.com"
+	resp = await client.post("/auth/register", json={
+		"email": email,
+		"password": "SecurePass123!",
+		"full_name": "Usage Test",
+	})
+	assert resp.status_code == 201, resp.text
+	token = resp.json()["access_token"]
+	payload = verify_jwt_token(token)
+	return (
+		{"Authorization": f"Bearer {token}"},
+		payload["sub"],
+		payload["tenant_id"],
+	)
+
+
+async def make_project(client, headers):
+	resp = await client.post("/projects", headers=headers, json={
+		"name": "Usage Project",
+		"podcast_metadata": {"show_title": "S", "author": "A", "description": "D"},
+	})
+	assert resp.status_code == 201, resp.text
+	return resp.json()["id"]
+
+
+async def create_episode(client, headers, project_id, number):
+	return await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": number,
+		"episode_metadata": {"title": f"Ep {number}", "description": "d"},
+	})
+
+
+async def seed_subscription(test_db, user_id, tenant_id, tier):
+	test_db.add(BillingSubscription(user_id=user_id, tenant_id=tenant_id, tier=tier))
+	await test_db.flush()
+
+
+async def seed_usage(test_db, user_id, tenant_id, **counters):
+	"""Set current-period usage counters, upserting the period row.
+
+	API metering may already have created the row for this request, so update it
+	in place when present rather than inserting a conflicting duplicate.
+	"""
+	from sqlalchemy import select
+	start, end = _current_period_dates()
+	existing = (await test_db.execute(
+		select(BillingUsage).where(
+			BillingUsage.user_id == user_id,
+			BillingUsage.period_start == start,
+		)
+	)).scalar_one_or_none()
+	if existing is None:
+		test_db.add(BillingUsage(
+			user_id=user_id, tenant_id=tenant_id,
+			period_start=start, period_end=end, **counters,
+		))
+	else:
+		for key, value in counters.items():
+			setattr(existing, key, value)
+	await test_db.flush()
+
+
+# ---------------------------------------------------------------------------
+# Episode quota enforcement & metering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_episode_creation_blocked_at_free_limit(client):
+	headers, _, _ = await register(client)
+	project_id = await make_project(client, headers)
+	free_limit = get_tier_limit("free", "episodes_per_month")
+
+	for i in range(1, free_limit + 1):
+		resp = await create_episode(client, headers, project_id, i)
+		assert resp.status_code == 201, resp.text
+
+	# The (limit+1)-th creation is rejected with 402 Payment Required.
+	resp = await create_episode(client, headers, project_id, free_limit + 1)
+	assert resp.status_code == 402, resp.text
+	assert "limit" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_episode_counter_increments_only_on_success(client):
+	headers, _, _ = await register(client)
+	project_id = await make_project(client, headers)
+	free_limit = get_tier_limit("free", "episodes_per_month")
+
+	for i in range(1, free_limit + 1):
+		assert (await create_episode(client, headers, project_id, i)).status_code == 201
+
+	usage = await client.get("/billing/usage", headers=headers)
+	assert usage.json()["usage"]["episodes"]["count"] == free_limit
+
+	# Over-limit attempt is rejected and must NOT bump the counter.
+	assert (await create_episode(client, headers, project_id, free_limit + 1)).status_code == 402
+	usage = await client.get("/billing/usage", headers=headers)
+	assert usage.json()["usage"]["episodes"]["count"] == free_limit
+
+
+@pytest.mark.asyncio
+async def test_enterprise_episodes_not_blocked(client, test_db):
+	headers, user_id, tenant_id = await register(client)
+	await seed_subscription(test_db, user_id, tenant_id, tier="enterprise")
+	project_id = await make_project(client, headers)
+	free_limit = get_tier_limit("free", "episodes_per_month")
+
+	# Enterprise is unlimited: creating beyond the free cap still succeeds.
+	for i in range(1, free_limit + 3):
+		resp = await create_episode(client, headers, project_id, i)
+		assert resp.status_code == 201, resp.text
+
+
+# ---------------------------------------------------------------------------
+# API-call metering & limit enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_api_calls_increase_monotonically(client):
+	headers, _, _ = await register(client)
+	first = (await client.get("/billing/usage", headers=headers)).json()["usage"]["api_calls"]["count"]
+	second = (await client.get("/billing/usage", headers=headers)).json()["usage"]["api_calls"]["count"]
+	# Reading usage is itself a metered call, so assert strict increase.
+	assert second > first
+
+
+@pytest.mark.asyncio
+async def test_api_call_blocked_at_free_cap(client, test_db):
+	headers, user_id, tenant_id = await register(client)
+	cap = get_tier_limit("free", "api_calls_per_month")
+	await seed_usage(test_db, user_id, tenant_id, api_calls=cap)
+
+	# A normal (non-billing) endpoint is blocked once the cap is reached.
+	resp = await client.get("/projects", headers=headers)
+	assert resp.status_code == 402, resp.text
+
+
+@pytest.mark.asyncio
+async def test_billing_endpoints_reachable_at_api_cap(client, test_db):
+	"""Over-quota users must still reach billing to view usage / upgrade."""
+	headers, user_id, tenant_id = await register(client)
+	cap = get_tier_limit("free", "api_calls_per_month")
+	await seed_usage(test_db, user_id, tenant_id, api_calls=cap)
+
+	resp = await client.get("/billing/usage", headers=headers)
+	assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_enterprise_api_calls_not_blocked(client, test_db):
+	headers, user_id, tenant_id = await register(client)
+	await seed_subscription(test_db, user_id, tenant_id, tier="enterprise")
+	cap = get_tier_limit("free", "api_calls_per_month")
+	await seed_usage(test_db, user_id, tenant_id, api_calls=cap + 10)
+
+	resp = await client.get("/billing/usage", headers=headers)
+	assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_public_paths_not_metered(client):
+	# Health is public: no auth, no metering, no error.
+	assert (await client.get("/health")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_non_access_token_not_metered_returns_401(client, test_db):
+	"""A non-access token must be rejected by auth (401), never pre-empted by a
+	metering 402 — even when the user is already over the API cap."""
+	from uuid import UUID
+	from src.services.auth_service import create_verification_token
+
+	_, user_id, tenant_id = await register(client)
+	cap = get_tier_limit("free", "api_calls_per_month")
+	await seed_usage(test_db, user_id, tenant_id, api_calls=cap)
+
+	verification_token = create_verification_token(
+		UUID(user_id), "x@example.com", UUID(tenant_id)
+	)
+	resp = await client.get(
+		"/projects", headers={"Authorization": f"Bearer {verification_token}"}
+	)
+	assert resp.status_code == 401, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Batch creation honours the same gate + tracking (adaptation beyond CR plan)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_batch_creation_metered_and_gated(client, test_db):
+	headers, user_id, tenant_id = await register(client)
+	project_id = await make_project(client, headers)
+	free_limit = get_tier_limit("free", "episodes_per_month")
+
+	# Pre-fill the period to one below the free cap so only one slot remains.
+	await seed_usage(test_db, user_id, tenant_id, episodes_created=free_limit - 1)
+
+	# A batch of 3 would exceed the remaining quota → rejected before any write.
+	resp = await client.post("/episodes/batch", headers=headers, json={
+		"episodes": [
+			{"project_id": project_id, "episode_number": n,
+			 "episode_metadata": {"title": f"B{n}", "description": "d"}}
+			for n in range(1, 4)
+		]
+	})
+	assert resp.status_code == 402, resp.text
+
+
+@pytest.mark.asyncio
+async def test_batch_creation_increments_counter(client):
+	headers, _, _ = await register(client)
+	project_id = await make_project(client, headers)
+
+	resp = await client.post("/episodes/batch", headers=headers, json={
+		"episodes": [
+			{"project_id": project_id, "episode_number": n,
+			 "episode_metadata": {"title": f"B{n}", "description": "d"}}
+			for n in range(1, 3)
+		]
+	})
+	assert resp.status_code == 202, resp.text
+
+	usage = await client.get("/billing/usage", headers=headers)
+	assert usage.json()["usage"]["episodes"]["count"] == 2


### PR DESCRIPTION
## Summary

Fixes #297. `track_episode_creation`, `track_api_call`, `check_episode_limit`, and `check_api_limit` existed in `usage_service.py` but had **zero callers** — so `episodes_created`/`api_calls` stayed `0` forever, free-tier limits never enforced, and overage always computed `0`. This wires them in at the request boundary.

Implements the CodeRabbit coding plan on the issue, verified against the codebase, plus two adaptations surfaced during exploration (see below). Depends on #296 (unique constraint) and #295 (idempotency), both already merged.

## Changes

**Episode quota (`routers/episodes.py`)**
- `POST /episodes`: `check_episode_limit` before create → `402` when over; `track_episode_creation` after a successful create.
- `POST /episodes/batch`: same gate (count-aware `check_episode_quota`) + per-created-episode tracking. *(Adaptation — the CR plan covered only the single endpoint; leaving batch open would be a metering/limit bypass that perpetuates the undercounting bug.)*

**API-call metering (global boundary dependency)**
- `meter_api_call` (in `dependencies.py`) registered as an app-level dependency in `main.py`. Meters every authenticated request and enforces the per-period API cap (`402`), reusing the RLS-aware, test-overridable `get_db` session. No-op for public paths and unauthenticated requests.
- `get_user_id_from_token` helper in `middleware/auth.py`.

**Correctness hardening (from local `codex` cross-family review)**
- Billing endpoints are exempt from the API-cap **gate** (still counted) — otherwise an over-quota user is bricked: they could neither view usage nor upgrade, because the recovery path itself would `402`.
- `get_user_id_from_token` uses `verify_access_token` (not `verify_jwt_token`), so refresh/verification tokens are not metered — auth returns the correct `401` instead of metering pre-empting with a `402`.
- Metering tolerates a deleted-user FK violation (the only FK on `billing_usage` is `user_id`), rolling back and letting `get_current_user` return `401`.

**Tests**
- New `tests/test_usage_enforcement.py` (real-DB pattern): episode/API counters increment, limit `402`s, enterprise/unlimited bypass, billing reachable at cap, batch gating + tracking, non-access-token → `401`.
- `conftest.py`: `override_get_db` no longer rolls back the **shared** test session on expected `HTTPException`s. Production uses a session-per-request, so an `HTTPException` there never wipes other requests' data; the shared test session would, breaking any assertion made after a rejected request.
- `test_episodes.py`: `project_and_auth` seeds an enterprise subscription so existing >5-episode CRUD/pagination tests aren't gated. Quota enforcement is covered by the new free-tier tests.
- `test_billing.py`: a new user's `api_calls` is no longer `0` once usage is read (reading is itself metered).

## Acceptance criteria
- [x] `check_episode_limit` called before create; `track_episode_creation` after successful commit
- [x] API calls tracked + enforced at the request boundary
- [x] Integration tests assert counters increment and limits enforce at the boundary

## Verification
- New enforcement suite: 11/11 pass.
- Full backend suite via the CI path (`pytest tests/`): 1565 passed, parity with `main` (the single pre-existing `test_audio_snippets::test_download_url_no_s3_config` failure is a known local-env flake present on `main` too).
- `ruff` clean.

## Known Limitations
- **Episode quota check-then-create race (out of scope, per the source plan).** Two concurrent `POST /episodes` near the cap can both pass the gate before either tracks, momentarily exceeding the limit by one. The CR plan explicitly deferred this ("acceptable for this ticket and out of scope here"); an atomic reserve-before-create would change the plan-mandated track-after-commit semantics. Suitable follow-up if hard atomicity is required.
- Batch gating is conservative: it rejects a whole batch whose requested size would exceed remaining quota (counts requested, not just would-succeed), then tracks only those actually created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic usage tracking for API requests and episode creation.
  * Introduced plan-limit checks that return a clear payment-required response when limits are reached.
  * Batch episode creation now counts all requested items before submission and tracks only successful creations.

* **Bug Fixes**
  * Public and billing pages remain accessible without being metered.
  * Requests with invalid or expired auth are handled correctly, without affecting usage counts.
  * Episode and API usage totals now stay accurate across successful and failed requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->