### PR TITLE
fix(contract): align web↔API project/episode contract + fix GET /projects 500 (#337)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ usage/examples.ipynb
 demo.md
 demo_*.md
 demo_*_runner.py
+
+# Local assistant memory artifacts
+apps/*/.claude/

--- a/apps/api/src/schemas/episode.py
+++ b/apps/api/src/schemas/episode.py
@@ -37,19 +37,15 @@ class EpisodeCreate(BaseModel):
 	@field_validator('episode_metadata')
 	@classmethod
 	def validate_episode_metadata(cls, v: dict) -> dict:
-		"""Validate required keys in episode_metadata."""
-		required_keys = {'title', 'description'}
-		missing_keys = required_keys - set(v.keys())
+		"""Validate episode_metadata (issue #337).
 
-		if missing_keys:
-			raise ValueError(
-				f"episode_metadata missing required keys: {', '.join(missing_keys)}"
-			)
-
-		# Validate types of required fields
+		title is required; description is optional at create (the UI only collects
+		a title). An empty string is still rejected for either key when present."""
+		if 'title' not in v:
+			raise ValueError("episode_metadata missing required key: title")
 		if not isinstance(v['title'], str) or not v['title'].strip():
 			raise ValueError("episode_metadata.title must be a non-empty string")
-		if not isinstance(v['description'], str) or not v['description'].strip():
+		if 'description' in v and (not isinstance(v['description'], str) or not v['description'].strip()):
 			raise ValueError("episode_metadata.description must be a non-empty string")
 
 		return v
@@ -88,22 +84,17 @@ class EpisodeUpdate(BaseModel):
 	@field_validator('episode_metadata')
 	@classmethod
 	def validate_episode_metadata(cls, v: Optional[dict]) -> Optional[dict]:
-		"""Validate required keys in episode_metadata if provided."""
+		"""Validate episode_metadata if provided (issue #337).
+
+		Mirrors EpisodeCreate: title required (non-empty), description optional."""
 		if v is None:
 			return v
 
-		required_keys = {'title', 'description'}
-		missing_keys = required_keys - set(v.keys())
-
-		if missing_keys:
-			raise ValueError(
-				f"episode_metadata missing required keys: {', '.join(missing_keys)}"
-			)
-
-		# Validate types of required fields
+		if 'title' not in v:
+			raise ValueError("episode_metadata missing required key: title")
 		if not isinstance(v['title'], str) or not v['title'].strip():
 			raise ValueError("episode_metadata.title must be a non-empty string")
-		if not isinstance(v['description'], str) or not v['description'].strip():
+		if 'description' in v and (not isinstance(v['description'], str) or not v['description'].strip()):
 			raise ValueError("episode_metadata.description must be a non-empty string")
 
 		return v

--- a/apps/api/src/schemas/project.py
+++ b/apps/api/src/schemas/project.py
@@ -39,22 +39,17 @@ class ProjectCreate(BaseModel):
 	@field_validator('podcast_metadata')
 	@classmethod
 	def validate_podcast_metadata(cls, v: dict) -> dict:
-		"""Validate required keys in podcast_metadata."""
-		required_keys = {'show_title', 'author', 'description'}
-		missing_keys = required_keys - set(v.keys())
+		"""Validate podcast_metadata (issue #337).
 
-		if missing_keys:
-			raise ValueError(
-				f"podcast_metadata missing required keys: {', '.join(missing_keys)}"
-			)
-
-		# Validate types of required fields
-		if not isinstance(v['show_title'], str) or not v['show_title'].strip():
-			raise ValueError("podcast_metadata.show_title must be a non-empty string")
-		if not isinstance(v['author'], str) or not v['author'].strip():
-			raise ValueError("podcast_metadata.author must be a non-empty string")
-		if not isinstance(v['description'], str) or not v['description'].strip():
-			raise ValueError("podcast_metadata.description must be a non-empty string")
+		Create is lightweight: the UI only collects a title/description at this
+		stage, so show_title/author/description are NOT required here. show_title
+		is defaulted from the project name in the service layer, and completeness
+		(REQUIRED_METADATA_FIELDS) is enforced later at distribution time by
+		rss_generation_service. We still reject an empty string for any of these
+		keys when it *is* present, to catch obviously-bad input."""
+		for key in ('show_title', 'author', 'description'):
+			if key in v and (not isinstance(v[key], str) or not v[key].strip()):
+				raise ValueError(f"podcast_metadata.{key} must be a non-empty string")
 
 		return v
 
@@ -92,25 +87,16 @@ class ProjectUpdate(BaseModel):
 	@field_validator('podcast_metadata')
 	@classmethod
 	def validate_podcast_metadata(cls, v: Optional[dict]) -> Optional[dict]:
-		"""Validate required keys in podcast_metadata if provided."""
+		"""Validate podcast_metadata if provided (issue #337).
+
+		Mirrors ProjectCreate: keys are not required, but an empty string for a
+		known field is rejected. Completeness is enforced at distribution time."""
 		if v is None:
 			return v
 
-		required_keys = {'show_title', 'author', 'description'}
-		missing_keys = required_keys - set(v.keys())
-
-		if missing_keys:
-			raise ValueError(
-				f"podcast_metadata missing required keys: {', '.join(missing_keys)}"
-			)
-
-		# Validate types of required fields
-		if not isinstance(v['show_title'], str) or not v['show_title'].strip():
-			raise ValueError("podcast_metadata.show_title must be a non-empty string")
-		if not isinstance(v['author'], str) or not v['author'].strip():
-			raise ValueError("podcast_metadata.author must be a non-empty string")
-		if not isinstance(v['description'], str) or not v['description'].strip():
-			raise ValueError("podcast_metadata.description must be a non-empty string")
+		for key in ('show_title', 'author', 'description'):
+			if key in v and (not isinstance(v[key], str) or not v[key].strip()):
+				raise ValueError(f"podcast_metadata.{key} must be a non-empty string")
 
 		return v
 

--- a/apps/api/src/services/episode_service.py
+++ b/apps/api/src/services/episode_service.py
@@ -195,7 +195,7 @@ async def get_episodes(
 	# Get total count (before pagination)
 	count_query = select(func.count()).select_from(query.subquery())
 	total_result = await db.execute(count_query)
-	total = total_result.scalar()
+	total = total_result.scalar() or 0  # guard None -> total_pages TypeError (issue #337)
 
 	# Apply sort order
 	sort_column = {
@@ -265,6 +265,11 @@ async def update_episode(
 			# Never mass-assign system-managed fields, even if a future schema
 			# change re-adds one to EpisodeUpdate.
 			continue
+		if field == "episode_metadata" and value is not None:
+			# Shallow-merge into existing JSONB so a partial update (e.g. title
+			# only, from the edit dialog) doesn't drop other keys like
+			# description/format/explicit/tags (issue #337).
+			value = {**(episode.episode_metadata or {}), **value}
 		setattr(episode, field, value)
 
 	await db.commit()

--- a/apps/api/src/services/episode_service.py
+++ b/apps/api/src/services/episode_service.py
@@ -265,7 +265,9 @@ async def update_episode(
 			# Never mass-assign system-managed fields, even if a future schema
 			# change re-adds one to EpisodeUpdate.
 			continue
-		if field == "episode_metadata" and value is not None:
+		if field == "episode_metadata":
+			if value is None:
+				continue  # can't null a NOT NULL JSONB column; treat as no-op
 			# Shallow-merge into existing JSONB so a partial update (e.g. title
 			# only, from the edit dialog) doesn't drop other keys like
 			# description/format/explicit/tags (issue #337).

--- a/apps/api/src/services/project_service.py
+++ b/apps/api/src/services/project_service.py
@@ -153,7 +153,9 @@ async def update_project(
 	for field, value in update_dict.items():
 		if field not in PROJECT_USER_EDITABLE_FIELDS:
 			continue  # never mass-assign non-user-editable fields
-		if field == "podcast_metadata" and value is not None:
+		if field == "podcast_metadata":
+			if value is None:
+				continue  # can't null a NOT NULL JSONB column; treat as no-op
 			# Shallow-merge into existing JSONB so a partial update doesn't drop
 			# other podcast_metadata keys (issue #337).
 			value = {**(project.podcast_metadata or {}), **value}

--- a/apps/api/src/services/project_service.py
+++ b/apps/api/src/services/project_service.py
@@ -47,10 +47,16 @@ async def create_project(
 	Returns:
 		Created Project instance
 	"""
+	# Default show_title to the project name so RSS/distribution has a sensible
+	# value even though the create UI doesn't collect it (issue #337).
+	podcast_metadata = dict(project_data.podcast_metadata or {})
+	if not podcast_metadata.get("show_title"):
+		podcast_metadata["show_title"] = project_data.name
+
 	project = Project(
 		name=project_data.name,
 		description=project_data.description,
-		podcast_metadata=project_data.podcast_metadata,
+		podcast_metadata=podcast_metadata,
 		user_id=user_id,
 		tenant_id=tenant_id,
 		is_archived=False
@@ -89,7 +95,9 @@ async def get_projects(
 	# Get total count (before pagination)
 	count_query = select(func.count()).select_from(query.subquery())
 	total_result = await db.execute(count_query)
-	total = total_result.scalar()
+	# COUNT never returns NULL, but guard anyway: a None here would make the
+	# router's total_pages arithmetic raise a TypeError -> HTTP 500 (issue #337).
+	total = total_result.scalar() or 0
 
 	# Get paginated results, ordered by most recent first
 	query = query.offset(skip).limit(limit).order_by(Project.created_at.desc())
@@ -145,6 +153,10 @@ async def update_project(
 	for field, value in update_dict.items():
 		if field not in PROJECT_USER_EDITABLE_FIELDS:
 			continue  # never mass-assign non-user-editable fields
+		if field == "podcast_metadata" and value is not None:
+			# Shallow-merge into existing JSONB so a partial update doesn't drop
+			# other podcast_metadata keys (issue #337).
+			value = {**(project.podcast_metadata or {}), **value}
 		setattr(project, field, value)
 
 	await db.commit()

--- a/apps/api/tests/test_episodes.py
+++ b/apps/api/tests/test_episodes.py
@@ -270,6 +270,29 @@ async def test_update_episode_title_only_preserves_other_metadata(client, projec
 
 
 @pytest.mark.asyncio
+async def test_update_episode_explicit_null_metadata_is_noop(client, project_and_auth):
+	"""An explicit episode_metadata: null must not crash (NOT NULL column) — treat
+	as no-op and still apply other fields (issue #337, CodeRabbit)."""
+	project_id, headers = project_and_auth
+
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "Keep", "description": "Keep"},
+	})
+	episode_id = create_response.json()["id"]
+
+	response = await client.put(f"/episodes/{episode_id}", headers=headers, json={
+		"episode_number": 2,
+		"episode_metadata": None,
+	})
+	assert response.status_code == 200  # not a 500
+	data = response.json()
+	assert data["episode_number"] == 2
+	assert data["episode_metadata"]["title"] == "Keep"  # preserved
+
+
+@pytest.mark.asyncio
 async def test_update_episode_number(client, project_and_auth):
 	"""Test updating episode number."""
 	project_id, headers = project_and_auth

--- a/apps/api/tests/test_episodes.py
+++ b/apps/api/tests/test_episodes.py
@@ -240,6 +240,36 @@ async def test_update_episode(client, project_and_auth):
 
 
 @pytest.mark.asyncio
+async def test_update_episode_title_only_preserves_other_metadata(client, project_and_auth):
+	"""A partial episode_metadata update must not drop other keys (issue #337).
+
+	The edit dialog sends only {title}; description/format/explicit must survive."""
+	project_id, headers = project_and_auth
+
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_metadata": {
+			"title": "Original Title",
+			"description": "Keep me",
+			"format": "full",
+			"explicit": True,
+		}
+	})
+	assert create_response.status_code == 201
+	episode_id = create_response.json()["id"]
+
+	response = await client.put(f"/episodes/{episode_id}", headers=headers, json={
+		"episode_metadata": {"title": "New Title"}
+	})
+	assert response.status_code == 200
+	meta = response.json()["episode_metadata"]
+	assert meta["title"] == "New Title"
+	assert meta["description"] == "Keep me"  # not dropped
+	assert meta["format"] == "full"
+	assert meta["explicit"] is True
+
+
+@pytest.mark.asyncio
 async def test_update_episode_number(client, project_and_auth):
 	"""Test updating episode number."""
 	project_id, headers = project_and_auth
@@ -446,8 +476,11 @@ async def test_validation_missing_title(client, project_and_auth):
 
 
 @pytest.mark.asyncio
-async def test_validation_missing_description(client, project_and_auth):
-	"""Test validation for missing episode_metadata.description."""
+async def test_create_episode_title_only_metadata(client, project_and_auth):
+	"""description is optional in episode_metadata at create (issue #337).
+
+	The create UI only collects a title. This previously asserted 422 for a
+	missing description."""
 	project_id, headers = project_and_auth
 
 	response = await client.post("/episodes", headers=headers, json={
@@ -455,8 +488,8 @@ async def test_validation_missing_description(client, project_and_auth):
 		"episode_number": 1,
 		"episode_metadata": {"title": "Title only"}
 	})
-	assert response.status_code == 422
-	assert "description" in response.text.lower()
+	assert response.status_code == 201
+	assert response.json()["episode_metadata"]["title"] == "Title only"
 
 
 @pytest.mark.asyncio
@@ -1360,14 +1393,16 @@ async def test_batch_create_returns_unique_batch_ids(client, project_and_auth):
 
 @pytest.mark.asyncio
 async def test_batch_create_invalid_metadata(client, project_and_auth):
-	"""Test that episode with missing required metadata returns 422."""
+	"""Test that episode with missing required metadata (title) returns 422.
+
+	description is optional at create (issue #337); title is still required."""
 	project_id, headers = project_and_auth
 
 	response = await client.post("/episodes/batch", headers=headers, json={
 		"episodes": [
 			{
 				"project_id": project_id,
-				"episode_metadata": {"title": "Missing description only"}
+				"episode_metadata": {"description": "Missing title only"}
 			}
 		]
 	})

--- a/apps/api/tests/test_projects.py
+++ b/apps/api/tests/test_projects.py
@@ -202,6 +202,26 @@ async def test_update_project_multiple_fields(client, auth_headers):
 
 
 @pytest.mark.asyncio
+async def test_update_project_explicit_null_metadata_is_noop(client, auth_headers):
+	"""An explicit podcast_metadata: null must not crash (NOT NULL column) — treat
+	as no-op and still apply other fields (issue #337, CodeRabbit)."""
+	create_response = await client.post("/projects", headers=auth_headers, json={
+		"name": "Orig",
+		"podcast_metadata": {"show_title": "Show", "author": "Author", "description": "Desc"},
+	})
+	project_id = create_response.json()["id"]
+
+	response = await client.put(f"/projects/{project_id}", headers=auth_headers, json={
+		"name": "Renamed",
+		"podcast_metadata": None,
+	})
+	assert response.status_code == 200  # not a 500
+	data = response.json()
+	assert data["name"] == "Renamed"
+	assert data["podcast_metadata"]["show_title"] == "Show"  # preserved
+
+
+@pytest.mark.asyncio
 async def test_update_project_ignores_ownership_fields(client, auth_headers):
 	"""A PUT carrying ownership/system fields must not reassign them
 	(mass-assignment guard); user-editable fields in the same request still apply."""

--- a/apps/api/tests/test_projects.py
+++ b/apps/api/tests/test_projects.py
@@ -488,17 +488,34 @@ async def test_list_only_shows_own_tenant_projects(client):
 # ============================================================================
 
 @pytest.mark.asyncio
-async def test_validation_missing_required_metadata_fields(client, auth_headers):
-	"""Test validation for missing required podcast_metadata keys."""
+async def test_create_project_minimal_metadata(client, auth_headers):
+	"""author/description are NOT required in podcast_metadata at create (issue #337).
+
+	The create UI only collects a title/description; completeness is enforced later
+	at distribution time. This previously asserted 422 for missing author/description."""
 	response = await client.post("/projects", headers=auth_headers, json={
-		"name": "Invalid Project",
+		"name": "Minimal Metadata Project",
 		"podcast_metadata": {
-			"show_title": "Show"
-			# Missing 'author' and 'description'
+			"language": "en",
+			"explicit": False,
+			# no show_title / author / description
 		}
 	})
-	assert response.status_code == 422  # Validation error
-	assert "podcast_metadata" in response.text.lower()
+	assert response.status_code == 201
+	data = response.json()
+	# show_title defaults to the project name so RSS has a sensible value.
+	assert data["podcast_metadata"]["show_title"] == "Minimal Metadata Project"
+
+
+@pytest.mark.asyncio
+async def test_create_project_preserves_provided_show_title(client, auth_headers):
+	"""An explicitly provided show_title is not overwritten by the name default."""
+	response = await client.post("/projects", headers=auth_headers, json={
+		"name": "Project Name",
+		"podcast_metadata": {"show_title": "Custom Show"},
+	})
+	assert response.status_code == 201
+	assert response.json()["podcast_metadata"]["show_title"] == "Custom Show"
 
 
 @pytest.mark.asyncio

--- a/apps/web/__tests__/app/dashboard/page.test.tsx
+++ b/apps/web/__tests__/app/dashboard/page.test.tsx
@@ -26,9 +26,10 @@ describe('DashboardPage', () => {
   it('renders projects on successful load', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
+      // Real API contract: {projects: [...]} with `name` (issue #337).
       json: async () => ({
-        items: [
-          { id: '1', title: 'My First Podcast', description: null, episode_count: 2, created_at: '2026-01-01' },
+        projects: [
+          { id: '1', name: 'My First Podcast', description: null, episode_count: 2, created_at: '2026-01-01' },
         ],
       }),
     }) as jest.Mock

--- a/apps/web/src/app/(auth)/dashboard/page.tsx
+++ b/apps/web/src/app/(auth)/dashboard/page.tsx
@@ -54,8 +54,20 @@ export default function DashboardPage() {
       const response = await fetch(`/api/proxy/projects`)
 
       if (response.ok) {
-        const data = await response.json() as { items?: Project[] }
-        setProjects(data.items ?? [])
+        // API is the contract source of truth: it returns {projects: [...]} where
+        // each row uses `name`. Map to this view-model's `title` (issue #337).
+        const data = await response.json() as {
+          projects?: Array<{ id: string; name: string; description: string | null; episode_count?: number; created_at: string }>
+        }
+        setProjects(
+          (data.projects ?? []).map((p) => ({
+            id: p.id,
+            title: p.name,
+            description: p.description,
+            episode_count: p.episode_count ?? 0,
+            created_at: p.created_at,
+          }))
+        )
       } else {
         showErrorToast("Failed to load projects")
       }
@@ -83,7 +95,9 @@ export default function DashboardPage() {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          title: data.title.trim(),
+          // API canonical field is `name`; show_title is defaulted from it
+          // server-side (issue #337).
+          name: data.title.trim(),
           description: data.description?.trim() || null,
           podcast_metadata: {
             language: "en",
@@ -118,12 +132,12 @@ export default function DashboardPage() {
       const response = await fetch(
         `/api/proxy/projects/${updated.id}`,
         {
-          method: "PATCH",
+          method: "PUT",  // API exposes PUT for project update (issue #337)
           headers: {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            title: updated.title,
+            name: updated.title,
             description: updated.description,
           }),
         }

--- a/apps/web/src/app/(auth)/projects/[id]/page.tsx
+++ b/apps/web/src/app/(auth)/projects/[id]/page.tsx
@@ -65,8 +65,9 @@ export default function ProjectPage() {
         `/api/proxy/projects/${params.id}`
       )
       if (response.ok) {
-        const data = await response.json() as Project
-        setProject(data)
+        // API returns `name`; map to this view-model's `title` (issue #337).
+        const data = await response.json() as { id: string; name: string; description: string | null }
+        setProject({ id: data.id, title: data.name, description: data.description })
       } else {
         showErrorToast("Failed to load project")
       }
@@ -81,11 +82,28 @@ export default function ProjectPage() {
   const loadEpisodes = useCallback(async () => {
     try {
       const response = await fetch(
-        `/api/proxy/episodes/projects/${params.id}/episodes`
+        `/api/proxy/episodes?project_id=${params.id}`
       )
       if (response.ok) {
-        const data = await response.json() as { items?: Episode[] }
-        setEpisodes(data.items ?? [])
+        // API returns {episodes: [...]} with nested episode_metadata; flatten to
+        // this view-model's title/description (issue #337).
+        const data = await response.json() as {
+          episodes?: Array<{
+            id: string
+            episode_metadata?: { title?: string; description?: string | null }
+            generation_status: string
+            created_at: string
+          }>
+        }
+        setEpisodes(
+          (data.episodes ?? []).map((e) => ({
+            id: e.id,
+            title: e.episode_metadata?.title ?? "",
+            description: e.episode_metadata?.description ?? null,
+            generation_status: e.generation_status,
+            created_at: e.created_at,
+          }))
+        )
       } else {
         showErrorToast("Failed to load episodes")
       }
@@ -105,15 +123,16 @@ export default function ProjectPage() {
   const onSubmit = async (data: EpisodeFormData) => {
     try {
       const response = await fetch(
-        `/api/proxy/episodes/projects/${params.id}/episodes`,
+        `/api/proxy/episodes`,
         {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
+            // API stores episode fields under nested episode_metadata (issue #337).
             project_id: params.id,
-            title: data.title.trim(),
+            episode_metadata: { title: data.title.trim() },
           }),
         }
       )
@@ -145,12 +164,12 @@ export default function ProjectPage() {
       const response = await fetch(
         `/api/proxy/projects/${updated.id}`,
         {
-          method: "PATCH",
+          method: "PUT",  // API exposes PUT for project update (issue #337)
           headers: {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            title: updated.title,
+            name: updated.title,
             description: updated.description,
           }),
         }
@@ -174,11 +193,11 @@ export default function ProjectPage() {
       const response = await fetch(
         `/api/proxy/episodes/${updated.id}`,
         {
-          method: "PATCH",
+          method: "PUT",  // API exposes PUT for episode update (issue #337)
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({ title: updated.title }),
+          body: JSON.stringify({ episode_metadata: { title: updated.title } }),
         }
       )
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,44 +1,67 @@
-# Issue #302 [P2.4] — Re-enable E2E suite & restore real CI signal
+# Issue #337 — [P2.4a] Web↔API contract broken (project/episode create + GET /projects 500)
 
-**Branch:** `fix/302-e2e-test-trust`
-**Goal:** Stop CI false-green: fix broken helper selectors, provision real two-session isolation tests, selectively re-enable headline + isolation specs, add a skip-count CI gate, correct the README.
+**Branch:** `fix/337-web-api-contract`
+**Blocks:** #302 (E2E un-fixme). PLAN_SOURCE: self-authored.
 
-## SCOPE NARROWED (user decision 2026-06-28)
-Re-enabling the isolation/journey specs uncovered a real app bug: **project/episode
-creation is broken** by a web<->API contract mismatch (web sends `title`; backend
-requires `name`/`*_metadata`) + `GET /projects` 500s. Filed as **#337 (P2.4a)**.
-Per user: ship test-trust infra now; keep isolation/journey specs written but
-`fixme`'d behind #337; re-enable only auth/route-protection (passes today).
+## Canonical decision (the architectural fork, resolved with a safe default)
 
-## Acceptance criteria (from issue)
-- [x] Fix selectors to current UI (helpers repaired + tsc-clean)
-- [x] Provision two independent authenticated sessions (User B in global-setup) + negative assertions written
-- [~] Re-enable headline journey + isolation specs — written & ready, `fixme`'d behind #337; auth route-protection re-enabled & passing
-- [x] CI fails on skip-count above threshold (skip-gate, self-tested)
-- [x] Correct README coverage claims
+The **API is the source of truth**; the DB column is `name` and episodes store nested
+`episode_metadata`. So:
 
-## Plan adaptations (verified against code — not in the issue's plan)
-1. **User B via global-setup, not per-test signup.** Dev registration is rate-limited 3/hr/IP (`01-auth.spec.ts:8`). Self-provisioning fresh users per isolation test = 4-5 regs/run -> flaky. Provision one deterministic, idempotent User B in `global-setup`, persist `user-b.json`, reuse across isolation tests. User A = existing shared `user.json`.
-2. **Headline journey stops before live generation.** Re-enable signup->project->episode->content->assert "Generate Podcast" visible. Keep the real generate->wait->download flow `fixme` (depends on #313/#314; 5-min live TTS is flaky/costly in CI).
+1. **Projects use `name`** (not `title`) end-to-end; the web app conforms (UI copy can still
+   say "Title", but the data field / payload is `name`).
+2. **Episodes use nested `episode_metadata.{title,description}`** end-to-end; the web app reads
+   nested and sends nested.
+3. **Create-time metadata is lightweight.** Relax `ProjectCreate`/`EpisodeCreate` validators so
+   they don't demand fields the product doesn't collect at create (`show_title`, `author`,
+   episode `description`). Server auto-defaults `podcast_metadata.show_title = name` when absent so
+   RSS has a sensible value. The existing **distribution-time** gate
+   (`rss_generation_service.REQUIRED_METADATA_FIELDS`) is untouched — completeness is enforced
+   where it actually matters.
 
-## Steps
+Rationale for not stopping: DB/RLS/all other consumers already use `name`; changing the DB is
+high-risk and pointless. This is the lower-risk, single-source-of-truth direction.
 
-### Phase 1 — Repair shared helpers (selectors -> real UI)
-- [ ] `episode-helpers.ts`: createEpisode (#episode-title, dialog-scoped submit, nav /episodes/{id}); addContentSource (URL/Text toggle aria-pressed, #content-url/#content-text, scoped submit); generatePodcast (Generate Podcast, valid `Status: queued` locator); waitForGeneration (valid `Status: complete`, long timeout); verifyAudioPlayer (audio[controls] + Download MP3 aria-label); deleteContentSource (aria-label="Delete content source" + ConfirmDeleteDialog).
-- [ ] `project-helpers.ts`: createProject (#project-title/#project-description, dialog-scoped submit — trigger&submit share "Create Project" text = strict-mode trap; nav via card `[role=button][aria-label="Open project: <t>"]`); deleteProject (aria-label="Delete <t>" + ConfirmDeleteDialog).
-- [ ] `auth-helpers.ts`: logout via `[aria-label="User menu"]` -> Logout; add User B context loader.
+## Steps (TDD: RED → GREEN per step)
 
-### Phase 2 — Two-session isolation + selective re-enable
-- [ ] `global-setup.ts`: register + browser-login User B (deterministic email from User A, idempotent), save `tests/e2e/.auth/user-b.json`.
-- [ ] `02-projects.spec.ts`: drop top-level fixme; keep CRUD/validation/nav sub-describes fixme; rewrite "Project Access Control" — User A creates, User B (separate context) blocked + negative assertion.
-- [ ] `03-episodes.spec.ts`: same pattern for "Episode Access Control".
-- [ ] `10-integration.spec.ts`: drop top-level fixme; re-enable trimmed "Complete User Journey" (stop at Generate visible) + "Concurrent User Workflow" isolation (two contexts); re-fixme generation/download/counts/edit/perf/mobile sub-describes targeting unverified UI.
-- [ ] `01-auth.spec.ts`: re-enable the 3 route-protection test.fixme cases using real logout.
+### Backend
+- [ ] **B1. Fix `GET /projects` 500.** Write a failing integration test that seeds one project for
+      an authed user and calls `GET /projects`; read the real traceback. Candidates: count-subquery
+      `select(func.count()).select_from(query.subquery())`, ORM serialization after
+      `commit()` (missing `refresh`/`expire_on_commit`), or RLS GUC unset on the async session.
+      Fix the actual root cause. Add the regression test. (`services/project_service.py`,
+      `routers/projects.py`, tests)
+- [ ] **B2. Relax `ProjectCreate.validate_podcast_metadata`** — only type-check keys that are
+      present; drop the "required + non-empty" demand for `show_title`/`author`/`description`.
+      Default `show_title` to `name` in `create_project` when absent. Keep `ProjectUpdate` in sync.
+      Tests for: minimal metadata create succeeds; show_title defaulted.
+- [ ] **B3. Relax `EpisodeCreate.validate_episode_metadata`** — require `title` (non-empty),
+      make `description` optional. Keep `EpisodeUpdate` in sync. Tests.
 
-### Phase 3 — CI skip-gate + docs
-- [ ] `playwright.config.ts`: add json reporter -> `playwright-report/results.json`.
-- [ ] `playwright-tests.yml`: after test run (test job, `if: always()`), parse `.stats.skipped`, emit GitHub notice (passed/failed/skipped), fail if skipped > THRESHOLD (documented; tuned from first CI run).
-- [ ] `tests/e2e/README.md`: replace "270 tests / Implemented" with active-vs-fixme reality; fix helper descriptions.
+### Frontend
+- [ ] **F1. Project `title` → `name`.** Update web `Project` interfaces + all read sites
+      (`dashboard/page.tsx` 205/217/219/226/234, `projects/[id]/page.tsx` 267/268,
+      `EditProjectDialog.tsx`), create payload (`dashboard/page.tsx:85`), update payloads
+      (`dashboard/page.tsx:118`, `projects/[id]/page.tsx:145`). Send
+      `podcast_metadata:{show_title:name, language, explicit}`. Keep form input id `#project-title`
+      + "Title" UI label so E2E selectors still resolve.
+- [ ] **F2. Episode nested metadata.** In `projects/[id]/page.tsx`: Episode interface + list reads
+      (304/316/317/324/332) → `episode.episode_metadata.title/description`; create payload
+      (114) → `{project_id, episode_metadata:{title}}`; edit payload (174) →
+      `{episode_metadata:{title}}`. (`episodes/[id]/page.tsx` already correct.)
+- [ ] **F3. Update web unit tests + `lib/validation.ts` only if shape assertions break.** Jest.
 
-### Quality gate
-- [ ] playwright `--list` parses (valid fixme structure); skip-gate self-tested on sample JSON; CI Playwright run green — tune THRESHOLD from actual count.
+### E2E (un-fixme the handed-off specs)
+- [ ] **E1.** Remove `.fixme` from: `02-projects.spec.ts:289` (Project isolation),
+      `03-episodes.spec.ts:341` (Episode isolation), `10-integration.spec.ts:12` (Complete Journey)
+      + `:324` (Concurrent Workflow). Helpers already use two independent sessions (PR #338) and
+      fill `#project-title`/`#episode-title` — no helper change expected.
+
+### Verify / gates
+- [ ] Backend `uv run pytest` green; web `npm run test` + typecheck green; lint.
+- [ ] Demo the create→list→display round-trip (Phase 11 hard gate) — projects + episodes.
+- [ ] E2E specs green (or documented dev-env dependency if they need the deployed target).
+
+## Acceptance criteria mapping
+- AC1 (align contract) → F1/F2/B2/B3. AC2 (GET /projects 500 + test) → B1.
+- AC3 (round-trip verify) → demo. AC4 (un-fixme 4 specs) → E1.

--- a/tests/e2e/specs/02-projects.spec.ts
+++ b/tests/e2e/specs/02-projects.spec.ts
@@ -286,7 +286,7 @@ test.describe.fixme('Project Management', () => {
 // global-setup). Ready to run, but BLOCKED: project creation is broken by the
 // web<->API contract mismatch (web sends `title`, backend requires
 // `name`/`podcast_metadata`). Un-fixme once #337 lands.
-test.describe.fixme('Project Access Control (isolation)', () => {
+test.describe('Project Access Control (isolation)', () => {
 	test('User B cannot access User A project', async ({ page, browser }) => {
 		// User A (default shared session) creates a private project.
 		const title = `Private Project ${Date.now()}`;

--- a/tests/e2e/specs/03-episodes.spec.ts
+++ b/tests/e2e/specs/03-episodes.spec.ts
@@ -338,7 +338,7 @@ test.describe.fixme('Episode Management', () => {
 // Multi-tenant isolation (User A = shared storageState; User B = persistent
 // second tenant from global-setup). Ready to run, but BLOCKED: project/episode
 // creation is broken by the web<->API contract mismatch. Un-fixme once #337 lands.
-test.describe.fixme('Episode Access Control (isolation)', () => {
+test.describe('Episode Access Control (isolation)', () => {
 	test('User B cannot access User A episode', async ({ page, browser }) => {
 		// User A (default shared session) creates a private episode.
 		const episodeTitle = `Private Episode ${Date.now()}`;

--- a/tests/e2e/specs/10-integration.spec.ts
+++ b/tests/e2e/specs/10-integration.spec.ts
@@ -9,7 +9,7 @@ import { createEpisode, addContentSource, generatePodcast, waitForGeneration, ve
 // un-fixme'ing once #337 lands. Remaining workflows target unverified UI or live
 // generation and stay individually fixme'd.
 test.describe('End-to-End Integration Workflows', () => {
-	test.describe.fixme('Complete User Journey: Signup to Ready-to-Generate', () => {
+	test.describe('Complete User Journey: Signup to Ready-to-Generate', () => {
 		// The headline journey: signup -> login -> project -> episode -> content ->
 		// ready to generate. The actual generate -> wait -> download leg lives in the
 		// fixme'd "Generation and Download" suite below because live TTS generation
@@ -321,7 +321,7 @@ test.describe('End-to-End Integration Workflows', () => {
 	// Two genuinely independent sessions (User A shared session + User B persistent
 	// context) prove data isolation. Ready to run, but BLOCKED on project creation
 	// (#337). Un-fixme once #337 lands.
-	test.describe.fixme('Concurrent User Workflow', () => {
+	test.describe('Concurrent User Workflow', () => {
 		test('should isolate data between two independent users', async ({ page, browser }) => {
 			// User A (shared session) creates a project.
 			const userAProject = { title: `User A Project ${Date.now()}` };


### PR DESCRIPTION
Closes #337. Unblocks #302 (the four handed-off E2E specs are un-`fixme`'d here).

## Problem
The web frontend and API disagreed on the core project/episode data contract, so create/list/display failed end-to-end. Beyond the field-name mismatch in the issue, exploration surfaced several more breaks: the dashboard read a non-existent `items` envelope, the project detail page called a **non-existent** `/episodes/projects/{id}/episodes` route, and both used **PATCH** where the API exposes **PUT**.

## Canonical decision
The **API is the source of truth** (DB column is `name`; episodes store nested `episode_metadata`; changing the DB/RLS would be high-risk and pointless). The web app conforms. To keep the diff minimal and leave forms/dialogs/E2E selectors untouched, the contract is translated **at each fetch boundary** — the web view-model stays `title`/flat, mapped to the API's `name`/nested shape only in the fetch calls.

## Changes
**Backend**
- Relax create-time metadata validators — `podcast_metadata` no longer requires `show_title`/`author`/`description`; `episode_metadata` no longer requires `description` (the create UI collects neither). Present keys must still be non-empty. Completeness stays enforced at **distribution time** (`rss_generation_service.REQUIRED_METADATA_FIELDS`), unchanged.
- Default `podcast_metadata.show_title` to the project `name` on create so RSS has a sensible value.
- Shallow-merge `podcast_metadata`/`episode_metadata` on update so a partial edit (title only) can't drop other JSONB keys *(found in review)*.
- Guard list pagination against a `None` count (`total or 0`) so it can't raise `TypeError → HTTP 500`.

**Frontend**
- Projects: send/read `name`; read the real `{projects:[...]}` envelope; PUT for update.
- Episodes: send/read nested `episode_metadata`; use `GET /episodes?project_id=` + `{episodes:[...]}`; `POST /episodes`; PUT for update.

**Tests** — updated project/episode validation tests to the new (intentional) contract; added positive tests for minimal-metadata create, `show_title` defaulting, and metadata-preserving partial update; fixed the dashboard mock; un-`fixme`'d the four #337 specs.

## Acceptance criteria
- ✅ AC1 align contract — backend validators + frontend fetch mapping
- ✅ AC2 `GET /projects` 500 + test — see Known Limitations for the 500's nature
- ✅ AC3 create→list→display round-trip — verified live (below)
- ✅ AC4 un-`fixme` the four specs — done

## Verification (live API round-trip, exact frontend shapes)
```
POST /projects {name, podcast_metadata:{language,explicit}}      → 201, show_title defaulted to name
GET  /projects                                                   → 200 {projects:[...]}  (issue's 500 endpoint)
PUT  /projects/{id} {name}                                       → 200
POST /episodes {project_id, episode_metadata:{title}}            → 201
GET  /episodes?project_id=…                                      → 200 {episodes:[...]}  nested metadata
PUT  /episodes/{id} {episode_metadata:{title}}                   → 200, other metadata preserved
```
Backend `pytest`: **739 passed**. Web `jest`: **246 passed**. Web `tsc` + `next lint`: clean. Cross-family review: `codex` (P2 metadata-drop fixed; P3 artifact removed).

## Known Limitations
- **`GET /projects` 500 (AC2):** could not be reproduced in the test harness — the existing `test_list_projects` and full CRUD suite pass, and the `projects` schema is unchanged since migration `001` (no column drift). The reported 500 was a snapshot of the deployed dev host on 2026-06-28 and is most likely un-deployed/older code or account-specific legacy row data. This PR hardens the one genuine code fragility (pagination count → `TypeError`); the real integration proof is the round-trip above + the un-`fixme`'d journey spec. If a 500 persists on dev after deploy, it's an ops/data issue (apply `alembic upgrade head`, inspect the offending row).
- **E2E timing:** the Playwright job runs against the **deployed** `dev.podcaststudiohub.me`, so the four un-`fixme`'d specs go green only **after** this PR merges and dev redeploys. The PR's own E2E run may show red against pre-deploy dev — expected, not a regression from this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled additional end-to-end flows for project access, episode access, and full user journeys.

* **Bug Fixes**
  * Improved project/episode validation to allow partial metadata at create/update, preserve existing fields on edits, and treat `null` metadata as a safe no-op.
  * Hardened pagination totals to avoid errors when counts are missing.
  * Updated dashboard and project pages to align with the latest API response/request formats (project `name`, nested `episode_metadata`).

* **Tests**
  * Added/updated backend and frontend tests to cover the new metadata behavior and refreshed mocked API response shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->