### PR TITLE
fix(db): make RLS-affected migration backfills (006/012) fail loud, not silent (#301)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ POSTGRES_USER=podcastfy
 POSTGRES_PASSWORD=podcastfy_password
 POSTGRES_DB=podcastfy
 DATABASE_URL=postgresql+asyncpg://podcastfy:podcastfy_password@localhost:5432/podcastfy
+# Privileged URL used ONLY by Alembic migrations (issue #301): must be a superuser
+# or BYPASSRLS owner role so RLS-affected backfills apply to all rows. Falls back
+# to DATABASE_URL when unset.
+MIGRATION_DATABASE_URL=postgresql+asyncpg://podcastfy:podcastfy_password@localhost:5432/podcastfy
 
 # Redis Configuration (for Celery)
 REDIS_URL=redis://localhost:6379/0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,11 +191,21 @@ jobs:
         run: |
           export ENCRYPTION_KEY="$(printf 'x%.0s' {1..32})"
           export JWT_SECRET_KEY=ci
-          if uv run alembic upgrade head; then
+          set +e
+          out="$(uv run alembic upgrade head 2>&1)"
+          rc=$?
+          set -e
+          echo "$out"
+          if [ "$rc" -eq 0 ]; then
             echo "::error::Migrations succeeded under a non-BYPASSRLS role — the row_security guard is not working (issue #301)."
             exit 1
           fi
-          echo "Confirmed: migrations failed loudly under the non-privileged role (expected)."
+          # The failure must be the RLS guard, not an unrelated error.
+          if ! echo "$out" | grep -qi "row.level security\|row_security"; then
+            echo "::error::Migrations failed under the non-privileged role, but not via the row_security guard (issue #301)."
+            exit 1
+          fi
+          echo "Confirmed: migrations failed loudly via the row-level-security guard (expected)."
 
   test-frontend:
     name: Frontend Tests (Next.js/Jest)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,12 @@ jobs:
   # non-CREATEROLE server role, leaving the schema 9 versions behind.) This job
   # mirrors the server's least-privilege model so that class of failure fails
   # the PR instead.
+  #
+  # It also locks in issue #301's two-role model: migrations run via a dedicated
+  # MIGRATION_DATABASE_URL pointing at a privileged (BYPASSRLS) owner role, so
+  # RLS-affected backfills (006/012) apply to all rows. The negative step proves
+  # the fail-loud guard: running migrations under a non-BYPASSRLS owner must
+  # error at the guarded backfill instead of silently no-oping.
   migrate-as-non-superuser:
     name: Migrations run under dev privilege model
     runs-on: ubuntu-latest
@@ -143,25 +149,31 @@ jobs:
         working-directory: apps/api
         run: uv sync
 
-      - name: Provision dev-parity roles and database
+      - name: Provision dev-parity roles and databases
         env:
           PGPASSWORD: postgres
         run: |
-          # Mirror the dev server: a non-superuser, non-CREATEROLE role owns the
-          # database and runs migrations; the podcastfy_app role is provisioned
-          # out-of-band (as a DBA would). Migrations must NOT require any privilege
-          # beyond what this owner role has. Throwaway CI credentials reuse the
-          # ubiquitous postgres/postgres service password (no real secret here).
+          # Mirror the dev server's least-privilege model. The migration owner is
+          # NOSUPERUSER/NOCREATEDB/NOCREATEROLE (migrations must not need those),
+          # but carries BYPASSRLS so the documented two-role model (issue #301)
+          # lets RLS-affected backfills apply to all rows. podcastfy_app is
+          # provisioned out-of-band (as a DBA would). A second database owned by a
+          # role WITHOUT BYPASSRLS exercises the fail-loud guard. Throwaway CI
+          # credentials reuse the postgres/postgres service password (no secret).
           psql -h localhost -U postgres -v ON_ERROR_STOP=1 <<'SQL'
-          CREATE ROLE podcastfy_user LOGIN PASSWORD 'postgres' NOSUPERUSER NOCREATEDB NOCREATEROLE;
+          CREATE ROLE podcastfy_user LOGIN PASSWORD 'postgres' NOSUPERUSER NOCREATEDB NOCREATEROLE BYPASSRLS;
           CREATE DATABASE podcastfy OWNER podcastfy_user;
           CREATE ROLE podcastfy_app LOGIN PASSWORD 'postgres' NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT;
+          CREATE ROLE podcastfy_norls LOGIN PASSWORD 'postgres' NOSUPERUSER NOCREATEDB NOCREATEROLE;
+          CREATE DATABASE podcastfy_norls OWNER podcastfy_norls;
           SQL
 
-      - name: Run migrations as the non-superuser owner
+      - name: Run migrations via the privileged MIGRATION_DATABASE_URL (must succeed)
         working-directory: apps/api
         env:
-          DATABASE_URL: postgresql+asyncpg://podcastfy_user:postgres@localhost:5432/podcastfy
+          # App connects as the non-privileged role; Alembic uses the privileged one.
+          DATABASE_URL: postgresql+asyncpg://podcastfy_app:postgres@localhost:5432/podcastfy
+          MIGRATION_DATABASE_URL: postgresql+asyncpg://podcastfy_user:postgres@localhost:5432/podcastfy
         run: |
           # config.py requires these at import; generate ephemeral values at
           # runtime so no secret-looking literal sits in the workflow file.
@@ -169,6 +181,21 @@ jobs:
           export ENCRYPTION_KEY="$(printf 'x%.0s' {1..32})"
           export JWT_SECRET_KEY=ci
           uv run alembic upgrade head
+
+      - name: Migrations under a non-BYPASSRLS role must fail loudly (issue #301)
+        working-directory: apps/api
+        env:
+          # Owner role WITHOUT BYPASSRLS — backfills are RLS-subject and must error.
+          MIGRATION_DATABASE_URL: postgresql+asyncpg://podcastfy_norls:postgres@localhost:5432/podcastfy_norls
+          DATABASE_URL: postgresql+asyncpg://podcastfy_norls:postgres@localhost:5432/podcastfy_norls
+        run: |
+          export ENCRYPTION_KEY="$(printf 'x%.0s' {1..32})"
+          export JWT_SECRET_KEY=ci
+          if uv run alembic upgrade head; then
+            echo "::error::Migrations succeeded under a non-BYPASSRLS role — the row_security guard is not working (issue #301)."
+            exit 1
+          fi
+          echo "Confirmed: migrations failed loudly under the non-privileged role (expected)."
 
   test-frontend:
     name: Frontend Tests (Next.js/Jest)

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -2,11 +2,18 @@
 # Copy this file to .env and fill in your actual values
 
 # Database Configuration
-# NOTE: Use the podcastfy (superuser) role only for running Alembic migrations.
-# The application and tests must connect as podcastfy_app (non-superuser) so that
+# The application and tests connect as podcastfy_app (non-superuser) so that
 # PostgreSQL enforces FORCE ROW LEVEL SECURITY on all tenant-scoped tables.
 # The podcastfy_app role is created by migration 003_force_rls.py.
 DATABASE_URL=postgresql+asyncpg://podcastfy_app:podcastfy_app_password@localhost:5432/podcastfy
+
+# Privileged URL used ONLY by Alembic migrations (issue #301). It must point at a
+# superuser or BYPASSRLS owner role so RLS-affected backfills (006/012) apply to
+# ALL rows. When unset, Alembic falls back to DATABASE_URL — but running migrations
+# under a role subject to RLS now fails loudly (the backfills SET LOCAL
+# row_security = off) instead of silently corrupting data. Set this in any
+# environment where DATABASE_URL is the non-privileged podcastfy_app role.
+MIGRATION_DATABASE_URL=postgresql+asyncpg://podcastfy:podcastfy_password@localhost:5432/podcastfy
 
 # API Server Binding (issue #209)
 # Bind loopback only — nginx reverse-proxies to 127.0.0.1 in prod. Never 0.0.0.0.

--- a/apps/api/alembic/env.py
+++ b/apps/api/alembic/env.py
@@ -27,8 +27,10 @@ config = context.config
 # Override sqlalchemy.url from environment variable
 from src.config import settings
 
-# Convert async database URL to sync for Alembic migrations
-database_url = settings.DATABASE_URL
+# Convert async database URL to sync for Alembic migrations.
+# Prefer the dedicated privileged migration URL when set so RLS-affected backfills
+# apply to all rows; fall back to DATABASE_URL otherwise (issue #301).
+database_url = settings.MIGRATION_DATABASE_URL or settings.DATABASE_URL
 if database_url.startswith("postgresql+asyncpg://"):
     # Replace asyncpg with psycopg for synchronous migrations
     database_url = database_url.replace("postgresql+asyncpg://", "postgresql+psycopg://")

--- a/apps/api/alembic/versions/006_make_episode_number_not_null.py
+++ b/apps/api/alembic/versions/006_make_episode_number_not_null.py
@@ -25,6 +25,14 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
 	connection = op.get_bind()
 
+	# Step 0: Fail loudly if this migration is run under a role subject to RLS
+	# (issue #301). 003 applies FORCE ROW LEVEL SECURITY to episodes; under an
+	# RLS-subject role the backfill below silently matches zero rows, then the
+	# NOT NULL / unique constraints build over un-backfilled data. With
+	# row_security=off, a no-bypass role errors here instead of corrupting data;
+	# for a superuser/BYPASSRLS migration role this is a harmless no-op.
+	connection.execute(text("SET LOCAL row_security = off"))
+
 	# Step 1: Backfill NULL episode_numbers.
 	# For each project, assign sequential numbers starting from
 	# MAX(existing episode_number) + 1 for NULL rows, ordered by created_at.

--- a/apps/api/alembic/versions/012_canonicalize_user_emails.py
+++ b/apps/api/alembic/versions/012_canonicalize_user_emails.py
@@ -25,6 +25,15 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
 	bind = op.get_bind()
 
+	# Fail loudly if run under a role subject to RLS (issue #301). 003 applies
+	# FORCE ROW LEVEL SECURITY to users; under an RLS-subject role the collision
+	# SELECT can be silently filtered and the lowercase UPDATE no-ops, then the
+	# unique lower(email) index builds over still-mixed-case data. With
+	# row_security=off, a no-bypass role errors instead of corrupting data; for a
+	# superuser/BYPASSRLS migration role this is a harmless no-op. SET LOCAL is
+	# transaction-scoped, so this one statement covers both the SELECT and UPDATE.
+	bind.execute(sa.text("SET LOCAL row_security = off"))
+
 	# Abort loudly on case-variant collisions — merging accounts is not safe to
 	# automate (it would orphan owned resources / drop credentials). Operator
 	# must dedupe manually before this migration can proceed.

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -24,6 +24,10 @@ class Settings(BaseSettings):
 
     # Database
     DATABASE_URL: str
+    # Privileged (superuser/BYPASSRLS owner) URL used ONLY by Alembic so RLS-affected
+    # backfills apply to all rows. Falls back to DATABASE_URL when unset (issue #301).
+    # Same optional-override convention as CELERY_BROKER_URL.
+    MIGRATION_DATABASE_URL: Optional[str] = None
     DATABASE_POOL_SIZE: int = 10
     DATABASE_MAX_OVERFLOW: int = 20
 

--- a/apps/api/tests/unit/test_migration_006_episode_number_not_null.py
+++ b/apps/api/tests/unit/test_migration_006_episode_number_not_null.py
@@ -155,6 +155,26 @@ def test_upgrade_executes_backfill_sql():
 	assert mock_conn.execute.called
 
 
+def test_upgrade_disables_row_security_before_backfill():
+	"""upgrade() must `SET LOCAL row_security = off` before the backfill (issue #301).
+
+	This makes a non-BYPASSRLS migration run fail loudly instead of silently
+	no-oping the backfill and then building constraints over un-backfilled data.
+	"""
+	mod = _load_migration()
+	mock_conn = MagicMock()
+	with patch('alembic.op.get_bind', return_value=mock_conn), \
+	     patch('alembic.op.alter_column'), \
+	     patch('alembic.op.create_unique_constraint'), \
+	     patch('alembic.op.create_index'):
+		mod.upgrade()
+	executed = [str(c.args[0]) for c in mock_conn.execute.call_args_list]
+	assert executed, "upgrade() executed no SQL"
+	assert executed[0].strip().lower() == "set local row_security = off"
+	# The backfill (an UPDATE) must come after the guard.
+	assert any("update episodes" in sql.lower() for sql in executed[1:])
+
+
 # ============================================================================
 # DOWNGRADE TESTS
 # ============================================================================

--- a/apps/api/tests/unit/test_migration_012_canonicalize_user_emails.py
+++ b/apps/api/tests/unit/test_migration_012_canonicalize_user_emails.py
@@ -64,18 +64,40 @@ def test_migration_depends_on_none():
 # ============================================================================
 
 def test_upgrade_disables_row_security_first():
-	"""upgrade() must `SET LOCAL row_security = off` before any table access (issue #301)."""
+	"""upgrade() must `SET LOCAL row_security = off` before any table access (issue #301).
+
+	Records SQL across BOTH execution paths (bind.execute for the collision SELECT,
+	op.execute for the lowercase UPDATE) so the test proves the guard precedes the
+	UPDATE — not merely that it precedes other bind.execute calls.
+	"""
 	mod = _load_migration()
-	bind = _bind_with_collisions([])
+	calls = []
+
+	def rec_bind(stmt, *args, **kwargs):
+		calls.append(str(stmt))
+		result = MagicMock()
+		result.fetchall.return_value = []  # no collisions
+		return result
+
+	def rec_op(stmt, *args, **kwargs):
+		calls.append(str(stmt))
+
+	bind = MagicMock()
+	bind.execute.side_effect = rec_bind
 	with patch('alembic.op.get_bind', return_value=bind), \
-	     patch('alembic.op.execute'), \
+	     patch('alembic.op.execute', side_effect=rec_op), \
 	     patch('alembic.op.create_index'):
 		mod.upgrade()
-	executed = [str(c.args[0]) for c in bind.execute.call_args_list]
-	assert executed, "upgrade() executed no SQL via the bind"
-	assert executed[0].strip().lower() == "set local row_security = off"
-	# The collision SELECT must come after the guard.
-	assert any("from users" in sql.lower() for sql in executed[1:])
+
+	assert calls, "upgrade() executed no SQL"
+	assert calls[0].strip().lower() == "set local row_security = off"
+	lowered = [c.lower() for c in calls]
+	guard_idx = next(i for i, c in enumerate(lowered) if "row_security" in c)
+	update_idx = next(
+		i for i, c in enumerate(lowered)
+		if "update users set email = lower(email)" in c
+	)
+	assert guard_idx < update_idx, "row_security guard must precede the email UPDATE"
 
 
 def test_upgrade_lowercases_and_creates_unique_index_when_clean():

--- a/apps/api/tests/unit/test_migration_012_canonicalize_user_emails.py
+++ b/apps/api/tests/unit/test_migration_012_canonicalize_user_emails.py
@@ -1,0 +1,119 @@
+"""
+Unit tests for migration 012_canonicalize_user_emails.
+
+Tests cover:
+- Migration metadata (revision ID, down_revision chaining)
+- upgrade() disables row_security before touching users (issue #301)
+- upgrade() aborts loudly on case-variant collisions (preserved behavior)
+- upgrade() lowercases emails and creates the unique lower(email) index
+- downgrade() drops the index
+"""
+
+import importlib.util
+import os
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+def _load_migration():
+	migration_path = os.path.join(
+		os.path.dirname(__file__),
+		'..', '..', 'alembic', 'versions',
+		'012_canonicalize_user_emails.py',
+	)
+	migration_path = os.path.normpath(migration_path)
+	spec = importlib.util.spec_from_file_location(
+		'migration_012', migration_path
+	)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+def _bind_with_collisions(rows):
+	"""Mock bind whose collision SELECT returns ``rows`` from .fetchall()."""
+	bind = MagicMock()
+	bind.execute.return_value.fetchall.return_value = rows
+	return bind
+
+
+# ============================================================================
+# METADATA TESTS
+# ============================================================================
+
+def test_migration_revision_id():
+	assert _load_migration().revision == '012'
+
+
+def test_migration_down_revision():
+	assert _load_migration().down_revision == '011'
+
+
+def test_migration_branch_labels_none():
+	assert _load_migration().branch_labels is None
+
+
+def test_migration_depends_on_none():
+	assert _load_migration().depends_on is None
+
+
+# ============================================================================
+# UPGRADE TESTS
+# ============================================================================
+
+def test_upgrade_disables_row_security_first():
+	"""upgrade() must `SET LOCAL row_security = off` before any table access (issue #301)."""
+	mod = _load_migration()
+	bind = _bind_with_collisions([])
+	with patch('alembic.op.get_bind', return_value=bind), \
+	     patch('alembic.op.execute'), \
+	     patch('alembic.op.create_index'):
+		mod.upgrade()
+	executed = [str(c.args[0]) for c in bind.execute.call_args_list]
+	assert executed, "upgrade() executed no SQL via the bind"
+	assert executed[0].strip().lower() == "set local row_security = off"
+	# The collision SELECT must come after the guard.
+	assert any("from users" in sql.lower() for sql in executed[1:])
+
+
+def test_upgrade_lowercases_and_creates_unique_index_when_clean():
+	"""With no collisions, upgrade() lowercases emails and builds the unique index."""
+	mod = _load_migration()
+	bind = _bind_with_collisions([])
+	with patch('alembic.op.get_bind', return_value=bind), \
+	     patch('alembic.op.execute') as mock_exec, \
+	     patch('alembic.op.create_index') as mock_idx:
+		mod.upgrade()
+	# op.execute carries the lowercase UPDATE.
+	update_sql = " ".join(str(c.args[0]).lower() for c in mock_exec.call_args_list)
+	assert "update users set email = lower(email)" in update_sql
+	index_names = [c.args[0] for c in mock_idx.call_args_list]
+	assert 'uq_users_email_lower' in index_names
+
+
+def test_upgrade_aborts_on_case_variant_collision():
+	"""upgrade() must raise RuntimeError when case-variant duplicates exist."""
+	mod = _load_migration()
+	bind = _bind_with_collisions([SimpleNamespace(canonical="a@x.com", n=2)])
+	with patch('alembic.op.get_bind', return_value=bind), \
+	     patch('alembic.op.execute') as mock_exec, \
+	     patch('alembic.op.create_index') as mock_idx:
+		with pytest.raises(RuntimeError, match="case-variant duplicate"):
+			mod.upgrade()
+	# Must abort before mutating data or creating the index.
+	assert not mock_exec.called
+	assert not mock_idx.called
+
+
+# ============================================================================
+# DOWNGRADE TESTS
+# ============================================================================
+
+def test_downgrade_drops_index():
+	mod = _load_migration()
+	with patch('alembic.op.drop_index') as mock_drop_idx:
+		mod.downgrade()
+	index_names = [c.args[0] for c in mock_drop_idx.call_args_list]
+	assert 'uq_users_email_lower' in index_names

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -259,11 +259,12 @@ Configure in **Settings** → **Environments** → **development**:
 
 **API (`/opt/podcaststudiohub/api/.env`):**
 ```bash
-# App role: non-privileged podcastfy_app (FORCE RLS enforced).
-DATABASE_URL=postgresql://podcastfy_app:pass@localhost/podcastfy
+# App role: non-privileged podcastfy_app (FORCE RLS enforced). The app requires
+# the asyncpg driver prefix (see apps/api/src/database.py).
+DATABASE_URL=postgresql+asyncpg://podcastfy_app:pass@localhost/podcastfy
 # Alembic-only privileged role (superuser/BYPASSRLS owner) — required so RLS-affected
 # backfills apply to all rows (issue #301). Falls back to DATABASE_URL when unset.
-MIGRATION_DATABASE_URL=postgresql://podcastfy:pass@localhost/podcastfy
+MIGRATION_DATABASE_URL=postgresql+asyncpg://podcastfy:pass@localhost/podcastfy
 REDIS_URL=redis://localhost:6379/0
 JWT_SECRET_KEY=<generate-with-openssl-rand-hex-32>
 JWT_ALGORITHM=HS256

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -93,6 +93,11 @@ rsync -avz --exclude='__pycache__' --exclude='*.pyc' \
 ssh root@<SERVER_IP> << 'EOF'
 cd /opt/podcaststudiohub/api
 uv sync
+# Migrations MUST run under the privileged role (issue #301): MIGRATION_DATABASE_URL
+# (set in .env) points Alembic at the superuser/BYPASSRLS owner so RLS-affected
+# backfills apply to all rows. The app keeps connecting as the non-privileged
+# podcastfy_app via DATABASE_URL. Without it, migrations fail loudly rather than
+# silently no-op the backfills.
 uv run alembic upgrade head
 
 # Clear Python cache
@@ -254,7 +259,11 @@ Configure in **Settings** → **Environments** → **development**:
 
 **API (`/opt/podcaststudiohub/api/.env`):**
 ```bash
-DATABASE_URL=postgresql://user:pass@localhost/podcastfy
+# App role: non-privileged podcastfy_app (FORCE RLS enforced).
+DATABASE_URL=postgresql://podcastfy_app:pass@localhost/podcastfy
+# Alembic-only privileged role (superuser/BYPASSRLS owner) — required so RLS-affected
+# backfills apply to all rows (issue #301). Falls back to DATABASE_URL when unset.
+MIGRATION_DATABASE_URL=postgresql://podcastfy:pass@localhost/podcastfy
 REDIS_URL=redis://localhost:6379/0
 JWT_SECRET_KEY=<generate-with-openssl-rand-hex-32>
 JWT_ALGORITHM=HS256

--- a/docs/env_inventory.md
+++ b/docs/env_inventory.md
@@ -19,6 +19,7 @@
 | POSTGRES_PASSWORD | ✅ | ❌ | Missing | Critical |
 | POSTGRES_DB | ✅ | ❌ | Missing | Critical |
 | DATABASE_URL | ✅ | ✅ | **Present** | Critical |
+| MIGRATION_DATABASE_URL | ✅ | ⚠️ optional | Alembic-only privileged URL; falls back to DATABASE_URL (issue #301) | High |
 
 ### Redis Configuration (Critical)
 | Variable | Expected | Present | Status | Priority |

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,36 +1,29 @@
-# Issue #300 — P2.2 `on_distribution_complete` silently drops failed distributions
+# Issue #301 [P2.3] — Migration backfills (006/012) silently no-op under FORCE RLS
 
-**Branch:** `fix/300-persist-distribution-failures`
+**Branch:** `fix/301-migration-rls-backfill`
+**Strategy (issue-chosen option 3):** dedicated privileged migration URL + fail-loud guard + tests.
 
-## Problem
-Permanent distribution errors return `{status: failed}` (Celery treats as SUCCESS) →
-`on_distribution_complete` only logs and returns → chain reaches `on_workflow_complete` →
-episode marked `complete`. The failure never reaches the DB; episodes look fully published when they aren't.
+## Root cause
+003 applies FORCE ROW LEVEL SECURITY to tenant tables keyed on the unset `app.tenant_id`
+GUC. When 006/012 backfills run under a role subject to RLS (the documented `podcastfy_app`,
+or a plain owner under FORCE), UPDATEs match zero rows and silently no-op — then NOT NULL /
+unique-index constraints build over un-backfilled data. Outcome depends entirely on which
+role runs migrations.
 
-## Design (settled by CodeRabbit plan — no fork)
-Keep distribution tasks returning `{status: failed}` (preserve independent per-platform distribution).
-Record each platform outcome; let the final callback derive a distinguishable terminal status.
+## Tasks
+1. **config**: add `MIGRATION_DATABASE_URL: Optional[str] = None` to `Settings` (apps/api/src/config.py).
+2. **alembic env**: source URL from `MIGRATION_DATABASE_URL or DATABASE_URL` (apps/api/alembic/env.py).
+3. **harden 006**: `SET LOCAL row_security = off` before the backfill (006_make_episode_number_not_null.py).
+4. **harden 012**: `SET LOCAL row_security = off` before collision SELECT + UPDATE (012_canonicalize_user_emails.py).
+5. **unit tests (RED→GREEN)**: extend test_migration_006 to assert SET LOCAL emitted before backfill;
+   add test_migration_012 asserting same + preserved collision/RuntimeError + index order.
+6. **CI**: reframe `migrate-as-non-superuser` job to the two-role model:
+   - positive: migration role NOSUPERUSER NOCREATEDB NOCREATEROLE **BYPASSRLS** + `MIGRATION_DATABASE_URL` → `alembic upgrade head` succeeds.
+   - negative: a non-BYPASSRLS owner role on a fresh DB → `alembic upgrade head` must FAIL at 006/012
+     (satisfies "test running migrations as the non-privileged role").
+7. **docs**: MIGRATION_DATABASE_URL in apps/api/.env.example, root .env.example, docs/env_inventory.md, deployment/README.md.
 
-## Steps (TDD: tests first)
-1. **callbacks.py `on_distribution_complete`** — failure branch now persists, via the same locked
-   read-modify-write as success: write `generation_progress["distribution"][platform] =
-   {status:"failed", error: result.get("error"), failed_at: _utcnow_iso()}`. Do NOT touch
-   `generation_status` on failure. Keep the error log.
-2. **callbacks.py `on_workflow_complete`** — inline locked RMW: read `distribution`; if any platform
-   entry `status != "complete"` set `generation_status="distribution_failed"` and record
-   `failed_platforms` in progress; else keep `complete`.
-3. **models/episode.py** — add `distribution_failed` to the `generation_status` values comment.
-4. **routers/generation.py** — add `distribution_failed` to `_RESTARTABLE_STATUSES`; add it to the
-   SSE terminal-break set at ~line 407 (status-consuming surface).
-5. **schemas/episode.py** — `generation_status: str` (free-form) — no change.
-
-## Tests (apps/api/tests/unit/test_celery_callbacks.py)
-- Replace `test_skips_update_on_failure_result` → `test_persists_failure_on_failure_result`
-  (failure is now written, not dropped; `generation_status` unchanged).
-- `on_workflow_complete`: sets `distribution_failed` when a platform failed.
-- `on_workflow_complete`: stays `complete` when all platforms succeeded.
-- (existing `test_marks_episode_complete` with no distribution key still passes.)
-
-## Acceptance criteria
-- [x] Non-success writes failure into `generation_progress['distribution'][platform]` and persists.
-- [x] Distinguishable terminal state `distribution_failed` introduced.
+## Acceptance criteria (from issue)
+- [ ] Dedicated MIGRATION_DATABASE_URL documented + wired.
+- [ ] Backfills fail loudly (not silently) under an RLS-subject role.
+- [ ] Test runs migrations as the non-privileged role and proves fail-loud.


### PR DESCRIPTION
## Summary
Fixes #301. Migrations 006/012 backfill data on tables that migration 003 places under
**FORCE ROW LEVEL SECURITY** (keyed on the unset `app.tenant_id` GUC). Run under any role
subject to RLS — the documented non-superuser `podcastfy_app`, or a plain owner under FORCE —
the backfill UPDATEs matched **zero rows and silently no-op'd**, after which the `NOT NULL` /
unique `lower(email)` constraints built over un-backfilled data. The outcome depended entirely
on which role happened to run migrations.

## Approach (issue's chosen option 3 — both)
- **`MIGRATION_DATABASE_URL`** (`apps/api/src/config.py`, `alembic/env.py`): optional, Alembic-only
  privileged (superuser/BYPASSRLS owner) URL so RLS-affected backfills apply to all rows. Falls
  back to `DATABASE_URL`. The app keeps connecting as the non-privileged `podcastfy_app`.
- **Fail-loud guard**: `SET LOCAL row_security = off` before the backfills in 006 and 012. For a
  BYPASSRLS/superuser role this is a harmless no-op; for any RLS-subject role the next query
  errors (`query would be affected by row-level security policy`) instead of silently corrupting
  data.
- **CI** (`migrate-as-non-superuser` job): reframed to the two-role model.
  - *Positive*: migrations run via a BYPASSRLS migration role + `MIGRATION_DATABASE_URL` → must succeed.
  - *Negative*: migrations under a non-BYPASSRLS owner → must **fail loudly** (satisfies the
    "test running migrations as the non-privileged role" acceptance criterion).
- **Docs**: `MIGRATION_DATABASE_URL` added to `apps/api/.env.example`, root `.env.example`,
  `docs/env_inventory.md`, and `deployment/README.md`.

## Acceptance criteria
- [x] Dedicated `MIGRATION_DATABASE_URL` (superuser/BYPASSRLS) documented + wired into Alembic.
- [x] Backfills fail loudly under an RLS-subject role (`SET LOCAL row_security = off`).
- [x] A test runs migrations as the non-privileged role and proves fail-loud (CI negative step).

## Verification (PostgreSQL 16, real DB)
- **Positive**: `alembic upgrade head` via a `NOSUPERUSER NOCREATEDB NOCREATEROLE BYPASSRLS`
  migration role succeeded through 006 and 012.
- **Negative**: the same upgrade under a non-BYPASSRLS owner failed at 006 with
  `psycopg.errors.InsufficientPrivilege: query would be affected by row-level security policy for table "episodes"`.
- New unit tests assert both migrations emit `SET LOCAL row_security = off` **before** their
  backfill (`test_migration_006…`, new `test_migration_012…`), with 012's collision/`RuntimeError`
  and index-order behavior preserved.
- Full backend unit suite: **739 passed**.

## Known limitations
- The fail-loud guard depends on `SET LOCAL` being transaction-scoped (Alembic's default
  per-migration transaction) — it does not protect a hand-run statement outside a transaction.
- Pre-existing ruff debt in `alembic/env.py` (E402 / unused imports) is unchanged and out of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a separate privileged database connection for migrations, while the app can continue using the standard connection.
  * Updated migration handling so backfills are more reliable when row-level security is enabled.

* **Bug Fixes**
  * Improved safety for data migrations that update existing records and enforce uniqueness.
  * Added a fail-fast check so migrations don’t silently skip required backfill work.

* **Documentation**
  * Updated environment and deployment docs with the new database connection setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->