### PR TITLE
fix(deploy): sync apps/api/README.md so server uv sync doesn't fail on a fresh box

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -143,11 +143,15 @@ jobs:
             apps/api/src/ \
             $SSH_USER@$SSH_HOST:$SERVER_PATH/api/src/
 
-          # Sync API config files
+          # Sync API config files.
+          # README.md is required: pyproject sets readme = "README.md" and the
+          # hatchling build validates it exists, so `uv sync` on the server fails
+          # with OSError on a from-scratch box if it isn't synced.
           rsync -avz -e "ssh -i ~/.ssh/deploy_key" \
             apps/api/pyproject.toml \
             apps/api/uv.lock \
             apps/api/alembic.ini \
+            apps/api/README.md \
             $SSH_USER@$SSH_HOST:$SERVER_PATH/api/
 
           # Sync migrations


### PR DESCRIPTION
## What
Adds `apps/api/README.md` to the Deploy API config rsync in `deploy-dev.yml`.

## Why
`apps/api/pyproject.toml` sets `readme = "README.md"` and the hatchling build validates the file exists. The workflow's rsync synced `pyproject.toml`/`uv.lock`/`alembic.ini` but **not** README.md, so the server-side `uv sync` failed with `OSError: Readme file does not exist: README.md` on a from-scratch host.

Surfaced while rebuilding the staging box (195.35.14.177) from scratch on 2026-07-01 — the old box already had the file, hiding the gap. Existing boxes are unaffected (they already have it); this only matters for clean provisioning.

## Test
Manual `uv sync` on the rebuilt box succeeded once README.md was present; migrations ran clean to head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development deployment workflow to sync additional API files, including the API README, during server updates.
  * Added clearer handling notes for the API configuration sync step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->