### PR TITLE
fix(distribution): persist failed distributions & add distribution_failed terminal state (#300)

### DIFF
--- a/apps/api/src/models/episode.py
+++ b/apps/api/src/models/episode.py
@@ -49,7 +49,10 @@ class Episode(Base):
 
     # Generation status tracking
     # Values: 'draft', 'queued', 'extracting', 'generating', 'synthesizing',
-    #         'uploading', 'composing', 'distributing', 'complete', 'failed'
+    #         'uploading', 'composing', 'distributing', 'complete', 'failed',
+    #         'distribution_failed'
+    # 'distribution_failed' is terminal: the episode generated and uploaded, but
+    # one or more platform distributions failed (issue #300).
     generation_status = Column(Text, nullable=False, default='draft', index=True)
 
     # Generation progress tracking

--- a/apps/api/src/routers/generation.py
+++ b/apps/api/src/routers/generation.py
@@ -40,7 +40,9 @@ _PODCASTFY_TTS_PROVIDER = {"gemini_multi": "geminimulti"}
 # distributing/…); starting a second run would race to write s3_url/s3_key/
 # generation_status and overwrite the in-progress celery_task_id in
 # generation_progress, so SSE would only track the newer task (issue #214).
-_RESTARTABLE_STATUSES = frozenset({"draft", "complete", "failed"})
+_RESTARTABLE_STATUSES = frozenset(
+    {"draft", "complete", "failed", "distribution_failed"}
+)
 
 
 def _podcastfy_tts_model(provider: str) -> str:
@@ -403,8 +405,12 @@ async def get_generation_progress_stream(
                 # Send SSE event
                 yield f"data: {json.dumps(progress_data)}\n\n"
 
-                # Check if generation is complete or failed
-                if current.generation_status in ["complete", "failed"]:
+                # Check if generation reached a terminal status
+                if current.generation_status in [
+                    "complete",
+                    "failed",
+                    "distribution_failed",
+                ]:
                     break
 
                 # Wait before next update (poll every 2 seconds)

--- a/apps/api/src/tasks/callbacks.py
+++ b/apps/api/src/tasks/callbacks.py
@@ -275,6 +275,9 @@ def on_workflow_complete(self: Task, result: Dict[str, Any], episode_id: str) ->
 			else:
 				episode.generation_status = "complete"
 				current_progress["status"] = "complete"
+				# Clear any stale marker from a prior distribution_failed run that
+				# has since been retried successfully (issue #300).
+				current_progress.pop("failed_platforms", None)
 			current_progress["completed_at"] = completed_at
 			episode.generation_progress = current_progress
 

--- a/apps/api/src/tasks/callbacks.py
+++ b/apps/api/src/tasks/callbacks.py
@@ -181,14 +181,19 @@ def on_distribution_complete(
 		episode_id: UUID string of the episode.
 		platform: Platform name (e.g. 'spotify', 'apple_podcasts', 'webhook').
 	"""
-	if result.get("status") != "success":
+	failed = result.get("status") != "success"
+	if failed:
+		# Permanently-failed distribution tasks return {status: failed} rather than
+		# raising (to keep per-platform distribution independent), so record the
+		# failure here instead of dropping it. The whole-episode generation_status
+		# is left untouched — on_workflow_complete derives the terminal state from
+		# the recorded per-platform outcomes (issue #300).
 		logger.error(
 			"Distribution to %s for episode %s indicates failure: %s",
 			platform,
 			episode_id,
 			result.get("error"),
 		)
-		return
 
 	try:
 		with SyncSessionLocal() as db:
@@ -199,24 +204,33 @@ def on_distribution_complete(
 
 			current_progress = dict(episode.generation_progress or {})
 			distribution = dict(current_progress.get("distribution", {}))
-			distribution[platform] = {
-				"status": "complete",
-				"platform_episode_id": result.get("platform_episode_id"),
-				"platform_url": result.get("platform_url"),
-				"distributed_at": _utcnow_iso(),
-			}
+			if failed:
+				distribution[platform] = {
+					"status": "failed",
+					"error": result.get("error"),
+					"failed_at": _utcnow_iso(),
+				}
+			else:
+				distribution[platform] = {
+					"status": "complete",
+					"platform_episode_id": result.get("platform_episode_id"),
+					"platform_url": result.get("platform_url"),
+					"distributed_at": _utcnow_iso(),
+				}
 			current_progress["distribution"] = distribution
 			episode.generation_progress = current_progress
-			episode.generation_status = "distributing"
+			if not failed:
+				episode.generation_status = "distributing"
 
 			db.commit()
 
-		logger.info(
-			"Episode %s distributed to %s: platform_id=%s",
-			episode_id,
-			platform,
-			result.get("platform_episode_id"),
-		)
+		if not failed:
+			logger.info(
+				"Episode %s distributed to %s: platform_id=%s",
+				episode_id,
+				platform,
+				result.get("platform_episode_id"),
+			)
 	except Exception as exc:
 		logger.error(
 			"Failed to update episode %s after distribution to %s: %s",
@@ -232,23 +246,52 @@ def on_workflow_complete(self: Task, result: Dict[str, Any], episode_id: str) ->
 	"""
 	Callback fired when the entire podcast workflow completes successfully.
 
-	Sets Episode.generation_status = 'complete'.
-
-	Args:
-		self: Celery task instance.
-		result: Final result from the last task in the workflow chain.
-		episode_id: UUID string of the episode.
+	Sets Episode.generation_status to 'complete' when every distributed platform
+	succeeded, or 'distribution_failed' when any platform's recorded outcome is
+	non-success — so a partially-failed run is not reported as fully published
+	(issue #300). The locked read is done inline (not via _update_episode) because
+	the final status depends on the per-platform outcomes already in the row.
 	"""
-	updated = _update_episode(
-		episode_id,
-		updates={"generation_status": "complete"},
-		progress_updates={
-			"status": "complete",
-			"completed_at": _utcnow_iso(),
-		},
-	)
-	if updated:
-		logger.info("Episode %s workflow completed successfully", episode_id)
+	try:
+		with SyncSessionLocal() as db:
+			episode = _get_episode_for_update(db, episode_id)
+			if episode is None:
+				logger.error("Episode %s not found in database", episode_id)
+				return
+
+			current_progress = dict(episode.generation_progress or {})
+			distribution = current_progress.get("distribution", {})
+			failed_platforms = [
+				platform
+				for platform, entry in distribution.items()
+				if (entry or {}).get("status") != "complete"
+			]
+
+			completed_at = _utcnow_iso()
+			if failed_platforms:
+				episode.generation_status = "distribution_failed"
+				current_progress["status"] = "distribution_failed"
+				current_progress["failed_platforms"] = failed_platforms
+			else:
+				episode.generation_status = "complete"
+				current_progress["status"] = "complete"
+			current_progress["completed_at"] = completed_at
+			episode.generation_progress = current_progress
+
+			db.commit()
+
+		if failed_platforms:
+			logger.error(
+				"Episode %s workflow completed with failed distributions: %s",
+				episode_id,
+				", ".join(failed_platforms),
+			)
+		else:
+			logger.info("Episode %s workflow completed successfully", episode_id)
+	except Exception as exc:
+		logger.error(
+			"Failed to finalize episode %s: %s", episode_id, exc, exc_info=True
+		)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/unit/test_celery_callbacks.py
+++ b/apps/api/tests/unit/test_celery_callbacks.py
@@ -293,8 +293,8 @@ class TestOnDistributionComplete:
 		assert stmt._for_update_arg is not None
 		mock_session.get.assert_not_called()
 
-	def test_skips_update_on_failure_result(self):
-		"""No database update when result indicates failure."""
+	def test_persists_failure_on_failure_result(self):
+		"""A non-success result is recorded in generation_progress, not dropped (issue #300)."""
 		episode_id = str(uuid.uuid4())
 		episode = _mock_episode(episode_id)
 		mock_ctx, mock_session = _make_sync_session(episode)
@@ -311,7 +311,14 @@ class TestOnDistributionComplete:
 				platform="spotify",
 			)
 
-		mock_ctx.__enter__.assert_not_called()
+		spotify_entry = episode.generation_progress["distribution"]["spotify"]
+		assert spotify_entry["status"] == "failed"
+		assert spotify_entry["error"] == "auth failed"
+		assert "failed_at" in spotify_entry
+		# Per-platform failure must not flip the episode-level status; the final
+		# workflow callback owns that decision.
+		assert episode.generation_status == "generating"
+		mock_session.commit.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -336,6 +343,47 @@ class TestOnWorkflowComplete:
 		progress = episode.generation_progress
 		assert progress.get("status") == "complete"
 		assert "completed_at" in progress
+		mock_session.commit.assert_called_once()
+
+	def test_stays_complete_when_all_distributions_succeeded(self):
+		"""All-success distribution keeps the terminal status 'complete' (issue #300)."""
+		episode_id = str(uuid.uuid4())
+		episode = _mock_episode(episode_id)
+		episode.generation_progress = {
+			"distribution": {
+				"spotify": {"status": "complete"},
+				"apple_podcasts": {"status": "complete"},
+			}
+		}
+		mock_ctx, mock_session = _make_sync_session(episode)
+
+		from src.tasks.callbacks import on_workflow_complete
+
+		with patch("src.tasks.callbacks.SyncSessionLocal", return_value=mock_ctx):
+			_invoke_task(on_workflow_complete, result={}, episode_id=episode_id)
+
+		assert episode.generation_status == "complete"
+		mock_session.commit.assert_called_once()
+
+	def test_marks_distribution_failed_when_a_platform_failed(self):
+		"""A failed platform yields the distinguishable 'distribution_failed' status (issue #300)."""
+		episode_id = str(uuid.uuid4())
+		episode = _mock_episode(episode_id)
+		episode.generation_progress = {
+			"distribution": {
+				"spotify": {"status": "complete"},
+				"apple_podcasts": {"status": "failed", "error": "auth failed"},
+			}
+		}
+		mock_ctx, mock_session = _make_sync_session(episode)
+
+		from src.tasks.callbacks import on_workflow_complete
+
+		with patch("src.tasks.callbacks.SyncSessionLocal", return_value=mock_ctx):
+			_invoke_task(on_workflow_complete, result={}, episode_id=episode_id)
+
+		assert episode.generation_status == "distribution_failed"
+		assert episode.generation_progress["failed_platforms"] == ["apple_podcasts"]
 		mock_session.commit.assert_called_once()
 
 	def test_handles_missing_episode(self):

--- a/apps/api/tests/unit/test_celery_callbacks.py
+++ b/apps/api/tests/unit/test_celery_callbacks.py
@@ -386,6 +386,27 @@ class TestOnWorkflowComplete:
 		assert episode.generation_progress["failed_platforms"] == ["apple_podcasts"]
 		mock_session.commit.assert_called_once()
 
+	def test_clears_stale_failed_platforms_on_successful_retry(self):
+		"""A retried run that fully succeeds drops the prior failed_platforms (issue #300)."""
+		episode_id = str(uuid.uuid4())
+		episode = _mock_episode(episode_id)
+		episode.generation_progress = {
+			"failed_platforms": ["apple_podcasts"],
+			"distribution": {
+				"spotify": {"status": "complete"},
+				"apple_podcasts": {"status": "complete"},
+			},
+		}
+		mock_ctx, mock_session = _make_sync_session(episode)
+
+		from src.tasks.callbacks import on_workflow_complete
+
+		with patch("src.tasks.callbacks.SyncSessionLocal", return_value=mock_ctx):
+			_invoke_task(on_workflow_complete, result={}, episode_id=episode_id)
+
+		assert episode.generation_status == "complete"
+		assert "failed_platforms" not in episode.generation_progress
+
 	def test_handles_missing_episode(self):
 		"""Callback does not raise when episode is not found."""
 		episode_id = str(uuid.uuid4())

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,34 +1,36 @@
-# Issue #296 — billing_usage unique constraint on (user_id, period_start)
+# Issue #300 — P2.2 `on_distribution_complete` silently drops failed distributions
+
+**Branch:** `fix/300-persist-distribution-failures`
 
 ## Problem
-`_get_or_create_usage` does check-then-insert with no DB uniqueness backstop. Concurrent
-same-month requests both insert → `scalar_one_or_none()` raises MultipleResultsFound (500),
-counts split across rows. Increments are also non-atomic (lost updates).
+Permanent distribution errors return `{status: failed}` (Celery treats as SUCCESS) →
+`on_distribution_complete` only logs and returns → chain reaches `on_workflow_complete` →
+episode marked `complete`. The failure never reaches the DB; episodes look fully published when they aren't.
 
-## Plan (TDD)
+## Design (settled by CodeRabbit plan — no fork)
+Keep distribution tasks returning `{status: failed}` (preserve independent per-platform distribution).
+Record each platform outcome; let the final callback derive a distinguishable terminal status.
 
-### 1. Model — `src/models/billing_usage.py`
-- Add `__table_args__ = (UniqueConstraint("user_id", "period_start", name="uq_billing_usage_user_period"),)`
-- Keep existing `index=True` on `user_id`.
+## Steps (TDD: tests first)
+1. **callbacks.py `on_distribution_complete`** — failure branch now persists, via the same locked
+   read-modify-write as success: write `generation_progress["distribution"][platform] =
+   {status:"failed", error: result.get("error"), failed_at: _utcnow_iso()}`. Do NOT touch
+   `generation_status` on failure. Keep the error log.
+2. **callbacks.py `on_workflow_complete`** — inline locked RMW: read `distribution`; if any platform
+   entry `status != "complete"` set `generation_status="distribution_failed"` and record
+   `failed_platforms` in progress; else keep `complete`.
+3. **models/episode.py** — add `distribution_failed` to the `generation_status` values comment.
+4. **routers/generation.py** — add `distribution_failed` to `_RESTARTABLE_STATUSES`; add it to the
+   SSE terminal-break set at ~line 407 (status-consuming surface).
+5. **schemas/episode.py** — `generation_status: str` (free-form) — no change.
 
-### 2. Migration — `alembic/versions/013_add_billing_usage_unique_constraint.py`
-- `revision = "013"`, `down_revision = "012"` (bare numbers, matching repo convention).
-- `upgrade()`: dedup existing rows per `(user_id, period_start)` (aggregate metric cols into one
-  surviving row, delete rest) via `op.execute`, then
-  `op.create_unique_constraint("uq_billing_usage_user_period", "billing_usage", ["user_id", "period_start"])`.
-- `downgrade()`: drop the constraint.
+## Tests (apps/api/tests/unit/test_celery_callbacks.py)
+- Replace `test_skips_update_on_failure_result` → `test_persists_failure_on_failure_result`
+  (failure is now written, not dropped; `generation_status` unchanged).
+- `on_workflow_complete`: sets `distribution_failed` when a platform failed.
+- `on_workflow_complete`: stays `complete` when all platforms succeeded.
+- (existing `test_marks_episode_complete` with no distribution key still passes.)
 
-### 3. Service — `src/services/usage_service.py`
-- `_get_or_create_usage`: use `insert(BillingUsage).values(...).on_conflict_do_nothing(index_elements=["user_id","period_start"])`
-  (postgresql dialect), then re-select and return the guaranteed row.
-- `track_episode_creation` / `track_api_call`: after ensuring row exists, atomic
-  `update(BillingUsage).where(...).values(col=BillingUsage.col + 1, updated_at=...)`. Drop Python-side `+=`.
-
-### 4. Test — `tests/test_usage_concurrency.py`
-- Independent sessions/engine per coroutine (test_db rolls back, can't model parallel commits).
-- `asyncio.gather` N concurrent `track_episode_creation` for same `(user_id, period_start)`.
-- Assert: exactly one row, counter == N, no MultipleResultsFound. Clean up committed rows.
-
-## Notes
-- Test DB is real PostgreSQL (asyncpg) → `on_conflict_do_nothing` works.
-- billing_usage has no RLS policy → concurrency test needs no tenant context.
+## Acceptance criteria
+- [x] Non-success writes failure into `generation_progress['distribution'][platform]` and persists.
+- [x] Distinguishable terminal state `distribution_failed` introduced.


### PR DESCRIPTION
Closes #300

## Problem
Permanent distribution errors return `{status: failed}`, which Celery treats as task SUCCESS. `on_distribution_complete` fired but only logged and returned — discarding the failure. The chain then reached `on_workflow_complete` and set `generation_status='complete'`, so an episode whose distribution silently failed looked fully published.

## Change
- **`on_distribution_complete`** — the non-success branch now records the per-platform failure (`status="failed"`, `error`, `failed_at`) using the same row-locked read-modify-write as the success branch (issue #276 pattern). It does **not** flip the episode-level `generation_status` (per-platform callbacks can overlap).
- **`on_workflow_complete`** — does an inline locked read of `generation_progress["distribution"]` and derives the terminal status: `distribution_failed` (recording `failed_platforms`) when any platform outcome is non-success, otherwise `complete`.
- **Lifecycle registration** — `distribution_failed` added to the `generation_status` values comment (`models/episode.py`), to `_RESTARTABLE_STATUSES` (`routers/generation.py`) so a partially-failed episode can be retried, and to the SSE terminal-break set so the progress stream closes instead of hanging.

### Design note
Distribution tasks deliberately keep returning `{status: failed}` rather than raising. Raising would trigger `link_error` and, because distribution is a chained sequence, abort all remaining platforms and mark the whole workflow `failed` — losing independent per-platform distribution. Recording outcomes + deriving the final status preserves that independence while making the failure visible. (This matches the design choice settled in the issue's CodeRabbit plan.)

## Acceptance criteria
- [x] On non-success, failure is written into `generation_progress['distribution'][platform]` and persisted.
- [x] Distinguishable terminal state `distribution_failed` introduced.

## Tests
`apps/api/tests/unit/test_celery_callbacks.py`:
- `test_persists_failure_on_failure_result` — failure is now persisted (not dropped); episode-level status untouched.
- `test_marks_distribution_failed_when_a_platform_failed` — final status becomes `distribution_failed` with `failed_platforms` recorded.
- `test_stays_complete_when_all_distributions_succeeded` — all-success still terminal `complete`.

Outcome evidence (Celery-internal change, no UI surface): 34 passed across `test_celery_callbacks.py` + `test_regenerate_endpoint.py`; ruff clean.

## Known limitations
- No DB migration needed (`generation_status` is a free-form text column; `EpisodeResponse.generation_status` is `str`).
- Frontend does not yet render `distribution_failed` distinctly — it is exposed via the API/SSE and treated as a terminal, restartable state; surfacing it in the UI is out of scope (relates to P4.4).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Episodes that fail distribution on one or more platforms are now marked with a clear terminal status instead of appearing fully completed.
  * Failed platform deliveries are tracked so the episode’s progress reflects which destinations failed.
  * Regenerating an episode now works for items that ended in distribution failure.
  * Live progress updates now stop when distribution failure is reached, matching other terminal states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->