### PR TITLE
fix(web): sentinel for default TTS option to avoid empty-string Radix SelectItem crash (#299)

### DIFF
--- a/apps/web/__mocks__/@radix-ui/react-select.tsx
+++ b/apps/web/__mocks__/@radix-ui/react-select.tsx
@@ -86,6 +86,14 @@ const Item = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement> & { value: string }
 >(({ children, className, value: itemValue, ...props }, ref) => {
+  // Mirror real @radix-ui/react-select: an empty-string Item value is forbidden
+  // and throws at render. Without this guard, the mock silently accepted "" and
+  // hid the production crash (#299).
+  if (itemValue === '') {
+    throw new Error(
+      'A <Select.Item /> must have a value prop that is not an empty string.'
+    )
+  }
   const { setValue, onValueChange, setOpen } = React.useContext(RootContext)
   return (
     <div

--- a/apps/web/__tests__/app/episodes/[id]/page.test.tsx
+++ b/apps/web/__tests__/app/episodes/[id]/page.test.tsx
@@ -61,6 +61,23 @@ function mockFetchRouter() {
   }) as jest.Mock
 }
 
+// Like mockFetchRouter, but returns a saved TTS config so the Saved
+// Configurations <Select> renders (the path that crashed in #299).
+function mockFetchRouterWithSavedConfig() {
+  return jest.fn((url: string) => {
+    if (url.includes('/content/episodes/')) {
+      return Promise.resolve({ ok: true, json: async () => ({ content_sources: [] }) })
+    }
+    if (url.includes('/tts-configs')) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ configs: [{ id: 'tts1', name: 'My Voice', provider: 'openai', is_default: true }] }),
+      })
+    }
+    return Promise.resolve({ ok: true, json: async () => draftEpisode })
+  }) as jest.Mock
+}
+
 describe('EpisodePage generate flow', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -93,5 +110,46 @@ describe('EpisodePage generate flow', () => {
     })
     expect(showSuccessToast).toHaveBeenCalledWith('Podcast generation started')
     expect(showErrorToast).not.toHaveBeenCalled()
+  })
+})
+
+describe('EpisodePage TTS config selector (#299)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('opens the saved-config Select and renders "Default (no override)" without crashing', async () => {
+    global.fetch = mockFetchRouterWithSavedConfig()
+    render(<EpisodePage />)
+
+    await screen.findByText('Test Episode')
+    await userEvent.click(screen.getByRole('button', { name: /tts settings/i }))
+    // Opening the Select renders the items; the default option previously threw
+    // at render via an empty-string SelectItem value (#299).
+    await userEvent.click(await screen.findByLabelText(/select a saved tts configuration/i))
+
+    expect(await screen.findByText('Default (no override)')).toBeInTheDocument()
+  })
+
+  it('applies the default option as tts_config_id: null', async () => {
+    const fetchMock = mockFetchRouterWithSavedConfig()
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+
+    await screen.findByText('Test Episode')
+    await userEvent.click(screen.getByRole('button', { name: /tts settings/i }))
+    await userEvent.click(await screen.findByLabelText(/select a saved tts configuration/i))
+    await userEvent.click(await screen.findByText('Default (no override)'))
+    await userEvent.click(screen.getByRole('button', { name: /apply to episode/i }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/proxy/episodes/ep1',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({ tts_config_id: null }),
+        })
+      )
+    })
   })
 })

--- a/apps/web/src/app/(auth)/episodes/[id]/page.tsx
+++ b/apps/web/src/app/(auth)/episodes/[id]/page.tsx
@@ -54,6 +54,10 @@ interface TTSConfig {
   is_default: boolean
 }
 
+// Radix <Select.Item> forbids empty-string values, so the "no override" option
+// uses a sentinel that maps back to null when applied (#299).
+const TTS_DEFAULT_SENTINEL = "__default__"
+
 const ACTIVE_STATUSES = ["queued", "extracting", "generating", "synthesizing", "uploading"]
 
 const STATUS_MESSAGES: Record<string, string> = {
@@ -90,7 +94,7 @@ export default function EpisodePage() {
   const [progressMessage, setProgressMessage] = useState("")
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>("connecting")
   const [ttsConfigs, setTtsConfigs] = useState<TTSConfig[]>([])
-  const [selectedTtsConfigId, setSelectedTtsConfigId] = useState<string>("")
+  const [selectedTtsConfigId, setSelectedTtsConfigId] = useState<string>(TTS_DEFAULT_SENTINEL)
   const [newTtsProvider, setNewTtsProvider] = useState<string>("openai")
   const [newTtsName, setNewTtsName] = useState<string>("")
   const [newTtsVoice1Id, setNewTtsVoice1Id] = useState<string>("")
@@ -426,7 +430,10 @@ export default function EpisodePage() {
       const response = await fetch(`/api/proxy/episodes/${params.id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ tts_config_id: selectedTtsConfigId || null }),
+        body: JSON.stringify({
+          tts_config_id:
+            selectedTtsConfigId === TTS_DEFAULT_SENTINEL ? null : selectedTtsConfigId,
+        }),
       })
       if (response.ok) {
         showSuccessToast("TTS settings applied")
@@ -743,7 +750,7 @@ export default function EpisodePage() {
                       <SelectValue placeholder="Select a configuration" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="">Default (no override)</SelectItem>
+                      <SelectItem value={TTS_DEFAULT_SENTINEL}>Default (no override)</SelectItem>
                       {ttsConfigs.map((cfg) => (
                         <SelectItem key={cfg.id} value={cfg.id}>
                           {cfg.name} ({cfg.provider})


### PR DESCRIPTION
Fixes #299

## Problem
The saved-TTS-config selector rendered `<SelectItem value="">Default (no override)</SelectItem>`. `@radix-ui/react-select ^2.2.6` forbids empty-string `Item` values and throws at render. The Select only renders once `ttsConfigs.length > 0`, so as soon as a user saved one config and reopened the dialog, the dialog crashed and TTS override became unusable. The hand-rolled Radix mock accepted `""`, so jest stayed green while production broke.

## Fix
- Introduce module-level `TTS_DEFAULT_SENTINEL = "__default__"` for the "Default (no override)" option (Radix-safe, non-empty).
- Initialize `selectedTtsConfigId` to the sentinel and use it as the `SelectItem` value.
- Map the sentinel back to `null` in `applyTTSConfig`'s PUT body (replacing the old `|| null` coercion that only handled `""`), so clearing an override still works.
- Harden `__mocks__/@radix-ui/react-select.tsx`: the `Item` mock now throws on an empty-string `value`, mirroring real Radix — empty-string misuse can no longer pass silently.
- Add regression tests that stub a saved config, open the dialog + Select, assert the default option renders without crashing and that applying it sends `{ tts_config_id: null }`.

## Demo / evidence
- **RED**: with the hardened mock and pre-fix component, the two new TTS tests fail (dialog throws on opening the Select) — reproduces the production crash.
- **GREEN**: after the fix, all 4 episode-page tests pass; full web suite **246/246 pass**; `tsc --noEmit` clean; ESLint clean.

## Acceptance criteria
- [x] Sentinel value mapped back to null in apply/clear logic
- [x] Empty-string guard added to the Radix mock
- [x] Regression test opening the dialog with a saved config against the faithful mock

## Known limitations
No live browser demo (would require standing up the full stack + auth + a persisted config). The mock now faithfully reproduces real Radix's empty-string prohibition, so the regression test exercises the exact crash path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the episode TTS settings flow so the “Default (no override)” option works reliably without crashing.
  * Updated saving behavior to clear the TTS configuration correctly when the default option is selected.
  * Added coverage to ensure the default TTS option can be opened, selected, and applied successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->