### PR TITLE
test(coverage): make coverage gates real — backend --cov-fail-under=85, frontend covers src/app (#303)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -91,7 +91,7 @@ jobs:
           uv run pytest tests/ \
             --cov=src \
             --cov-report=term-missing \
-            --cov-fail-under=0 \
+            --cov-fail-under=85 \
             -v
 
       - name: Install frontend dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
             --cov-report=xml:coverage/backend/coverage.xml \
             --cov-report=html:coverage/backend \
             --cov-report=term-missing \
-            --cov-fail-under=0 \
+            --cov-fail-under=85 \
             -v
 
       - name: Upload backend coverage reports

--- a/apps/api/.coveragerc
+++ b/apps/api/.coveragerc
@@ -1,5 +1,7 @@
 [run]
-concurrency = greenlet
+# greenlet: trace async SQLAlchemy code after await db.execute()/commit()
+# thread: keep tracing code run in Starlette's threadpool (sync deps)
+concurrency = greenlet, thread
 source = src
 omit =
     */tests/*

--- a/apps/api/.coveragerc
+++ b/apps/api/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+concurrency = greenlet
 source = src
 omit =
     */tests/*

--- a/apps/api/pytest.ini
+++ b/apps/api/pytest.ini
@@ -20,26 +20,8 @@ addopts =
     --cov-report=xml:coverage/backend/coverage.xml
     --cov-fail-under=85
 
-# Exclude patterns from coverage
-[coverage:run]
-omit =
-    */tests/*
-    */alembic/*
-    */__pycache__/*
-    */migrations/*
-    */.venv/*
-
-# Coverage report settings
-[coverage:report]
-exclude_lines =
-    pragma: no cover
-    def __repr__
-    raise AssertionError
-    raise NotImplementedError
-    if __name__ == .__main__.:
-    if TYPE_CHECKING:
-    @abstractmethod
-    @abc.abstractmethod
+# Coverage run/report settings live in .coveragerc (coverage.py does not
+# read [coverage:*] sections from pytest.ini).
 
 # Markers for organizing tests
 markers =

--- a/apps/api/pytest.ini
+++ b/apps/api/pytest.ini
@@ -18,7 +18,7 @@ addopts =
     --cov-report=html:coverage/backend
     --cov-report=term-missing
     --cov-report=xml:coverage/backend/coverage.xml
-    --cov-fail-under=0
+    --cov-fail-under=85
 
 # Exclude patterns from coverage
 [coverage:run]

--- a/apps/api/pytest.ini
+++ b/apps/api/pytest.ini
@@ -22,16 +22,10 @@ addopts =
 
 # Coverage run/report settings live in .coveragerc (coverage.py does not
 # read [coverage:*] sections from pytest.ini).
-
-# Markers for organizing tests
-markers =
-    unit: Unit tests
-    integration: Integration tests
-    slow: Tests that take longer to run
-    asyncio: Async tests
-
-# Warning settings
-filterwarnings =
-    error
-    ignore::UserWarning
-    ignore::DeprecationWarning
+#
+# NOTE: this file used to carry `markers` and `filterwarnings` entries BELOW
+# the (dead) [coverage:*] section headers, so pytest never parsed them — they
+# were dead config too. `filterwarnings = error` in particular was never
+# active; activating it errors on third-party import warnings (e.g. pydub
+# SyntaxWarning) and is tracked as a separate issue rather than smuggled into
+# a coverage-gate change.

--- a/apps/api/src/services/episode_service.py
+++ b/apps/api/src/services/episode_service.py
@@ -5,7 +5,6 @@ Provides CRUD operations for episodes with project validation, pagination,
 status filtering, and generation status management. RLS ensures tenant isolation.
 """
 
-import json
 from datetime import datetime
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, cast, or_
@@ -178,7 +177,7 @@ async def get_episodes(
 	if tags:
 		for tag in tags:
 			query = query.where(
-				Episode.episode_metadata['tags'].op('@>')(cast(json.dumps([tag]), JSONB))
+				Episode.episode_metadata['tags'].op('@>')(cast([tag], JSONB))
 			)
 
 	# TTS config filter

--- a/apps/api/tests/test_audio_snippets.py
+++ b/apps/api/tests/test_audio_snippets.py
@@ -800,7 +800,11 @@ async def test_download_url_no_s3_config(client, auth_headers):
 	snippet_id = create_response.json()["id"]
 
 	# Try to get download URL - s3_key is set but no bucket configured
-	with patch("src.services.audio_snippet_service.generate_download_url") as mock_gen:
+	# Patch the name as bound in the router module (it's imported via
+	# `from ..services.audio_snippet_service import generate_download_url`),
+	# not the service module — patching the latter doesn't affect the
+	# router's already-bound reference.
+	with patch("src.routers.audio_snippets.generate_download_url") as mock_gen:
 		from fastapi import HTTPException, status as http_status
 		mock_gen.side_effect = HTTPException(
 			status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/apps/api/tests/test_content.py
+++ b/apps/api/tests/test_content.py
@@ -1305,3 +1305,204 @@ async def test_upload_pdf_episode_not_found(client, authenticated_headers):
         )
 
     assert response.status_code == 404
+
+
+# ============================================================================
+# BROKER-UNAVAILABLE TESTS (auto-extract dispatch failure must not fail creation)
+# ============================================================================
+
+@pytest.mark.asyncio
+async def test_create_content_source_broker_unavailable(client, episode_and_auth):
+    """If queuing the extraction task raises, creation still succeeds (logged, not fatal)."""
+    episode_id, headers = episode_and_auth
+
+    content_data = {
+        "episode_id": episode_id,
+        "source_type": "url",
+        "source_data": {
+            "url": "https://example.com/article",
+            "title": "Test Article"
+        }
+    }
+
+    mock_client = _mock_http_200()
+    with patch(
+        "src.services.source_validator_service.httpx.AsyncClient",
+        return_value=mock_client,
+    ), patch(
+        "src.tasks.content_extraction.extract_content_task"
+    ) as mock_task:
+        mock_task.delay.side_effect = Exception("broker unavailable")
+        response = await client.post(
+            f"/episodes/{episode_id}/content",
+            headers=headers,
+            json=content_data
+        )
+
+    assert response.status_code == 201
+    assert response.json()["source_type"] == "url"
+    mock_task.delay.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_upload_pdf_broker_unavailable(client, episode_and_auth):
+    """If queuing the extraction task raises after upload, upload still succeeds."""
+    episode_id, headers = episode_and_auth
+
+    with patch(
+        "src.services.content_service._upload_pdf_to_s3", new_callable=AsyncMock
+    ) as mock_s3, patch(
+        "src.tasks.content_extraction.extract_content_task"
+    ) as mock_task:
+        mock_s3.return_value = "https://bucket.s3.amazonaws.com/content/key.pdf"
+        mock_task.delay.side_effect = Exception("broker unavailable")
+        response = await client.post(
+            f"/episodes/{episode_id}/content/upload",
+            headers=headers,
+            files=_pdf_upload_files(),
+            data={"auto_extract": "true"},
+        )
+
+    assert response.status_code == 201
+    assert response.json()["source_type"] == "pdf"
+    mock_task.delay.assert_called_once()
+
+
+# ============================================================================
+# LIST CONTENT SOURCES — EPISODE NOT FOUND
+# ============================================================================
+
+@pytest.mark.asyncio
+async def test_list_content_sources_episode_not_found(client, authenticated_headers):
+    """Listing content sources for a non-existent episode returns 404."""
+    random_episode_id = str(uuid4())
+
+    response = await client.get(
+        f"/episodes/{random_episode_id}/content",
+        headers=authenticated_headers
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+# ============================================================================
+# TRIGGER EXTRACTION ENDPOINT TESTS
+# ============================================================================
+
+@pytest.mark.asyncio
+async def test_trigger_extraction_success(client, url_content_source):
+    """Triggering extraction on an existing content source returns 202 with task info."""
+    content, headers = url_content_source
+
+    mock_task = MagicMock()
+    mock_task.id = "task-abc-123"
+    with patch(
+        "src.tasks.content_extraction.extract_content_task"
+    ) as mock_extract_task:
+        mock_extract_task.delay.return_value = mock_task
+        response = await client.post(
+            f"/content/{content['id']}/extract",
+            headers=headers
+        )
+
+    assert response.status_code == 202
+    data = response.json()
+    assert data["content_source_id"] == content["id"]
+    assert data["task_id"] == "task-abc-123"
+    assert data["status"] == "extracting"
+    mock_extract_task.delay.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_trigger_extraction_not_found(client, authenticated_headers):
+    """Triggering extraction on a non-existent content source returns 404."""
+    random_id = str(uuid4())
+
+    response = await client.post(
+        f"/content/{random_id}/extract",
+        headers=authenticated_headers
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_trigger_extraction_broker_unavailable(client, url_content_source):
+    """When the extraction task cannot be queued, returns 503."""
+    content, headers = url_content_source
+
+    with patch(
+        "src.tasks.content_extraction.extract_content_task"
+    ) as mock_extract_task:
+        mock_extract_task.delay.side_effect = Exception("broker down")
+        response = await client.post(
+            f"/content/{content['id']}/extract",
+            headers=headers
+        )
+
+    assert response.status_code == 503
+    assert "unavailable" in response.json()["detail"].lower()
+
+
+# ============================================================================
+# EXTRACTION STATUS ENDPOINT TESTS
+# ============================================================================
+
+@pytest.mark.asyncio
+async def test_get_extraction_status_not_found(client, authenticated_headers):
+    """Getting extraction status for a non-existent content source returns 404."""
+    random_id = str(uuid4())
+
+    response = await client.get(
+        f"/content/{random_id}/extraction-status",
+        headers=authenticated_headers
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_get_extraction_status_pending_no_word_count(client, url_content_source):
+    """A pending content source has no extracted_word_count."""
+    content, headers = url_content_source
+
+    response = await client.get(
+        f"/content/{content['id']}/extraction-status",
+        headers=headers
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["content_source_id"] == content["id"]
+    assert data["extraction_status"] == "pending"
+    assert data["extracted_word_count"] is None
+    assert data["error_message"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_extraction_status_computes_word_count(client, url_content_source):
+    """A completed content source's extracted_word_count reflects the extracted text."""
+    content, headers = url_content_source
+
+    update_response = await client.put(
+        f"/content/{content['id']}",
+        headers=headers,
+        json={
+            "extraction_status": "complete",
+            "extracted_content": "one two three four five"
+        }
+    )
+    assert update_response.status_code == 200
+
+    response = await client.get(
+        f"/content/{content['id']}/extraction-status",
+        headers=headers
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["extraction_status"] == "complete"
+    assert data["extracted_word_count"] == 5

--- a/apps/api/tests/test_encryption_db.py
+++ b/apps/api/tests/test_encryption_db.py
@@ -1,0 +1,143 @@
+"""
+Integration tests for the DB-dependent credential encryption helpers.
+
+encrypt_credential / decrypt_credential / decrypt_credential_sync /
+encrypt_api_keys / decrypt_api_keys all delegate to PostgreSQL pgcrypto
+functions (encrypt_credential/decrypt_credential SQL functions provisioned by
+migration 001_initial_schema.py). Per project policy these are tested against
+a real database rather than mocked.
+"""
+
+import pytest
+
+from src.database import SyncSessionLocal
+from src.utils.encryption import (
+	decrypt_api_keys,
+	decrypt_credential,
+	decrypt_credential_sync,
+	encrypt_api_keys,
+	encrypt_credential,
+)
+
+
+# ============================================================================
+# encrypt_credential / decrypt_credential (async round trip)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_encrypt_credential_returns_ciphertext_different_from_plaintext(test_db):
+	plaintext = "sk-super-secret-api-key-12345"
+
+	encrypted = await encrypt_credential(test_db, plaintext)
+
+	assert isinstance(encrypted, str)
+	assert encrypted != plaintext
+
+
+@pytest.mark.asyncio
+async def test_decrypt_credential_round_trips_encrypted_value(test_db):
+	plaintext = "sk-super-secret-api-key-12345"
+
+	encrypted = await encrypt_credential(test_db, plaintext)
+	decrypted = await decrypt_credential(test_db, encrypted)
+
+	assert decrypted == plaintext
+
+
+@pytest.mark.asyncio
+async def test_encrypt_credential_is_nondeterministic(test_db):
+	"""pgcrypto's pgp_sym_encrypt salts its output, so encrypting the same
+	plaintext twice should not yield identical ciphertext."""
+	plaintext = "another-secret-value"
+
+	encrypted_1 = await encrypt_credential(test_db, plaintext)
+	encrypted_2 = await encrypt_credential(test_db, plaintext)
+
+	assert encrypted_1 != encrypted_2
+	assert await decrypt_credential(test_db, encrypted_1) == plaintext
+	assert await decrypt_credential(test_db, encrypted_2) == plaintext
+
+
+# ============================================================================
+# encrypt_api_keys / decrypt_api_keys (async, dict of multiple keys)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_encrypt_api_keys_encrypts_each_present_value(test_db):
+	api_keys = {
+		"openai_api_key": "sk-openai-123",
+		"elevenlabs_api_key": "el-456",
+	}
+
+	encrypted = await encrypt_api_keys(test_db, api_keys)
+
+	assert set(encrypted.keys()) == set(api_keys.keys())
+	for key_name, plaintext in api_keys.items():
+		assert encrypted[key_name] != plaintext
+
+
+@pytest.mark.asyncio
+async def test_encrypt_api_keys_skips_falsy_values(test_db):
+	"""Keys with empty/None values must not be sent to pgcrypto or included
+	in the returned dict (the `if key_value:` guard in encrypt_api_keys)."""
+	api_keys = {
+		"openai_api_key": "sk-openai-123",
+		"gemini_api_key": "",
+		"custom_api_key": None,
+	}
+
+	encrypted = await encrypt_api_keys(test_db, api_keys)
+
+	assert "openai_api_key" in encrypted
+	assert "gemini_api_key" not in encrypted
+	assert "custom_api_key" not in encrypted
+
+
+@pytest.mark.asyncio
+async def test_decrypt_api_keys_round_trips_multiple_keys(test_db):
+	api_keys = {
+		"openai_api_key": "sk-openai-123",
+		"elevenlabs_api_key": "el-456",
+	}
+
+	encrypted = await encrypt_api_keys(test_db, api_keys)
+	decrypted = await decrypt_api_keys(test_db, encrypted)
+
+	assert decrypted == api_keys
+
+
+@pytest.mark.asyncio
+async def test_decrypt_api_keys_skips_falsy_values(test_db):
+	encrypted_keys = {
+		"openai_api_key": await encrypt_credential(test_db, "sk-openai-123"),
+		"gemini_api_key": "",
+		"custom_api_key": None,
+	}
+
+	decrypted = await decrypt_api_keys(test_db, encrypted_keys)
+
+	assert decrypted == {"openai_api_key": "sk-openai-123"}
+
+
+# ============================================================================
+# decrypt_credential_sync (synchronous Session — used by Celery tasks)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_decrypt_credential_sync_round_trips_value_from_sync_session(test_db):
+	"""Encrypt via the async session (as the web app would), then decrypt via
+	a plain synchronous Session (as a Celery task would) and confirm the
+	round trip yields the original plaintext."""
+	plaintext = "sk-celery-task-secret"
+	encrypted = await encrypt_credential(test_db, plaintext)
+
+	sync_db = SyncSessionLocal()
+	try:
+		decrypted = decrypt_credential_sync(sync_db, encrypted)
+	finally:
+		sync_db.close()
+
+	assert decrypted == plaintext

--- a/apps/api/tests/test_encryption_db.py
+++ b/apps/api/tests/test_encryption_db.py
@@ -9,6 +9,7 @@ a real database rather than mocked.
 """
 
 import pytest
+from sqlalchemy.exc import DBAPIError
 
 from src.database import SyncSessionLocal
 from src.utils.encryption import (
@@ -141,3 +142,21 @@ async def test_decrypt_credential_sync_round_trips_value_from_sync_session(test_
 		sync_db.close()
 
 	assert decrypted == plaintext
+
+
+# ============================================================================
+# Negative path: corrupt/invalid ciphertext
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_decrypt_credential_raises_on_corrupt_ciphertext(test_db):
+	"""decrypt_credential must not silently return garbage or None for
+	corrupt input — it should fail loudly. `decode(encrypted_credential,
+	'base64')` in the SQL function rejects non-base64 input at the database
+	level, and that failure propagates up through asyncpg/SQLAlchemy as a
+	DBAPIError rather than being swallowed."""
+	with pytest.raises(DBAPIError) as exc_info:
+		await decrypt_credential(test_db, "not-valid-base64-ciphertext!!!")
+
+	assert "invalid symbol" in str(exc_info.value).lower()

--- a/apps/api/tests/test_episodes.py
+++ b/apps/api/tests/test_episodes.py
@@ -1430,3 +1430,395 @@ async def test_batch_create_invalid_metadata(client, project_and_auth):
 		]
 	})
 	assert response.status_code == 422
+
+
+# ============================================================================
+# QUOTA ENFORCEMENT TESTS (#297)
+# ============================================================================
+
+async def _register_free_tier_user_and_project(client):
+	"""Register a plain free-tier user (no enterprise subscription seeded) and
+	create a project. Returns (project_id, headers)."""
+	reg_response = await client.post("/auth/register", json={
+		"email": f"quota_{uuid4()}@example.com",
+		"password": "SecurePass123!",
+		"full_name": "Quota Test User"
+	})
+	assert reg_response.status_code == 201
+	token = reg_response.json()["access_token"]
+	headers = {"Authorization": f"Bearer {token}"}
+
+	proj_response = await client.post("/projects", headers=headers, json={
+		"name": "Quota Project",
+		"podcast_metadata": {
+			"show_title": "Quota Show",
+			"author": "Quota Author",
+			"description": "Quota Description"
+		}
+	})
+	assert proj_response.status_code == 201
+	project_id = proj_response.json()["id"]
+
+	return project_id, headers
+
+
+@pytest.mark.asyncio
+async def test_create_episode_quota_exceeded(client):
+	"""Free-tier users are blocked with 402 once the monthly episode limit is reached."""
+	from src.utils.pricing import get_tier_limit
+
+	project_id, headers = await _register_free_tier_user_and_project(client)
+	free_limit = get_tier_limit("free", "episodes_per_month")
+
+	for i in range(1, free_limit + 1):
+		resp = await client.post("/episodes", headers=headers, json={
+			"project_id": project_id,
+			"episode_number": i,
+			"episode_metadata": {"title": f"Ep {i}", "description": "d"}
+		})
+		assert resp.status_code == 201, resp.text
+
+	# The (limit+1)-th creation is rejected with 402 Payment Required.
+	resp = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": free_limit + 1,
+		"episode_metadata": {"title": "Over limit", "description": "d"}
+	})
+	assert resp.status_code == 402
+	assert "limit" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_batch_create_episodes_quota_exceeded(client, test_db):
+	"""Batch creation is gated up front: a batch that would exceed the plan's
+	remaining monthly quota is rejected with 402 before any episode is created."""
+	from sqlalchemy import select
+	from src.models.billing_usage import BillingUsage
+	from src.services.auth_service import verify_jwt_token
+	from src.services.usage_service import _current_period_dates
+	from src.utils.pricing import get_tier_limit
+
+	project_id, headers = await _register_free_tier_user_and_project(client)
+	token = headers["Authorization"].split(" ", 1)[1]
+	claims = verify_jwt_token(token)
+	free_limit = get_tier_limit("free", "episodes_per_month")
+
+	# Pre-fill usage to one below the free cap (upsert: registration/project
+	# creation may already have created this period's usage row via metering).
+	start, end = _current_period_dates()
+	existing = (await test_db.execute(
+		select(BillingUsage).where(
+			BillingUsage.user_id == claims["sub"],
+			BillingUsage.period_start == start,
+		)
+	)).scalar_one_or_none()
+	if existing is None:
+		test_db.add(BillingUsage(
+			user_id=claims["sub"], tenant_id=claims["tenant_id"],
+			period_start=start, period_end=end, episodes_created=free_limit - 1,
+		))
+	else:
+		existing.episodes_created = free_limit - 1
+	await test_db.flush()
+
+	# A batch of 3 would exceed the single remaining slot → rejected before any write.
+	response = await client.post("/episodes/batch", headers=headers, json={
+		"episodes": [
+			{"project_id": project_id, "episode_metadata": {"title": f"B{n}", "description": "d"}}
+			for n in range(1, 4)
+		]
+	})
+	assert response.status_code == 402
+	assert "limit" in response.json()["detail"].lower()
+
+
+# ============================================================================
+# TAG FILTERING TESTS
+# ============================================================================
+
+@pytest.mark.asyncio
+async def test_list_episodes_tags_query_param_accepted(client, project_and_auth):
+	"""The `?tags=` query param is parsed (comma-split) and accepted by the endpoint."""
+	project_id, headers = project_and_auth
+
+	await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "Tagged", "description": "d", "tags": ["tech", "ai"]}
+	})
+
+	response = await client.get(
+		f"/episodes?project_id={project_id}&tags=tech,ai",
+		headers=headers
+	)
+	assert response.status_code == 200
+	assert "episodes" in response.json()
+
+
+@pytest.mark.asyncio
+async def test_get_episodes_filters_by_tags(client, test_db, project_and_auth):
+	"""Regression test for a double-JSON-encoding bug in get_episodes()'s tag filter
+	(src/services/episode_service.py): `cast(json.dumps([tag]), JSONB)` pre-encodes
+	the value before the JSONB bind processor encodes it again, so the `@>`
+	containment check never matches and the filter silently returns zero rows.
+
+	Creates one episode tagged ["news", "tech"] and one tagged ["news"] only, then
+	calls get_episodes() directly (not through the HTTP layer) to verify the tags
+	filter actually narrows results: filtering by "news" must return both episodes,
+	filtering by "tech" must return only the news+tech one.
+	"""
+	from uuid import UUID
+	from src.services.episode_service import get_episodes
+
+	project_id, headers = project_and_auth
+
+	news_tech = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "News and Tech", "description": "d", "tags": ["news", "tech"]}
+	})
+	news_only = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 2,
+		"episode_metadata": {"title": "News Only", "description": "d", "tags": ["news"]}
+	})
+	assert news_tech.status_code == 201
+	assert news_only.status_code == 201
+	news_tech_id = news_tech.json()["id"]
+	news_only_id = news_only.json()["id"]
+
+	news_episodes, news_total = await get_episodes(
+		db=test_db, project_id=UUID(project_id), skip=0, limit=20, tags=["news"]
+	)
+	assert news_total == 2
+	assert {str(ep.id) for ep in news_episodes} == {news_tech_id, news_only_id}
+
+	tech_episodes, tech_total = await get_episodes(
+		db=test_db, project_id=UUID(project_id), skip=0, limit=20, tags=["tech"]
+	)
+	assert tech_total == 1
+	assert str(tech_episodes[0].id) == news_tech_id
+
+
+# ============================================================================
+# DOWNLOAD ENDPOINT TESTS
+# ============================================================================
+
+def _mock_s3_storage(total_size: int, content: bytes, mock_class):
+	"""Configure a mock StorageService for download tests."""
+	from unittest.mock import MagicMock
+
+	mock_instance = MagicMock()
+	mock_class.return_value = mock_instance
+	mock_instance.bucket_name = "test-bucket"
+	mock_instance.s3_client.head_object.return_value = {"ContentLength": total_size}
+	mock_body = MagicMock()
+	mock_body.read.side_effect = [content, b""]
+	mock_instance.s3_client.get_object.return_value = {"Body": mock_body}
+	return mock_instance
+
+
+@pytest.mark.asyncio
+async def test_download_episode_not_found(client, project_and_auth):
+	"""Downloading a non-existent episode returns 404."""
+	_, headers = project_and_auth
+	fake_id = str(uuid4())
+
+	response = await client.get(f"/episodes/{fake_id}/download", headers=headers)
+	assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_download_episode_not_complete(client, project_and_auth):
+	"""Downloading a draft (not-complete) episode returns 403."""
+	project_id, headers = project_and_auth
+
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "Draft Ep", "description": "Desc"}
+	})
+	episode_id = create_response.json()["id"]
+
+	response = await client.get(f"/episodes/{episode_id}/download", headers=headers)
+	assert response.status_code == 403
+	assert "not ready" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_download_no_audio_in_storage(client, project_and_auth, set_system_fields):
+	"""A 'complete' episode with neither s3_key nor a usable file_path returns 404."""
+	project_id, headers = project_and_auth
+
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "No Audio", "description": "Desc"}
+	})
+	episode_id = create_response.json()["id"]
+	await set_system_fields(episode_id, generation_status="complete")
+
+	response = await client.get(f"/episodes/{episode_id}/download", headers=headers)
+	assert response.status_code == 404
+	assert "audio file not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_download_s3_full_file_success(client, project_and_auth, set_system_fields):
+	"""A 'complete' episode with an s3_key streams from S3 with correct headers."""
+	from unittest.mock import patch
+
+	project_id, headers = project_and_auth
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "S3 Episode", "description": "Desc"}
+	})
+	episode_id = create_response.json()["id"]
+	await set_system_fields(
+		episode_id, generation_status="complete", s3_key="podcasts/episode.mp3"
+	)
+
+	fake_audio = b"FAKE_MP3_CONTENT_" * 10
+	with patch("src.routers.episodes.StorageService") as MockStorage:
+		_mock_s3_storage(len(fake_audio), fake_audio, MockStorage)
+		response = await client.get(f"/episodes/{episode_id}/download", headers=headers)
+
+	assert response.status_code == 200
+	assert response.headers["content-type"] == "audio/mpeg"
+	assert "attachment" in response.headers["content-disposition"]
+	assert int(response.headers["content-length"]) == len(fake_audio)
+	assert response.headers["accept-ranges"] == "bytes"
+	assert response.headers["cache-control"] == "private, max-age=31536000"
+
+
+@pytest.mark.asyncio
+async def test_download_s3_range_206(client, project_and_auth, set_system_fields):
+	"""A Range request against an S3-backed episode returns 206 with Content-Range."""
+	from unittest.mock import patch
+
+	project_id, headers = project_and_auth
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "S3 Range Episode", "description": "Desc"}
+	})
+	episode_id = create_response.json()["id"]
+	await set_system_fields(
+		episode_id, generation_status="complete", s3_key="podcasts/episode.mp3"
+	)
+
+	total_size = 5242880
+	range_start, range_end = 0, 1023
+	with patch("src.routers.episodes.StorageService") as MockStorage:
+		_mock_s3_storage(total_size, b"X" * 1024, MockStorage)
+		response = await client.get(
+			f"/episodes/{episode_id}/download",
+			headers={**headers, "Range": f"bytes={range_start}-{range_end}"}
+		)
+
+	assert response.status_code == 206
+	assert response.headers["content-range"] == f"bytes {range_start}-{range_end}/{total_size}"
+	assert int(response.headers["content-length"]) == 1024
+
+
+@pytest.mark.asyncio
+async def test_download_invalid_range_returns_416(client, project_and_auth, set_system_fields):
+	"""An out-of-bounds Range header returns 416."""
+	from unittest.mock import patch
+
+	project_id, headers = project_and_auth
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "Bad Range Episode", "description": "Desc"}
+	})
+	episode_id = create_response.json()["id"]
+	await set_system_fields(
+		episode_id, generation_status="complete", s3_key="podcasts/episode.mp3"
+	)
+
+	total_size = 5242880
+	with patch("src.routers.episodes.StorageService") as MockStorage:
+		mock_instance = MockStorage.return_value
+		mock_instance.bucket_name = "test-bucket"
+		mock_instance.s3_client.head_object.return_value = {"ContentLength": total_size}
+
+		response = await client.get(
+			f"/episodes/{episode_id}/download",
+			headers={**headers, "Range": f"bytes={total_size}-{total_size + 100}"}
+		)
+
+	assert response.status_code == 416
+
+
+@pytest.mark.asyncio
+async def test_download_local_file_success(
+	client, project_and_auth, set_system_fields, tmp_path, monkeypatch
+):
+	"""When no s3_key is set but file_path points at a real local file under
+	LOCAL_AUDIO_STORAGE_PATH, the endpoint streams it from disk (issue #292)."""
+	from src.config import settings
+
+	monkeypatch.setattr(settings, "LOCAL_AUDIO_STORAGE_PATH", str(tmp_path))
+	project_id, headers = project_and_auth
+
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "Local Episode", "description": "Desc"}
+	})
+	episode_id = create_response.json()["id"]
+
+	audio = b"LOCAL_MP3_CONTENT_" * 16
+	audio_path = tmp_path / "episode-local.mp3"
+	audio_path.write_bytes(audio)
+
+	await set_system_fields(
+		episode_id, generation_status="complete", file_path=str(audio_path)
+	)
+
+	response = await client.get(f"/episodes/{episode_id}/download", headers=headers)
+
+	assert response.status_code == 200
+	assert response.headers["content-type"] == "audio/mpeg"
+	assert int(response.headers["content-length"]) == len(audio)
+	assert response.content == audio
+
+
+@pytest.mark.asyncio
+async def test_download_local_file_range_206(
+	client, project_and_auth, set_system_fields, tmp_path, monkeypatch
+):
+	"""A Range request against a locally stored file returns 206 with the correct slice."""
+	from src.config import settings
+
+	monkeypatch.setattr(settings, "LOCAL_AUDIO_STORAGE_PATH", str(tmp_path))
+	project_id, headers = project_and_auth
+
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "Local Range Episode", "description": "Desc"}
+	})
+	episode_id = create_response.json()["id"]
+
+	audio = bytes(range(256)) * 8  # 2048 bytes
+	audio_path = tmp_path / "episode-local.mp3"
+	audio_path.write_bytes(audio)
+	total_size = len(audio)
+	range_start, range_end = 100, 199
+
+	await set_system_fields(
+		episode_id, generation_status="complete", file_path=str(audio_path)
+	)
+
+	response = await client.get(
+		f"/episodes/{episode_id}/download",
+		headers={**headers, "Range": f"bytes={range_start}-{range_end}"}
+	)
+
+	assert response.status_code == 206
+	assert response.headers["content-range"] == f"bytes {range_start}-{range_end}/{total_size}"
+	assert int(response.headers["content-length"]) == 100
+	assert response.content == audio[range_start:range_end + 1]

--- a/apps/api/tests/test_episodes.py
+++ b/apps/api/tests/test_episodes.py
@@ -1522,6 +1522,9 @@ async def test_batch_create_episodes_quota_exceeded(client, test_db):
 	await test_db.flush()
 
 	# A batch of 3 would exceed the single remaining slot → rejected before any write.
+	before = await client.get(f"/episodes?project_id={project_id}", headers=headers)
+	episodes_before = before.json()["total"]
+
 	response = await client.post("/episodes/batch", headers=headers, json={
 		"episodes": [
 			{"project_id": project_id, "episode_metadata": {"title": f"B{n}", "description": "d"}}
@@ -1530,6 +1533,11 @@ async def test_batch_create_episodes_quota_exceeded(client, test_db):
 	})
 	assert response.status_code == 402
 	assert "limit" in response.json()["detail"].lower()
+
+	# Confirm the rejection actually happened before any write — no partial
+	# batch episodes were persisted.
+	after = await client.get(f"/episodes?project_id={project_id}", headers=headers)
+	assert after.json()["total"] == episodes_before
 
 
 # ============================================================================

--- a/apps/api/tests/test_quality_metrics_endpoint.py
+++ b/apps/api/tests/test_quality_metrics_endpoint.py
@@ -14,6 +14,8 @@ Tests cover:
 import pytest
 from uuid import uuid4
 
+from src.routers.quality_metrics import _overall_score
+
 
 # ============================================================================
 # FIXTURES
@@ -213,6 +215,59 @@ async def test_get_episode_quality_metrics_not_found(client, user_project_episod
 
 
 @pytest.mark.asyncio
+async def test_get_episode_quality_metrics_malformed_data(client, user_project_episode, set_system_fields):
+	"""Test 422 when stored quality_metrics is missing required fields."""
+	project_id, episode_id, headers = user_project_episode
+
+	await set_system_fields(
+		episode_id,
+		generation_status="complete",
+		generation_progress={
+			"stage": "complete",
+			"progress": 100,
+			# Missing required fields (total_words, coherence_score, etc.)
+			"quality_metrics": {"tone": "casual"},
+		},
+	)
+
+	response = await client.get(
+		f"/quality-metrics/episodes/{episode_id}",
+		headers=headers,
+	)
+	assert response.status_code == 422
+	assert str(episode_id) in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_get_episode_quality_metrics_uses_stored_calculated_at(
+	client, user_project_episode, set_system_fields
+):
+	"""Test that a stored `calculated_at` ISO string is parsed and returned
+	rather than falling back to the episode's updated_at."""
+	project_id, episode_id, headers = user_project_episode
+	stored_calculated_at = "2025-01-15T10:30:00"
+
+	await set_system_fields(
+		episode_id,
+		generation_status="complete",
+		generation_progress={
+			"stage": "complete",
+			"progress": 100,
+			"calculated_at": stored_calculated_at,
+			"quality_metrics": SAMPLE_QUALITY_METRICS,
+		},
+	)
+
+	response = await client.get(
+		f"/quality-metrics/episodes/{episode_id}",
+		headers=headers,
+	)
+	assert response.status_code == 200
+	data = response.json()
+	assert data["calculated_at"].startswith("2025-01-15T10:30:00")
+
+
+@pytest.mark.asyncio
 async def test_get_episode_quality_metrics_unauthorized(client, episode_with_metrics):
 	"""Test 401 without authentication."""
 	project_id, episode_id, headers = episode_with_metrics
@@ -338,6 +393,74 @@ async def test_get_project_quality_metrics_multiple_episodes(client, user_projec
 
 
 @pytest.mark.asyncio
+async def test_get_project_quality_metrics_trend_improving(client, user_project_episode, set_system_fields):
+	"""Test trend direction is 'improving' when the later episode scores higher."""
+	project_id, episode_id, headers = user_project_episode
+
+	# First (older) episode has poor metrics
+	await set_system_fields(episode_id, generation_progress={
+		"stage": "complete",
+		"quality_metrics": POOR_QUALITY_METRICS,
+	})
+
+	# Second (recent) episode has good metrics
+	ep2 = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 2,
+		"episode_metadata": {
+			"title": "Improved Episode",
+			"description": "Improved quality",
+		},
+	})
+	await set_system_fields(ep2.json()["id"], generation_progress={
+		"stage": "complete",
+		"quality_metrics": SAMPLE_QUALITY_METRICS,
+	})
+
+	response = await client.get(
+		f"/quality-metrics/projects/{project_id}",
+		headers=headers,
+	)
+	assert response.status_code == 200
+	assert response.json()["trend"]["direction"] == "improving"
+
+
+@pytest.mark.asyncio
+async def test_get_project_quality_metrics_trend_stable_with_two_episodes(
+	client, user_project_episode, set_system_fields
+):
+	"""Test trend direction is 'stable' when both episodes score identically."""
+	project_id, episode_id, headers = user_project_episode
+
+	await set_system_fields(episode_id, generation_progress={
+		"stage": "complete",
+		"quality_metrics": SAMPLE_QUALITY_METRICS,
+	})
+
+	ep2 = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 2,
+		"episode_metadata": {
+			"title": "Identical Episode",
+			"description": "Same quality",
+		},
+	})
+	await set_system_fields(ep2.json()["id"], generation_progress={
+		"stage": "complete",
+		"quality_metrics": SAMPLE_QUALITY_METRICS,
+	})
+
+	response = await client.get(
+		f"/quality-metrics/projects/{project_id}",
+		headers=headers,
+	)
+	assert response.status_code == 200
+	data = response.json()
+	assert data["trend"]["direction"] == "stable"
+	assert data["trend"]["trend_score"] == 0.0
+
+
+@pytest.mark.asyncio
 async def test_get_project_quality_metrics_not_found(client, user_project_episode):
 	"""Test 404 for non-existent project."""
 	project_id, episode_id, headers = user_project_episode
@@ -348,6 +471,23 @@ async def test_get_project_quality_metrics_not_found(client, user_project_episod
 		headers=headers,
 	)
 	assert response.status_code == 404
+
+
+# ============================================================================
+# _overall_score helper (pure function, unit-level)
+# ============================================================================
+
+def test_overall_score_returns_zero_when_no_overall_dimension_present():
+	"""_overall_score should default to 0.0 if the list has no 'overall' entry."""
+	from src.schemas.quality_metrics import QualityScore
+
+	scores = [QualityScore(dimension="coherence", score=0.9, rating="excellent")]
+
+	assert _overall_score(scores) == 0.0
+
+
+def test_overall_score_returns_zero_for_empty_list():
+	assert _overall_score([]) == 0.0
 
 
 # ============================================================================

--- a/apps/api/tests/test_rss_feed.py
+++ b/apps/api/tests/test_rss_feed.py
@@ -9,6 +9,9 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+from src.routers.rss_feed import _fetch_rss_from_s3, get_rss_service
+from src.services.rss_generation_service import RSSGenerationService
+
 
 # ============================================================================
 # SHARED FIXTURES
@@ -317,6 +320,28 @@ async def test_update_rss_feed_requires_auth(client, project_with_metadata):
 
 
 @pytest.mark.asyncio
+async def test_update_rss_feed_invalid_metadata(client, project_with_metadata):
+	"""Test 422 when regeneration fails because merged metadata is missing required fields."""
+	project_id, headers = project_with_metadata
+
+	with patch("src.routers.rss_feed.RSSGenerationService") as MockService:
+		mock_instance = AsyncMock()
+		mock_instance.generate_rss_for_project.side_effect = ValueError(
+			"podcast_metadata missing required field: 'author'"
+		)
+		MockService.return_value = mock_instance
+
+		response = await client.put(
+			f"/projects/{project_id}/rss-feed",
+			headers=headers,
+			json={"podcast_metadata": {"show_title": "New Title"}},
+		)
+
+	assert response.status_code == 422
+	assert "author" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
 async def test_update_rss_feed_internal_error_hides_details(client, project_with_metadata):
 	"""500 during regeneration returns a generic message, not exception internals."""
 	project_id, headers = project_with_metadata
@@ -458,3 +483,40 @@ async def test_public_feed_accessible_without_jwt(client, project_with_metadata)
 
 	# Should succeed without auth
 	assert response.status_code == 200
+
+
+# ============================================================================
+# Dependency provider / internal helper unit tests
+#
+# get_rss_service is a *synchronous* FastAPI dependency, so when it is
+# resolved through a live HTTP request it runs inside Starlette's
+# threadpool executor and is invisible to coverage (.coveragerc only
+# configures `concurrency = greenlet`, not `thread`). Call it directly here
+# so it executes on the main test thread.
+# ============================================================================
+
+def test_get_rss_service_returns_service_instance():
+	"""get_rss_service() should construct a fresh RSSGenerationService."""
+	service = get_rss_service()
+
+	assert isinstance(service, RSSGenerationService)
+
+
+@pytest.mark.asyncio
+async def test_fetch_rss_from_s3_downloads_and_reads_file():
+	"""_fetch_rss_from_s3 should download the S3 object to a temp file, read
+	its bytes, and clean up the temp file afterwards."""
+	xml_bytes = b'<?xml version="1.0"?><rss version="2.0"><channel><title>T</title></channel></rss>'
+
+	async def fake_download_file(s3_key, local_path):
+		with open(local_path, "wb") as f:
+			f.write(xml_bytes)
+		return local_path
+
+	rss_service = MagicMock()
+	rss_service.storage.download_file = AsyncMock(side_effect=fake_download_file)
+
+	result = await _fetch_rss_from_s3(rss_service, "rss-feeds/some-project/feed.xml")
+
+	assert result == xml_bytes
+	rss_service.storage.download_file.assert_awaited_once()

--- a/apps/api/tests/unit/conftest.py
+++ b/apps/api/tests/unit/conftest.py
@@ -2,6 +2,7 @@
 Minimal conftest for unit tests — sets required env vars without loading the full app.
 """
 import os
+from uuid import UUID, uuid4
 
 # Set required environment variables before any src imports
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://x:x@localhost/x")
@@ -9,3 +10,28 @@ os.environ.setdefault("ENCRYPTION_KEY", "a" * 32)
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-unit-tests")
 os.environ.setdefault("CELERY_TASK_ALWAYS_EAGER", "true")
 os.environ.setdefault("ENVIRONMENT", "test")
+
+
+async def _register_user(
+	client,
+	email: str | None = None,
+	*,
+	email_prefix: str = "unit_test_",
+	full_name: str = "Unit Test User",
+) -> UUID:
+	"""Register a real user via the auth flow and return their user id.
+
+	Shared by service-layer unit tests (billing_service, team_service, ...)
+	that need a real, persisted user for FK-backed rows rather than a bare
+	uuid4(). Uses the same `client` (bound to the shared `test_db` session)
+	so the row is visible to direct service-layer calls in the same test.
+	"""
+	if email is None:
+		email = f"{email_prefix}{uuid4()}@example.com"
+	response = await client.post("/auth/register", json={
+		"email": email,
+		"password": "SecurePass123!",
+		"full_name": full_name,
+	})
+	assert response.status_code == 201, response.text
+	return UUID(response.json()["user"]["id"])

--- a/apps/api/tests/unit/test_billing_unit.py
+++ b/apps/api/tests/unit/test_billing_unit.py
@@ -6,9 +6,12 @@ These tests do not require a database connection.
 import types
 from typing import Any, Callable
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
+
+from tests.unit.conftest import _register_user
 
 
 # ---------------------------------------------------------------------------
@@ -109,7 +112,7 @@ class TestStripeEnabled:
 		"""When stripe module is unavailable, _stripe_enabled should be False."""
 		import src.services.billing_service as bs
 		monkeypatch.setattr(bs, "_STRIPE_AVAILABLE", False)
-		monkeypatch.setattr(bs, "_get_stripe_key", lambda: "sk_test_fake")
+		monkeypatch.setattr(bs, "_get_stripe_key", lambda: "fake-stripe-key")
 		assert bs._stripe_enabled() is False
 
 
@@ -210,7 +213,7 @@ def _enable_stripe(
 	fake.error = types.SimpleNamespace(SignatureVerificationError=_SigError)
 	monkeypatch.setattr(bs, "_STRIPE_AVAILABLE", True)
 	monkeypatch.setattr(bs, "_stripe_module", fake)
-	monkeypatch.setattr(bs, "_get_stripe_key", lambda: "sk_test_fake")
+	monkeypatch.setattr(bs, "_get_stripe_key", lambda: "fake-stripe-key")
 	return bs, _SigError
 
 
@@ -272,3 +275,255 @@ class TestStripeSettings:
 		from src.config import settings
 		assert hasattr(settings, "STRIPE_SECRET_KEY")
 		assert hasattr(settings, "STRIPE_WEBHOOK_SECRET")
+
+
+# ---------------------------------------------------------------------------
+# _get_stripe_key (real body, not monkeypatched)
+# ---------------------------------------------------------------------------
+
+
+class TestGetStripeKeyReal:
+	def test_returns_none_when_unconfigured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+		from src.config import settings
+		from src.services.billing_service import _get_stripe_key
+		monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", None, raising=False)
+		assert _get_stripe_key() is None
+
+	def test_returns_configured_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+		from src.config import settings
+		from src.services.billing_service import _get_stripe_key
+		monkeypatch.setattr(settings, "STRIPE_SECRET_KEY", "fake-stripe-key", raising=False)
+		assert _get_stripe_key() == "fake-stripe-key"
+
+
+# ---------------------------------------------------------------------------
+# get_subscription (plain lookup, not the get-or-create variant)
+# ---------------------------------------------------------------------------
+
+
+class TestGetSubscriptionPlain:
+	@pytest.mark.asyncio
+	async def test_returns_none_when_absent(self, test_db) -> None:
+		from uuid import uuid4
+		from src.services.billing_service import get_subscription
+		assert await get_subscription(test_db, uuid4()) is None
+
+	@pytest.mark.asyncio
+	async def test_returns_existing_subscription(self, test_db, client) -> None:
+		from src.services.billing_service import get_or_create_subscription, get_subscription
+		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
+		tenant_id = uuid4()
+		created = await get_or_create_subscription(test_db, user_id, tenant_id)
+		fetched = await get_subscription(test_db, user_id)
+		assert fetched is not None
+		assert fetched.id == created.id
+
+
+# ---------------------------------------------------------------------------
+# create_checkout_session — invalid tier and real-Stripe branches
+# ---------------------------------------------------------------------------
+
+
+class TestCreateCheckoutInvalidTier:
+	@pytest.mark.asyncio
+	async def test_invalid_tier_raises_400(self, test_db) -> None:
+		from uuid import uuid4
+		from src.services.billing_service import create_checkout_session
+		with pytest.raises(HTTPException) as exc:
+			await create_checkout_session(test_db, uuid4(), uuid4(), "invalid_tier")
+		assert exc.value.status_code == 400
+
+
+def _enable_fake_stripe_sdk(monkeypatch: pytest.MonkeyPatch):
+	"""Enable billing_service's real-Stripe code path with a fake stripe SDK.
+
+	The real `stripe` package isn't installed in this environment, so the
+	Customer/Session creation calls are faked to exercise create_checkout_session's
+	Stripe-enabled branch (lines otherwise unreachable in mock mode).
+	"""
+	import src.services.billing_service as bs
+
+	fake_customer = types.SimpleNamespace(id="cus_fake123")
+	fake_session = types.SimpleNamespace(url="https://checkout.stripe.com/session/test")
+	fake = types.SimpleNamespace(
+		api_key=None,
+		Customer=types.SimpleNamespace(create=lambda **kwargs: fake_customer),
+		checkout=types.SimpleNamespace(
+			Session=types.SimpleNamespace(create=lambda **kwargs: fake_session)
+		),
+	)
+	monkeypatch.setattr(bs, "_STRIPE_AVAILABLE", True)
+	monkeypatch.setattr(bs, "_stripe_module", fake)
+	monkeypatch.setattr(bs, "_get_stripe_key", lambda: "fake-stripe-key")
+	return bs
+
+
+class TestCreateCheckoutStripeEnabled:
+	@pytest.mark.asyncio
+	async def test_creates_stripe_session_for_new_customer(
+		self, test_db, client, monkeypatch: pytest.MonkeyPatch
+	) -> None:
+		bs = _enable_fake_stripe_sdk(monkeypatch)
+		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
+		tenant_id = uuid4()
+
+		result = await bs.create_checkout_session(test_db, user_id, tenant_id, "pro")
+
+		assert result["checkout_url"] == "https://checkout.stripe.com/session/test"
+		sub = await bs.get_subscription(test_db, user_id)
+		assert sub.stripe_customer_id == "cus_fake123"
+
+	@pytest.mark.asyncio
+	async def test_reuses_existing_stripe_customer(
+		self, test_db, client, monkeypatch: pytest.MonkeyPatch
+	) -> None:
+		bs = _enable_fake_stripe_sdk(monkeypatch)
+		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
+		tenant_id = uuid4()
+		sub = await bs.get_or_create_subscription(test_db, user_id, tenant_id)
+		sub.stripe_customer_id = "cus_existing"
+		await test_db.commit()
+
+		result = await bs.create_checkout_session(test_db, user_id, tenant_id, "pro")
+
+		assert result["checkout_url"] == "https://checkout.stripe.com/session/test"
+		await test_db.refresh(sub)
+		assert sub.stripe_customer_id == "cus_existing"
+
+	@pytest.mark.asyncio
+	async def test_enterprise_requires_custom_pricing(
+		self, test_db, client, monkeypatch: pytest.MonkeyPatch
+	) -> None:
+		bs = _enable_fake_stripe_sdk(monkeypatch)
+		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
+		with pytest.raises(HTTPException) as exc:
+			await bs.create_checkout_session(test_db, user_id, uuid4(), "enterprise")
+		assert exc.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# update_subscription_tier — unknown tier branch
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateSubscriptionTierUnknown:
+	@pytest.mark.asyncio
+	async def test_unknown_tier_raises_400(self, test_db) -> None:
+		from uuid import uuid4
+		from src.services.billing_service import update_subscription_tier
+		with pytest.raises(HTTPException) as exc:
+			await update_subscription_tier(test_db, uuid4(), uuid4(), "bogus_tier")
+		assert exc.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# _handle_subscription_updated / _handle_subscription_deleted (direct calls)
+# ---------------------------------------------------------------------------
+
+
+class TestHandleSubscriptionUpdatedDirect:
+	@pytest.mark.asyncio
+	async def test_updates_matching_subscription(self, test_db, client) -> None:
+		from src.models.billing_subscription import SubscriptionStatus
+		from src.services.billing_service import (
+			_handle_subscription_updated,
+			get_or_create_subscription,
+		)
+		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
+		tenant_id = uuid4()
+		sub = await get_or_create_subscription(test_db, user_id, tenant_id)
+		sub.stripe_customer_id = "cus_matched"
+		await test_db.commit()
+
+		await _handle_subscription_updated(
+			test_db, {"id": "sub_123", "customer": "cus_matched", "status": "past_due"}
+		)
+
+		await test_db.refresh(sub)
+		assert sub.stripe_subscription_id == "sub_123"
+		assert sub.status == SubscriptionStatus.PAST_DUE
+
+	@pytest.mark.asyncio
+	async def test_no_matching_subscription_is_a_noop(self, test_db) -> None:
+		from src.services.billing_service import _handle_subscription_updated
+		# Should return quietly; no subscription has this customer id.
+		await _handle_subscription_updated(
+			test_db, {"id": "sub_x", "customer": "cus_does_not_exist", "status": "active"}
+		)
+
+
+class TestHandleSubscriptionDeletedDirect:
+	@pytest.mark.asyncio
+	async def test_cancels_and_downgrades_matching_subscription(self, test_db, client) -> None:
+		from src.models.billing_subscription import SubscriptionStatus, SubscriptionTier
+		from src.services.billing_service import (
+			_handle_subscription_deleted,
+			get_or_create_subscription,
+			update_subscription_tier,
+		)
+		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
+		tenant_id = uuid4()
+		sub = await get_or_create_subscription(test_db, user_id, tenant_id)
+		await update_subscription_tier(test_db, user_id, tenant_id, "pro")
+		sub.stripe_customer_id = "cus_deleted"
+		await test_db.commit()
+
+		await _handle_subscription_deleted(test_db, {"customer": "cus_deleted"})
+
+		await test_db.refresh(sub)
+		assert sub.status == SubscriptionStatus.CANCELED
+		assert sub.tier == SubscriptionTier.FREE
+		assert sub.canceled_at is not None
+
+	@pytest.mark.asyncio
+	async def test_no_matching_subscription_is_a_noop(self, test_db) -> None:
+		from src.services.billing_service import _handle_subscription_deleted
+		await _handle_subscription_deleted(test_db, {"customer": "cus_does_not_exist_either"})
+
+
+# ---------------------------------------------------------------------------
+# process_webhook — full dispatch to the subscription handlers (real db)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessWebhookDispatchesToHandlers:
+	@pytest.mark.asyncio
+	async def test_subscription_updated_event_updates_db(
+		self, test_db, client, monkeypatch: pytest.MonkeyPatch
+	) -> None:
+		construct_event = MagicMock(return_value={
+			"type": "customer.subscription.updated",
+			"data": {"object": {"id": "sub_new", "customer": "cus_dispatch", "status": "active"}},
+		})
+		bs, _ = _enable_stripe(monkeypatch, construct_event)
+		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
+		sub = await bs.get_or_create_subscription(test_db, user_id, uuid4())
+		sub.stripe_customer_id = "cus_dispatch"
+		await test_db.commit()
+
+		result = await bs.process_webhook(test_db, b"{}", "sig", "whsec_test")
+
+		assert result["event_type"] == "customer.subscription.updated"
+		await test_db.refresh(sub)
+		assert sub.stripe_subscription_id == "sub_new"
+
+	@pytest.mark.asyncio
+	async def test_subscription_deleted_event_updates_db(
+		self, test_db, client, monkeypatch: pytest.MonkeyPatch
+	) -> None:
+		from src.models.billing_subscription import SubscriptionStatus
+		construct_event = MagicMock(return_value={
+			"type": "customer.subscription.deleted",
+			"data": {"object": {"customer": "cus_dispatch2"}},
+		})
+		bs, _ = _enable_stripe(monkeypatch, construct_event)
+		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
+		sub = await bs.get_or_create_subscription(test_db, user_id, uuid4())
+		sub.stripe_customer_id = "cus_dispatch2"
+		await test_db.commit()
+
+		result = await bs.process_webhook(test_db, b"{}", "sig", "whsec_test")
+
+		assert result["event_type"] == "customer.subscription.deleted"
+		await test_db.refresh(sub)
+		assert sub.status == SubscriptionStatus.CANCELED

--- a/apps/api/tests/unit/test_billing_unit.py
+++ b/apps/api/tests/unit/test_billing_unit.py
@@ -444,12 +444,29 @@ class TestHandleSubscriptionUpdatedDirect:
 		assert sub.status == SubscriptionStatus.PAST_DUE
 
 	@pytest.mark.asyncio
-	async def test_no_matching_subscription_is_a_noop(self, test_db) -> None:
-		from src.services.billing_service import _handle_subscription_updated
+	async def test_no_matching_subscription_is_a_noop(self, test_db, client) -> None:
+		from src.models.billing_subscription import SubscriptionStatus
+		from src.services.billing_service import (
+			_handle_subscription_updated,
+			get_or_create_subscription,
+		)
+		# Seed an existing subscription in a state distinct from what a match
+		# would produce, so a false match would be visible below.
+		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
+		sub = await get_or_create_subscription(test_db, user_id, uuid4())
+		sub.stripe_customer_id = "cus_unrelated"
+		sub.status = SubscriptionStatus.PAST_DUE
+		sub.stripe_subscription_id = "sub_preexisting"
+		await test_db.commit()
+
 		# Should return quietly; no subscription has this customer id.
 		await _handle_subscription_updated(
 			test_db, {"id": "sub_x", "customer": "cus_does_not_exist", "status": "active"}
 		)
+
+		await test_db.refresh(sub)
+		assert sub.status == SubscriptionStatus.PAST_DUE
+		assert sub.stripe_subscription_id == "sub_preexisting"
 
 
 class TestHandleSubscriptionDeletedDirect:
@@ -476,9 +493,28 @@ class TestHandleSubscriptionDeletedDirect:
 		assert sub.canceled_at is not None
 
 	@pytest.mark.asyncio
-	async def test_no_matching_subscription_is_a_noop(self, test_db) -> None:
-		from src.services.billing_service import _handle_subscription_deleted
+	async def test_no_matching_subscription_is_a_noop(self, test_db, client) -> None:
+		from src.models.billing_subscription import SubscriptionStatus, SubscriptionTier
+		from src.services.billing_service import (
+			_handle_subscription_deleted,
+			get_or_create_subscription,
+			update_subscription_tier,
+		)
+		# Seed an existing paid subscription; a false match here would cancel
+		# and downgrade it, which the assertions below would catch.
+		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
+		tenant_id = uuid4()
+		sub = await get_or_create_subscription(test_db, user_id, tenant_id)
+		await update_subscription_tier(test_db, user_id, tenant_id, "pro")
+		sub.stripe_customer_id = "cus_unrelated_2"
+		await test_db.commit()
+
 		await _handle_subscription_deleted(test_db, {"customer": "cus_does_not_exist_either"})
+
+		await test_db.refresh(sub)
+		assert sub.tier == SubscriptionTier.PRO
+		assert sub.status == SubscriptionStatus.ACTIVE
+		assert sub.canceled_at is None
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/unit/test_team_service_unit.py
+++ b/apps/api/tests/unit/test_team_service_unit.py
@@ -1,0 +1,221 @@
+"""
+Direct service-layer unit tests for team_service.py.
+
+These call the async service functions directly against a real AsyncSession
+(the `test_db` fixture) instead of going through the router. Some branches
+are unreachable through the API: every team route asserts membership via
+`rbac_service.assert_permission` before calling into team_service, which
+always returns 403 for a non-member — so team_service.get_team's own 404
+for a nonexistent team, and similar not-found branches, can only be
+exercised by calling the service layer directly.
+"""
+
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from src.models.team_invitation import TeamInvitation
+from src.models.team_member import TeamMember
+from src.schemas.team import TeamCreate
+from src.services import team_service
+from tests.unit.conftest import _register_user
+
+
+class TestGetTeamNotFound:
+	@pytest.mark.asyncio
+	async def test_raises_404_for_nonexistent_team(self, test_db):
+		with pytest.raises(HTTPException) as exc:
+			await team_service.get_team(test_db, uuid4())
+		assert exc.value.status_code == 404
+
+
+class TestUpdateTeamPartialUpdate:
+	@pytest.mark.asyncio
+	async def test_only_provided_fields_are_updated(self, test_db, client):
+		owner_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		team = await team_service.create_team(
+			test_db, owner_id, TeamCreate(name="Original Name", description="Original Description")
+		)
+
+		from src.schemas.team import TeamUpdate
+
+		updated = await team_service.update_team(
+			test_db, team.id, TeamUpdate(description="New Description")
+		)
+		assert updated.name == "Original Name"
+		assert updated.description == "New Description"
+
+
+class TestDeleteTeam:
+	@pytest.mark.asyncio
+	async def test_delete_team_removes_it(self, test_db, client):
+		owner_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		team = await team_service.create_team(test_db, owner_id, TeamCreate(name="Doomed Team"))
+
+		await team_service.delete_team(test_db, team.id)
+
+		with pytest.raises(HTTPException) as exc:
+			await team_service.get_team(test_db, team.id)
+		assert exc.value.status_code == 404
+
+
+class TestGetMemberCount:
+	@pytest.mark.asyncio
+	async def test_counts_only_active_members(self, test_db, client):
+		owner_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		team = await team_service.create_team(test_db, owner_id, TeamCreate(name="Count Team"))
+		assert await team_service.get_member_count(test_db, team.id) == 1
+
+		other_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		test_db.add(TeamMember(team_id=team.id, user_id=other_id, role="viewer", status="suspended"))
+		await test_db.commit()
+
+		# Suspended members should not count.
+		assert await team_service.get_member_count(test_db, team.id) == 1
+
+
+class TestUpdateMemberRoleNotFound:
+	@pytest.mark.asyncio
+	async def test_raises_404_when_member_missing(self, test_db, client):
+		owner_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		team = await team_service.create_team(test_db, owner_id, TeamCreate(name="No Member Team"))
+		with pytest.raises(HTTPException) as exc:
+			await team_service.update_member_role(test_db, team.id, uuid4(), "editor")
+		assert exc.value.status_code == 404
+
+
+class TestUpdateMemberRoleSuccess:
+	@pytest.mark.asyncio
+	async def test_changes_role_and_persists(self, test_db, client):
+		owner_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		team = await team_service.create_team(test_db, owner_id, TeamCreate(name="Role Team"))
+		member_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		test_db.add(TeamMember(team_id=team.id, user_id=member_id, role="viewer", status="active"))
+		await test_db.commit()
+
+		updated = await team_service.update_member_role(test_db, team.id, member_id, "analyst")
+		assert updated.role == "analyst"
+		assert updated.user_id == member_id
+
+
+class TestRemoveMemberNotFound:
+	@pytest.mark.asyncio
+	async def test_raises_404_when_member_missing(self, test_db, client):
+		owner_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		team = await team_service.create_team(test_db, owner_id, TeamCreate(name="No Member Team 2"))
+		with pytest.raises(HTTPException) as exc:
+			await team_service.remove_member(test_db, team.id, uuid4())
+		assert exc.value.status_code == 404
+
+
+class TestRemoveMemberSuccess:
+	@pytest.mark.asyncio
+	async def test_removes_existing_member(self, test_db, client):
+		owner_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		team = await team_service.create_team(test_db, owner_id, TeamCreate(name="Removal Team"))
+		member_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		test_db.add(TeamMember(team_id=team.id, user_id=member_id, role="viewer", status="active"))
+		await test_db.commit()
+
+		await team_service.remove_member(test_db, team.id, member_id)
+
+		remaining = await team_service.get_members(test_db, team.id)
+		assert member_id not in [m.user_id for m in remaining]
+
+
+class TestAcceptInvitationExpired:
+	@pytest.mark.asyncio
+	async def test_expired_invitation_rejected_and_marked_expired(self, test_db, client):
+		owner_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		invitee_email = f"expired_{uuid4()}@example.com"
+		invitee_id = await _register_user(client, invitee_email, full_name="Team Unit Test User")
+
+		team = await team_service.create_team(test_db, owner_id, TeamCreate(name="Expired Invite Team"))
+
+		token = "expired-token-" + uuid4().hex
+		invitation = TeamInvitation(
+			team_id=team.id,
+			inviter_id=owner_id,
+			email=invitee_email,
+			role="viewer",
+			token=token,
+			status="pending",
+			expires_at=datetime.utcnow() - timedelta(days=1),
+		)
+		test_db.add(invitation)
+		await test_db.commit()
+
+		with pytest.raises(HTTPException) as exc:
+			await team_service.accept_invitation(test_db, token, invitee_id, invitee_email)
+		assert exc.value.status_code == 400
+		assert "expired" in exc.value.detail.lower()
+
+		await test_db.refresh(invitation)
+		assert invitation.status == "expired"
+
+
+class TestAcceptInvitationAlreadyMember:
+	@pytest.mark.asyncio
+	async def test_already_member_rejected(self, test_db, client):
+		owner_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		member_email = f"already_{uuid4()}@example.com"
+		member_id = await _register_user(client, member_email, full_name="Team Unit Test User")
+
+		team = await team_service.create_team(test_db, owner_id, TeamCreate(name="Already Member Team"))
+
+		# The invitee is already an active member of the team.
+		test_db.add(TeamMember(team_id=team.id, user_id=member_id, role="viewer", status="active"))
+		await test_db.commit()
+
+		# A separate pending invitation exists for the same team/email.
+		token = "already-token-" + uuid4().hex
+		invitation = TeamInvitation(
+			team_id=team.id,
+			inviter_id=owner_id,
+			email=member_email,
+			role="viewer",
+			token=token,
+			status="pending",
+			expires_at=datetime.utcnow() + timedelta(days=7),
+		)
+		test_db.add(invitation)
+		await test_db.commit()
+
+		with pytest.raises(HTTPException) as exc:
+			await team_service.accept_invitation(test_db, token, member_id, member_email)
+		assert exc.value.status_code == 400
+		assert "already a member" in exc.value.detail.lower()
+
+
+class TestAcceptInvitationSuccess:
+	@pytest.mark.asyncio
+	async def test_accept_creates_active_membership(self, test_db, client):
+		owner_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		invitee_email = f"accept_{uuid4()}@example.com"
+		invitee_id = await _register_user(client, invitee_email, full_name="Team Unit Test User")
+
+		team = await team_service.create_team(test_db, owner_id, TeamCreate(name="Accept Team"))
+
+		token = "accept-token-" + uuid4().hex
+		invitation = TeamInvitation(
+			team_id=team.id,
+			inviter_id=owner_id,
+			email=invitee_email,
+			role="editor",
+			token=token,
+			status="pending",
+			expires_at=datetime.utcnow() + timedelta(days=7),
+		)
+		test_db.add(invitation)
+		await test_db.commit()
+
+		membership = await team_service.accept_invitation(test_db, token, invitee_id, invitee_email)
+		assert membership.role == "editor"
+		assert membership.status == "active"
+		assert membership.user_id == invitee_id
+
+		await test_db.refresh(invitation)
+		assert invitation.status == "accepted"
+		assert invitation.accepted_at is not None

--- a/apps/web/__mocks__/@hugeicons/core-free-icons.ts
+++ b/apps/web/__mocks__/@hugeicons/core-free-icons.ts
@@ -7,6 +7,7 @@ export const ArrowDown01Icon = mockIcon
 export const ArrowUp01Icon = mockIcon
 export const FolderOpenIcon = mockIcon
 export const Inbox01Icon = mockIcon
+export const InboxIcon = mockIcon
 export const FileEditIcon = mockIcon
 export const MusicNote01Icon = mockIcon
 export const Alert02Icon = mockIcon

--- a/apps/web/__tests__/app/api/auth/route.test.ts
+++ b/apps/web/__tests__/app/api/auth/route.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment node
+ *
+ * The NextAuth route handler is just glue: it wires the shared authOptions
+ * (tested separately in __tests__/lib/auth.test.ts) into the NextAuth()
+ * factory and re-exports the resulting handler for GET and POST.
+ */
+jest.mock('next-auth', () => ({
+  __esModule: true,
+  default: jest.fn(() => 'nextauth-handler'),
+}))
+
+jest.mock('@/lib/auth', () => ({
+  authOptions: { providers: [] },
+}))
+
+import NextAuth from 'next-auth'
+import { GET, POST } from '@/app/api/auth/[...nextauth]/route'
+import { authOptions } from '@/lib/auth'
+
+const nextAuthMock = NextAuth as unknown as jest.Mock
+
+describe('NextAuth route handler', () => {
+  it('configures NextAuth with the shared authOptions', () => {
+    expect(nextAuthMock).toHaveBeenCalledWith(authOptions)
+  })
+
+  it('exports the same handler for both GET and POST', () => {
+    expect(GET).toBe('nextauth-handler')
+    expect(POST).toBe('nextauth-handler')
+    expect(GET).toBe(POST)
+  })
+})

--- a/apps/web/__tests__/app/dashboard/page.test.tsx
+++ b/apps/web/__tests__/app/dashboard/page.test.tsx
@@ -1,14 +1,24 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import DashboardPage from '@/app/(auth)/dashboard/page'
+import { withOverride } from '../../../test-utils/fetch-router'
 
-const mockPush = jest.fn()
+let mockSessionStatus = 'authenticated'
 
-jest.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockPush }),
-}))
+// DashboardPage's load effect depends on the `router` object itself (not just
+// `router.push`), so the mock must return the SAME object on every call —
+// otherwise every render creates a new reference, retriggering the effect
+// and re-fetching projects in an infinite loop that clobbers state updates
+// made by other handlers (edit/delete) mid-test.
+jest.mock('next/navigation', () => {
+  const router = { push: jest.fn() }
+  return { useRouter: () => router }
+})
+
+const mockPush = (jest.requireMock('next/navigation').useRouter() as { push: jest.Mock }).push
 
 jest.mock('next-auth/react', () => ({
-  useSession: () => ({ status: 'authenticated' }),
+  useSession: () => ({ status: mockSessionStatus }),
 }))
 
 jest.mock('@/lib/toast', () => ({
@@ -16,23 +26,41 @@ jest.mock('@/lib/toast', () => ({
   showErrorToast: jest.fn(),
 }))
 
-const { showErrorToast } = jest.requireMock('@/lib/toast')
+const { showSuccessToast, showErrorToast } = jest.requireMock('@/lib/toast')
+
+const podcastProject = {
+  id: '1',
+  name: 'My First Podcast',
+  description: null,
+  episode_count: 2,
+  created_at: '2026-01-01',
+}
+
+type FetchRouterOpts = {
+  projects?: typeof podcastProject[]
+  listOk?: boolean
+}
+
+function mockFetchRouter({ projects = [podcastProject], listOk = true }: FetchRouterOpts = {}) {
+  return jest.fn((url: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET'
+    if (url === '/api/proxy/projects' && method === 'GET') {
+      return listOk
+        ? Promise.resolve({ ok: true, json: async () => ({ projects }) })
+        : Promise.resolve({ ok: false })
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) })
+  }) as jest.Mock
+}
 
 describe('DashboardPage', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockSessionStatus = 'authenticated'
   })
 
   it('renders projects on successful load', async () => {
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      // Real API contract: {projects: [...]} with `name` (issue #337).
-      json: async () => ({
-        projects: [
-          { id: '1', name: 'My First Podcast', description: null, episode_count: 2, created_at: '2026-01-01' },
-        ],
-      }),
-    }) as jest.Mock
+    global.fetch = mockFetchRouter()
 
     render(<DashboardPage />)
 
@@ -41,7 +69,7 @@ describe('DashboardPage', () => {
   })
 
   it('shows an error toast when the load fails', async () => {
-    global.fetch = jest.fn().mockResolvedValue({ ok: false }) as jest.Mock
+    global.fetch = mockFetchRouter({ listOk: false })
 
     render(<DashboardPage />)
 
@@ -58,5 +86,252 @@ describe('DashboardPage', () => {
     await waitFor(() => {
       expect(showErrorToast).toHaveBeenCalledWith('Failed to load projects: Network error')
     })
+  })
+
+  it('redirects to /login when unauthenticated', async () => {
+    mockSessionStatus = 'unauthenticated'
+    global.fetch = mockFetchRouter()
+
+    render(<DashboardPage />)
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/login'))
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('shows an empty state when there are no projects', async () => {
+    global.fetch = mockFetchRouter({ projects: [] })
+
+    render(<DashboardPage />)
+
+    expect(await screen.findByText('No projects yet')).toBeInTheDocument()
+  })
+
+  it('opens the create dialog from the empty state action', async () => {
+    global.fetch = mockFetchRouter({ projects: [] })
+    render(<DashboardPage />)
+    await screen.findByText('No projects yet')
+
+    const createButtons = screen.getAllByRole('button', { name: 'Create Project' })
+    await userEvent.click(createButtons[createButtons.length - 1])
+
+    expect(screen.getByLabelText(/project title/i)).toBeInTheDocument()
+  })
+
+  it('navigates to the project page when a card is clicked', async () => {
+    global.fetch = mockFetchRouter()
+    render(<DashboardPage />)
+
+    await userEvent.click(await screen.findByRole('button', { name: /open project: my first podcast/i }))
+    expect(mockPush).toHaveBeenCalledWith('/projects/1')
+  })
+
+  it('navigates to the project page on Enter key', async () => {
+    global.fetch = mockFetchRouter()
+    render(<DashboardPage />)
+
+    const card = await screen.findByRole('button', { name: /open project: my first podcast/i })
+    card.focus()
+    await userEvent.keyboard('{Enter}')
+    expect(mockPush).toHaveBeenCalledWith('/projects/1')
+  })
+
+  it('creates a project and reloads the list', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/projects' && (init?.method ?? 'GET') === 'POST', () =>
+      Promise.resolve({ ok: true, json: async () => ({}) })
+    )
+    global.fetch = fetchMock
+
+    render(<DashboardPage />)
+    await screen.findByText('My First Podcast')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Create Project' }))
+    await userEvent.type(screen.getByLabelText(/project title/i), 'New Show')
+    const submitButtons = screen.getAllByRole('button', { name: /create project/i })
+    await userEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/proxy/projects',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            name: 'New Show',
+            description: null,
+            podcast_metadata: { language: 'en', explicit: false },
+          }),
+        })
+      )
+    })
+    expect(showSuccessToast).toHaveBeenCalledWith('Project created successfully')
+  })
+
+  it('closes the create dialog without submitting when cancelled', async () => {
+    global.fetch = mockFetchRouter()
+    render(<DashboardPage />)
+    await screen.findByText('My First Podcast')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Create Project' }))
+    expect(screen.getByLabelText(/project title/i)).toBeInTheDocument()
+
+    await userEvent.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByLabelText(/project title/i)).not.toBeInTheDocument())
+  })
+
+  it('shows an error toast when project creation fails', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/projects' && (init?.method ?? 'GET') === 'POST', () =>
+      Promise.resolve({ ok: false, statusText: 'Bad Request' })
+    )
+    global.fetch = fetchMock
+
+    render(<DashboardPage />)
+    await screen.findByText('My First Podcast')
+    await userEvent.click(screen.getByRole('button', { name: 'Create Project' }))
+    await userEvent.type(screen.getByLabelText(/project title/i), 'New Show')
+    const submitButtons = screen.getAllByRole('button', { name: /create project/i })
+    await userEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to create project: Bad Request')
+    )
+  })
+
+  it('shows a network error toast when project creation throws', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/projects' && (init?.method ?? 'GET') === 'POST', () =>
+      Promise.reject(new Error('boom'))
+    )
+    global.fetch = fetchMock
+
+    render(<DashboardPage />)
+    await screen.findByText('My First Podcast')
+    await userEvent.click(screen.getByRole('button', { name: 'Create Project' }))
+    await userEvent.type(screen.getByLabelText(/project title/i), 'New Show')
+    const submitButtons = screen.getAllByRole('button', { name: /create project/i })
+    await userEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to create project: Network error')
+    )
+  })
+
+  it('updates a project title', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/projects/1' && (init?.method ?? 'GET') === 'PUT', () =>
+      Promise.resolve({ ok: true, json: async () => ({}) })
+    )
+    global.fetch = fetchMock
+
+    render(<DashboardPage />)
+    await screen.findByText('My First Podcast')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit My First Podcast' }))
+    const titleInput = screen.getByLabelText(/project title/i)
+    await userEvent.clear(titleInput)
+    await userEvent.type(titleInput, 'Renamed Show')
+    await userEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() => expect(showSuccessToast).toHaveBeenCalledWith('Project updated'))
+    expect(await screen.findByText('Renamed Show')).toBeInTheDocument()
+  })
+
+  it('shows an error toast when project update fails', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/projects/1' && (init?.method ?? 'GET') === 'PUT', () =>
+      Promise.resolve({ ok: false, statusText: 'Bad Request' })
+    )
+    global.fetch = fetchMock
+
+    render(<DashboardPage />)
+    await screen.findByText('My First Podcast')
+    await userEvent.click(screen.getByRole('button', { name: 'Edit My First Podcast' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to update project: Bad Request')
+    )
+  })
+
+  it('shows a network error toast when project update throws', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/projects/1' && (init?.method ?? 'GET') === 'PUT', () =>
+      Promise.reject(new Error('boom'))
+    )
+    global.fetch = fetchMock
+
+    render(<DashboardPage />)
+    await screen.findByText('My First Podcast')
+    await userEvent.click(screen.getByRole('button', { name: 'Edit My First Podcast' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to update project: Network error')
+    )
+  })
+
+  it('closes the edit dialog without submitting when cancelled', async () => {
+    global.fetch = mockFetchRouter()
+    render(<DashboardPage />)
+    await screen.findByText('My First Podcast')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit My First Podcast' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => expect(screen.queryByLabelText(/project title/i)).not.toBeInTheDocument())
+  })
+
+  it('deletes a project', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/projects/1' && (init?.method ?? 'GET') === 'DELETE', () =>
+      Promise.resolve({ ok: true, json: async () => ({}) })
+    )
+    global.fetch = fetchMock
+
+    render(<DashboardPage />)
+    await screen.findByText('My First Podcast')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete My First Podcast' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(showSuccessToast).toHaveBeenCalledWith('Project deleted successfully'))
+    expect(screen.queryByText('My First Podcast')).not.toBeInTheDocument()
+  })
+
+  it('shows an error toast when project deletion fails', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/projects/1' && (init?.method ?? 'GET') === 'DELETE', () =>
+      Promise.resolve({ ok: false, statusText: 'Bad Request' })
+    )
+    global.fetch = fetchMock
+
+    render(<DashboardPage />)
+    await screen.findByText('My First Podcast')
+    await userEvent.click(screen.getByRole('button', { name: 'Delete My First Podcast' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to delete project: Bad Request')
+    )
+  })
+
+  it('shows a network error toast when project deletion throws', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/projects/1' && (init?.method ?? 'GET') === 'DELETE', () =>
+      Promise.reject(new Error('boom'))
+    )
+    global.fetch = fetchMock
+
+    render(<DashboardPage />)
+    await screen.findByText('My First Podcast')
+    await userEvent.click(screen.getByRole('button', { name: 'Delete My First Podcast' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to delete project: Network error')
+    )
+  })
+
+  it('closes the delete dialog without deleting when cancelled', async () => {
+    global.fetch = mockFetchRouter()
+    render(<DashboardPage />)
+    await screen.findByText('My First Podcast')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete My First Podcast' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => expect(screen.queryByText('Delete Project?')).not.toBeInTheDocument())
+    expect(screen.getByText('My First Podcast')).toBeInTheDocument()
   })
 })

--- a/apps/web/__tests__/app/episodes/[id]/page.test.tsx
+++ b/apps/web/__tests__/app/episodes/[id]/page.test.tsx
@@ -1,11 +1,13 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import EpisodePage from '@/app/(auth)/episodes/[id]/page'
+import { withOverride } from '../../../../test-utils/fetch-router'
 
 const mockPush = jest.fn()
+const mockBack = jest.fn()
 
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockPush }),
+  useRouter: () => ({ push: mockPush, back: mockBack }),
   useParams: () => ({ id: 'ep1' }),
 }))
 
@@ -19,10 +21,24 @@ jest.mock('@/lib/toast', () => ({
 }))
 
 // SSE/polling are only wired up for active statuses; stub them so a draft
-// episode render never touches the network manager.
+// episode render never touches the network manager. Tests that need to drive
+// the SSE callbacks (complete/failed/status-change/fallback) reach in via
+// `lastRobustESOptions`, which the fake class captures on construction.
+let lastRobustESOptions: {
+  onMessage: (data: unknown) => void
+  onError?: (info: { message: string; attempt: number; maxRetries: number }) => void
+  onFallbackToPolling?: () => void
+  onStatusChange?: (status: string) => void
+} | null = null
+
+const startPollingMock = jest.fn((_options?: unknown) => jest.fn())
+
 jest.mock('@/lib/event-source-manager', () => ({
-  startPolling: jest.fn(() => jest.fn()),
+  startPolling: (options: unknown) => startPollingMock(options),
   RobustEventSource: class {
+    constructor(_url: string, options: typeof lastRobustESOptions) {
+      lastRobustESOptions = options
+    }
     connect() {}
     close() {}
   },
@@ -34,11 +50,64 @@ const draftEpisode = {
   id: 'ep1',
   episode_metadata: { title: 'Test Episode', description: 'desc' },
   generation_status: 'draft',
-  generation_progress: {},
-  s3_url: null,
+  generation_progress: {} as { progress?: number; error_message?: string; status?: string },
+  s3_url: null as string | null,
   project_id: 'p1',
-  tts_config_id: null,
+  tts_config_id: null as string | null,
   episode_number: 1,
+}
+
+// In an ACTIVE_STATUSES state so the SSE effect wires up handleMessage /
+// handleFallbackToPolling via RobustEventSource.
+const generatingEpisode = {
+  ...draftEpisode,
+  generation_status: 'generating',
+}
+
+const failedEpisode = {
+  ...draftEpisode,
+  generation_status: 'failed',
+  generation_progress: { error_message: 'TTS provider rejected the request' },
+}
+
+const completeEpisode = {
+  ...draftEpisode,
+  generation_status: 'complete',
+  s3_url: 'https://cdn.example.com/ep1.mp3',
+}
+
+// Exercises the "resume in-progress state" branches in loadEpisode: a
+// non-null saved tts_config_id and a persisted progress percentage.
+const episodeWithSavedProgress = {
+  ...draftEpisode,
+  generation_status: 'queued',
+  generation_progress: { progress: 42 },
+  tts_config_id: 'tts1',
+}
+
+// Generic router for tests that just need a specific episode/content/tts
+// fixture returned, with optional per-endpoint failure overrides layered on.
+function mockEpisodeFetchRouter({
+  episode = draftEpisode,
+  contentSources = [{ id: 'c1', source_type: 'url', source_data: { url: 'https://example.com' }, extraction_status: 'complete' }],
+  ttsConfigs = [] as Array<{ id: string; name: string; provider: string; is_default: boolean }>,
+}: {
+  episode?: typeof draftEpisode
+  contentSources?: Array<{ id: string; source_type: string; source_data: Record<string, string>; extraction_status: string }>
+  ttsConfigs?: Array<{ id: string; name: string; provider: string; is_default: boolean }>
+} = {}) {
+  return jest.fn((url: string) => {
+    if (url.includes('/generate')) {
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    }
+    if (/\/api\/proxy\/episodes\/[^/]+\/content(\?|$)/.test(url)) {
+      return Promise.resolve({ ok: true, json: async () => ({ content_sources: contentSources }) })
+    }
+    if (url.includes('/tts-configs')) {
+      return Promise.resolve({ ok: true, json: async () => ({ configs: ttsConfigs }) })
+    }
+    return Promise.resolve({ ok: true, json: async () => episode })
+  }) as jest.Mock
 }
 
 // Route the component's mount-time fetches by URL; generate POST is asserted separately.
@@ -77,6 +146,10 @@ function mockFetchRouterWithSavedConfig() {
     return Promise.resolve({ ok: true, json: async () => draftEpisode })
   }) as jest.Mock
 }
+
+beforeEach(() => {
+  lastRobustESOptions = null
+})
 
 describe('EpisodePage generate flow', () => {
   beforeEach(() => {
@@ -151,5 +224,643 @@ describe('EpisodePage TTS config selector (#299)', () => {
         })
       )
     })
+  })
+})
+
+describe('EpisodePage generate failures', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('shows an error toast when generation fails to start', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter(),
+      (url) => url.includes('/generate'),
+      () => Promise.resolve({ ok: false, statusText: 'Bad Request' })
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+
+    const generateBtn = await screen.findByRole('button', { name: /generate podcast/i })
+    await waitFor(() => expect(generateBtn).toBeEnabled())
+    await userEvent.click(generateBtn)
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to generate podcast: Bad Request')
+    )
+  })
+
+  it('shows a network error toast when generation throws', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter(),
+      (url) => url.includes('/generate'),
+      () => Promise.reject(new Error('boom'))
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+
+    const generateBtn = await screen.findByRole('button', { name: /generate podcast/i })
+    await waitFor(() => expect(generateBtn).toBeEnabled())
+    await userEvent.click(generateBtn)
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to generate podcast: Network error')
+    )
+  })
+})
+
+describe('EpisodePage SSE progress', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('shows the progress bar and connecting status for an active episode', async () => {
+    global.fetch = mockEpisodeFetchRouter({ episode: generatingEpisode })
+    render(<EpisodePage />)
+
+    await screen.findByText('Test Episode')
+    expect(screen.getByRole('progressbar', { name: /generation progress/i })).toBeInTheDocument()
+    expect(await screen.findByText('Connecting...')).toBeInTheDocument()
+  })
+
+  it('handles a completion message from the SSE stream', async () => {
+    global.fetch = mockEpisodeFetchRouter({ episode: generatingEpisode })
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await waitFor(() => expect(lastRobustESOptions).not.toBeNull())
+    act(() => {
+      lastRobustESOptions!.onMessage({ status: 'complete', progress: { progress: 100 } })
+    })
+
+    await waitFor(() => expect(showSuccessToast).toHaveBeenCalledWith('Podcast generated successfully'))
+  })
+
+  it('handles a failure message from the SSE stream', async () => {
+    global.fetch = mockEpisodeFetchRouter({ episode: generatingEpisode })
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await waitFor(() => expect(lastRobustESOptions).not.toBeNull())
+    act(() => {
+      lastRobustESOptions!.onMessage({ status: 'failed', progress: {} })
+    })
+
+    await waitFor(() => expect(showErrorToast).toHaveBeenCalledWith('Podcast generation failed'))
+  })
+
+  it('falls back to polling and reflects the polling connection status', async () => {
+    global.fetch = mockEpisodeFetchRouter({ episode: generatingEpisode })
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await waitFor(() => expect(lastRobustESOptions).not.toBeNull())
+    act(() => {
+      lastRobustESOptions!.onFallbackToPolling?.()
+    })
+
+    expect(await screen.findByText('Using polling mode')).toBeInTheDocument()
+    expect(startPollingMock).toHaveBeenCalled()
+  })
+
+  it('reflects connected/reconnecting/error status changes', async () => {
+    global.fetch = mockEpisodeFetchRouter({ episode: generatingEpisode })
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+    await waitFor(() => expect(lastRobustESOptions).not.toBeNull())
+
+    act(() => {
+      lastRobustESOptions!.onStatusChange?.('connected')
+    })
+    expect(await screen.findByText('Connected')).toBeInTheDocument()
+
+    act(() => {
+      lastRobustESOptions!.onStatusChange?.('reconnecting')
+    })
+    expect(await screen.findByText('Reconnecting...')).toBeInTheDocument()
+
+    act(() => {
+      lastRobustESOptions!.onStatusChange?.('error')
+    })
+    expect(await screen.findByText('Connection lost, retrying...')).toBeInTheDocument()
+  })
+
+  it('prefers a progress-specific status message over the generic one', async () => {
+    global.fetch = mockEpisodeFetchRouter({ episode: generatingEpisode })
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+    await waitFor(() => expect(lastRobustESOptions).not.toBeNull())
+
+    // Same status as the current episode ("generating"): the SSE effect keys
+    // off episode.generation_status, so keeping it unchanged means it won't
+    // restart and reset progressMessage back to the generic STATUS_MESSAGES
+    // text, letting us observe the progress-specific message in isolation.
+    act(() => {
+      lastRobustESOptions!.onMessage({
+        status: 'generating',
+        progress: { progress: 10, status: 'Generating episode audio (chunk 3 of 10)' },
+      })
+    })
+
+    expect(await screen.findByText('Generating episode audio (chunk 3 of 10)')).toBeInTheDocument()
+  })
+
+  it('logs SSE connection errors via onError', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    global.fetch = mockEpisodeFetchRouter({ episode: generatingEpisode })
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+    await waitFor(() => expect(lastRobustESOptions).not.toBeNull())
+
+    act(() => {
+      lastRobustESOptions!.onError?.({ message: 'Connection lost, retrying...', attempt: 1, maxRetries: 5 })
+    })
+
+    expect(warnSpy).toHaveBeenCalledWith('SSE error: Connection lost, retrying... (attempt 1/5)')
+    warnSpy.mockRestore()
+  })
+})
+
+describe('EpisodePage error and terminal states', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('shows an "episode not found" state when the load fails', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false }) as jest.Mock
+    render(<EpisodePage />)
+
+    expect(await screen.findByText('Episode not found')).toBeInTheDocument()
+    expect(showErrorToast).toHaveBeenCalledWith('Failed to load episode')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Back' }))
+    expect(mockBack).toHaveBeenCalled()
+  })
+
+  it('shows a network error toast when the episode fetch rejects', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('boom')) as jest.Mock
+    render(<EpisodePage />)
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to load episode: Network error')
+    )
+  })
+
+  it('shows the failure error message for a failed episode', async () => {
+    global.fetch = mockEpisodeFetchRouter({ episode: failedEpisode })
+    render(<EpisodePage />)
+
+    expect(await screen.findByText('Error: TTS provider rejected the request')).toBeInTheDocument()
+  })
+
+  it('renders the audio player and download button for a completed episode', async () => {
+    global.fetch = mockEpisodeFetchRouter({ episode: completeEpisode })
+    render(<EpisodePage />)
+
+    await screen.findByText('Test Episode')
+    expect(screen.getByLabelText(/podcast audio: test episode/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /download mp3/i })).toBeInTheDocument()
+  })
+
+  it('navigates back to the project page', async () => {
+    global.fetch = mockEpisodeFetchRouter()
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getByRole('button', { name: '← Back to Project' }))
+    expect(mockPush).toHaveBeenCalledWith('/projects/p1')
+  })
+
+  it('resumes a saved TTS config id and progress percentage from the loaded episode', async () => {
+    global.fetch = mockEpisodeFetchRouter({ episode: episodeWithSavedProgress })
+    render(<EpisodePage />)
+
+    await screen.findByText('Test Episode')
+    expect(screen.getByRole('progressbar', { name: /generation progress/i })).toHaveAttribute(
+      'aria-valuenow',
+      '42'
+    )
+  })
+})
+
+describe('EpisodePage content sources', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('adds a URL content source', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter({ contentSources: [] }),
+      (url, init) => /\/api\/proxy\/episodes\/[^/]+\/content$/.test(url) && init?.method === 'POST',
+      () => Promise.resolve({ ok: true, json: async () => ({}) })
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'Add Content' })[0])
+    await userEvent.type(
+      screen.getByPlaceholderText(/https:\/\/example.com\/article/i),
+      'https://example.com/post'
+    )
+    const submitButtons = screen.getAllByRole('button', { name: /add content/i })
+    await userEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/proxy/episodes/ep1/content',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            episode_id: 'ep1',
+            source_type: 'url',
+            source_data: { url: 'https://example.com/post', title: 'Web Article' },
+          }),
+        })
+      )
+    })
+    expect(showSuccessToast).toHaveBeenCalledWith('Content source added')
+  })
+
+  it('adds a text content source', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter({ contentSources: [] }),
+      (url, init) => /\/api\/proxy\/episodes\/[^/]+\/content$/.test(url) && init?.method === 'POST',
+      () => Promise.resolve({ ok: true, json: async () => ({}) })
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'Add Content' })[0])
+    await userEvent.click(screen.getByRole('button', { name: 'Text' }))
+    await userEvent.type(
+      screen.getByPlaceholderText(/enter your content here/i),
+      'This is enough content to pass validation.'
+    )
+    const submitButtons = screen.getAllByRole('button', { name: /add content/i })
+    await userEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/proxy/episodes/ep1/content',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            episode_id: 'ep1',
+            source_type: 'text',
+            source_data: { content: 'This is enough content to pass validation.', title: 'Custom Text' },
+          }),
+        })
+      )
+    })
+  })
+
+  it('opens the add-content dialog from the empty state action', async () => {
+    global.fetch = mockEpisodeFetchRouter({ contentSources: [] })
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    const addButtons = screen.getAllByRole('button', { name: 'Add Content' })
+    await userEvent.click(addButtons[addButtons.length - 1])
+
+    expect(screen.getByPlaceholderText(/https:\/\/example.com\/article/i)).toBeInTheDocument()
+  })
+
+  it('toggles the content source type back to URL', async () => {
+    global.fetch = mockEpisodeFetchRouter({ contentSources: [] })
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'Add Content' })[0])
+    await userEvent.click(screen.getByRole('button', { name: 'Text' }))
+    await userEvent.click(screen.getByRole('button', { name: 'URL' }))
+
+    expect(screen.getByPlaceholderText(/https:\/\/example.com\/article/i)).toBeInTheDocument()
+  })
+
+  it('closes the add-content dialog without submitting when cancelled', async () => {
+    global.fetch = mockEpisodeFetchRouter({ contentSources: [] })
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'Add Content' })[0])
+    expect(screen.getByPlaceholderText(/https:\/\/example.com\/article/i)).toBeInTheDocument()
+
+    await userEvent.keyboard('{Escape}')
+    await waitFor(() =>
+      expect(screen.queryByPlaceholderText(/https:\/\/example.com\/article/i)).not.toBeInTheDocument()
+    )
+  })
+
+  it('shows an error toast when adding content fails', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter({ contentSources: [] }),
+      (url, init) => /\/api\/proxy\/episodes\/[^/]+\/content$/.test(url) && init?.method === 'POST',
+      () => Promise.resolve({ ok: false, statusText: 'Bad Request' })
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'Add Content' })[0])
+    await userEvent.type(
+      screen.getByPlaceholderText(/https:\/\/example.com\/article/i),
+      'https://example.com/post'
+    )
+    const submitButtons = screen.getAllByRole('button', { name: /add content/i })
+    await userEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to add content source: Bad Request')
+    )
+  })
+
+  it('shows a network error toast when adding content throws', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter({ contentSources: [] }),
+      (url, init) => /\/api\/proxy\/episodes\/[^/]+\/content$/.test(url) && init?.method === 'POST',
+      () => Promise.reject(new Error('boom'))
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'Add Content' })[0])
+    await userEvent.type(
+      screen.getByPlaceholderText(/https:\/\/example.com\/article/i),
+      'https://example.com/post'
+    )
+    const submitButtons = screen.getAllByRole('button', { name: /add content/i })
+    await userEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to add content source: Network error')
+    )
+  })
+
+  it('deletes a content source', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter(),
+      (url, init) => url === '/api/proxy/content/c1' && init?.method === 'DELETE',
+      () => Promise.resolve({ ok: true, json: async () => ({}) })
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete content source' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(showSuccessToast).toHaveBeenCalledWith('Content source deleted'))
+  })
+
+  it('shows an error toast when deleting a content source fails', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter(),
+      (url, init) => url === '/api/proxy/content/c1' && init?.method === 'DELETE',
+      () => Promise.resolve({ ok: false, statusText: 'Bad Request' })
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete content source' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to delete content source: Bad Request')
+    )
+  })
+
+  it('shows a network error toast when deleting a content source throws', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter(),
+      (url, init) => url === '/api/proxy/content/c1' && init?.method === 'DELETE',
+      () => Promise.reject(new Error('boom'))
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete content source' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to delete content source: Network error')
+    )
+  })
+
+  it('closes the delete-content dialog without deleting when cancelled', async () => {
+    global.fetch = mockEpisodeFetchRouter()
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete content source' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => expect(screen.queryByText('Delete Content Source?')).not.toBeInTheDocument())
+  })
+})
+
+describe('EpisodePage TTS config creation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('saves a new OpenAI TTS configuration', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter(),
+      (url, init) => url === '/api/proxy/tts-configs' && init?.method === 'POST',
+      () => Promise.resolve({
+        ok: true,
+        json: async () => ({ id: 'tts-new', name: 'My Config', provider: 'openai', is_default: false }),
+      })
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getByRole('button', { name: /tts settings/i }))
+    await userEvent.type(screen.getByLabelText('Name'), 'My Config')
+    await userEvent.click(screen.getByRole('button', { name: 'Save Configuration' }))
+
+    await waitFor(() =>
+      expect(showSuccessToast).toHaveBeenCalledWith('TTS configuration saved')
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/proxy/tts-configs',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'My Config',
+          provider: 'openai',
+          config: { model: 'tts-1-hd', voice_1: 'alloy', voice_2: 'echo' },
+          is_default: false,
+        }),
+      })
+    )
+  })
+
+  it('requires voice IDs before an ElevenLabs configuration can be saved', async () => {
+    global.fetch = mockEpisodeFetchRouter()
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getByRole('button', { name: /tts settings/i }))
+    await userEvent.type(screen.getByLabelText('Name'), 'My ElevenLabs Config')
+    await userEvent.click(screen.getByLabelText(/select tts provider/i))
+    await userEvent.click(await screen.findByText('ElevenLabs'))
+
+    const saveBtn = screen.getByRole('button', { name: 'Save Configuration' })
+    expect(saveBtn).toBeDisabled()
+
+    await userEvent.type(screen.getByLabelText('Voice 1 ID'), 'voice-1')
+    expect(saveBtn).toBeDisabled()
+    await userEvent.type(screen.getByLabelText('Voice 2 ID'), 'voice-2')
+    expect(saveBtn).toBeEnabled()
+  })
+
+  it('saves a new ElevenLabs TTS configuration with voice IDs', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter(),
+      (url, init) => url === '/api/proxy/tts-configs' && init?.method === 'POST',
+      () => Promise.resolve({
+        ok: true,
+        json: async () => ({ id: 'tts-new', name: 'My ElevenLabs Config', provider: 'elevenlabs', is_default: false }),
+      })
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getByRole('button', { name: /tts settings/i }))
+    await userEvent.type(screen.getByLabelText('Name'), 'My ElevenLabs Config')
+    await userEvent.click(screen.getByLabelText(/select tts provider/i))
+    await userEvent.click(await screen.findByText('ElevenLabs'))
+    await userEvent.type(screen.getByLabelText('Voice 1 ID'), 'voice-1')
+    await userEvent.type(screen.getByLabelText('Voice 2 ID'), 'voice-2')
+    await userEvent.click(screen.getByRole('button', { name: 'Save Configuration' }))
+
+    await waitFor(() => expect(showSuccessToast).toHaveBeenCalledWith('TTS configuration saved'))
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/proxy/tts-configs',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'My ElevenLabs Config',
+          provider: 'elevenlabs',
+          config: {
+            model: 'eleven_multilingual_v2',
+            voice_1_id: 'voice-1',
+            voice_2_id: 'voice-2',
+          },
+          is_default: false,
+        }),
+      })
+    )
+  })
+
+  it('shows an error toast when saving a TTS configuration fails', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter(),
+      (url, init) => url === '/api/proxy/tts-configs' && init?.method === 'POST',
+      () => Promise.resolve({ ok: false })
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getByRole('button', { name: /tts settings/i }))
+    await userEvent.type(screen.getByLabelText('Name'), 'My Config')
+    await userEvent.click(screen.getByRole('button', { name: 'Save Configuration' }))
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to save TTS configuration')
+    )
+  })
+
+  it('shows a network error toast when saving a TTS configuration throws', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter(),
+      (url, init) => url === '/api/proxy/tts-configs' && init?.method === 'POST',
+      () => Promise.reject(new Error('boom'))
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getByRole('button', { name: /tts settings/i }))
+    await userEvent.type(screen.getByLabelText('Name'), 'My Config')
+    await userEvent.click(screen.getByRole('button', { name: 'Save Configuration' }))
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to save TTS configuration: Network error')
+    )
+  })
+
+  it('applies a non-default saved TTS configuration', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter({
+        ttsConfigs: [{ id: 'tts1', name: 'My Voice', provider: 'openai', is_default: false }],
+      }),
+      (url, init) => url === '/api/proxy/episodes/ep1' && init?.method === 'PUT',
+      () => Promise.resolve({ ok: true, json: async () => ({}) })
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getByRole('button', { name: /tts settings/i }))
+    await userEvent.click(await screen.findByLabelText(/select a saved tts configuration/i))
+    await userEvent.click(await screen.findByText(/my voice \(openai\)/i))
+    await userEvent.click(screen.getByRole('button', { name: /apply to episode/i }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/proxy/episodes/ep1',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({ tts_config_id: 'tts1' }),
+        })
+      )
+    })
+    expect(showSuccessToast).toHaveBeenCalledWith('TTS settings applied')
+  })
+
+  it('shows an error toast when applying TTS settings fails', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter(),
+      (url, init) => url === '/api/proxy/episodes/ep1' && init?.method === 'PUT',
+      () => Promise.resolve({ ok: false })
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getByRole('button', { name: /tts settings/i }))
+    await userEvent.click(screen.getByRole('button', { name: /apply to episode/i }))
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to apply TTS settings')
+    )
+  })
+
+  it('shows a network error toast when applying TTS settings throws', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter(),
+      (url, init) => url === '/api/proxy/episodes/ep1' && init?.method === 'PUT',
+      () => Promise.reject(new Error('boom'))
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getByRole('button', { name: /tts settings/i }))
+    await userEvent.click(screen.getByRole('button', { name: /apply to episode/i }))
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to apply TTS settings: Network error')
+    )
   })
 })

--- a/apps/web/__tests__/app/login/page.test.tsx
+++ b/apps/web/__tests__/app/login/page.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import LoginPage from '@/app/login/page'
+
+const mockPush = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+const mockSignIn = jest.fn()
+
+jest.mock('next-auth/react', () => ({
+  signIn: (...args: unknown[]) => mockSignIn(...args),
+}))
+
+async function fillAndSubmit() {
+  await userEvent.type(screen.getByLabelText(/email/i), 'a@b.com')
+  await userEvent.type(screen.getByLabelText(/password/i), 'password123')
+  await userEvent.click(screen.getByRole('button', { name: /sign in/i }))
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('redirects to /dashboard on successful sign-in', async () => {
+    mockSignIn.mockResolvedValue({ error: null })
+
+    render(<LoginPage />)
+    await fillAndSubmit()
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/dashboard'))
+    expect(mockSignIn).toHaveBeenCalledWith('credentials', {
+      email: 'a@b.com',
+      password: 'password123',
+      redirect: false,
+    })
+  })
+
+  it('shows an error and resets loading when credentials are invalid', async () => {
+    mockSignIn.mockResolvedValue({ error: 'CredentialsSignin' })
+
+    render(<LoginPage />)
+    await fillAndSubmit()
+
+    expect(await screen.findByText('Invalid email or password')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeEnabled()
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+
+  it('shows a generic error when signIn throws', async () => {
+    mockSignIn.mockRejectedValue(new Error('network down'))
+
+    render(<LoginPage />)
+    await fillAndSubmit()
+
+    expect(await screen.findByText('An error occurred. Please try again.')).toBeInTheDocument()
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+
+  it('shows the loading label while the request is in flight', async () => {
+    let resolveSignIn: (value: { error: null }) => void = () => {}
+    mockSignIn.mockImplementation(
+      () => new Promise((resolve) => { resolveSignIn = resolve })
+    )
+
+    render(<LoginPage />)
+    await userEvent.type(screen.getByLabelText(/email/i), 'a@b.com')
+    await userEvent.type(screen.getByLabelText(/password/i), 'password123')
+    await userEvent.click(screen.getByRole('button', { name: /sign in/i }))
+
+    expect(await screen.findByRole('button', { name: /signing in/i })).toBeInTheDocument()
+
+    resolveSignIn({ error: null })
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/dashboard'))
+  })
+})

--- a/apps/web/__tests__/app/page.test.tsx
+++ b/apps/web/__tests__/app/page.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import Home from '@/app/page'
+
+const mockPush = jest.fn()
+let mockSessionValue: { data: unknown; status: string }
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => mockSessionValue,
+}))
+
+describe('Home', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders a loading message and does not redirect while the session is loading', () => {
+    mockSessionValue = { data: null, status: 'loading' }
+    render(<Home />)
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+
+  it('redirects to /dashboard when a session exists', () => {
+    mockSessionValue = { data: { user: { id: '1' } }, status: 'authenticated' }
+    render(<Home />)
+
+    expect(mockPush).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('redirects to /login when there is no session', () => {
+    mockSessionValue = { data: null, status: 'unauthenticated' }
+    render(<Home />)
+
+    expect(mockPush).toHaveBeenCalledWith('/login')
+  })
+})

--- a/apps/web/__tests__/app/projects/[id]/page.test.tsx
+++ b/apps/web/__tests__/app/projects/[id]/page.test.tsx
@@ -1,0 +1,415 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ProjectPage from '@/app/(auth)/projects/[id]/page'
+import { withOverride } from '../../../../test-utils/fetch-router'
+
+const mockPush = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => ({ id: 'p1' }),
+}))
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({ status: 'authenticated' }),
+}))
+
+jest.mock('@/lib/toast', () => ({
+  showSuccessToast: jest.fn(),
+  showErrorToast: jest.fn(),
+}))
+
+const { showSuccessToast, showErrorToast } = jest.requireMock('@/lib/toast')
+
+const project = { id: 'p1', name: 'My Podcast', description: 'A show' }
+
+const pilotEpisode = {
+  id: 'e1',
+  episode_metadata: { title: 'Pilot', description: 'First one' as string | null },
+  generation_status: 'draft',
+  created_at: '2026-01-01',
+}
+
+// Exercises the getStatusBadge fallback branch (status not in the known map).
+const oddEpisode = {
+  id: 'e2',
+  episode_metadata: { title: 'Bonus', description: null },
+  generation_status: 'mystery-status',
+  created_at: '2026-01-02',
+}
+
+type FetchRouterOpts = {
+  episodes?: typeof pilotEpisode[]
+  projectOk?: boolean
+  episodesOk?: boolean
+}
+
+// Routes the component's mount-time GETs by URL. Individual tests layer
+// method-specific overrides (PUT/POST/DELETE) on top via mockImplementation.
+function mockFetchRouter({
+  episodes = [pilotEpisode],
+  projectOk = true,
+  episodesOk = true,
+}: FetchRouterOpts = {}) {
+  return jest.fn((url: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET'
+    if (url === '/api/proxy/projects/p1' && method === 'GET') {
+      return projectOk
+        ? Promise.resolve({ ok: true, json: async () => project })
+        : Promise.resolve({ ok: false })
+    }
+    if (url.startsWith('/api/proxy/episodes?project_id=') && method === 'GET') {
+      return episodesOk
+        ? Promise.resolve({ ok: true, json: async () => ({ episodes }) })
+        : Promise.resolve({ ok: false })
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) })
+  }) as jest.Mock
+}
+
+describe('ProjectPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('loads the project and its episodes', async () => {
+    global.fetch = mockFetchRouter({ episodes: [pilotEpisode, oddEpisode] })
+    render(<ProjectPage />)
+
+    expect(await screen.findByRole('heading', { name: 'My Podcast' })).toBeInTheDocument()
+    expect(screen.getByText('Pilot')).toBeInTheDocument()
+    expect(screen.getByLabelText('Status: draft')).toBeInTheDocument()
+    expect(screen.getByLabelText('Status: mystery-status')).toBeInTheDocument()
+    expect(global.fetch).toHaveBeenCalledWith('/api/proxy/projects/p1')
+  })
+
+  it('shows an empty state when there are no episodes', async () => {
+    global.fetch = mockFetchRouter({ episodes: [] })
+    render(<ProjectPage />)
+
+    expect(await screen.findByText('No episodes in this project')).toBeInTheDocument()
+  })
+
+  it('opens the create dialog from the empty state action', async () => {
+    global.fetch = mockFetchRouter({ episodes: [] })
+    render(<ProjectPage />)
+    await screen.findByText('No episodes in this project')
+
+    const createButtons = screen.getAllByRole('button', { name: 'Create Episode' })
+    await userEvent.click(createButtons[createButtons.length - 1])
+
+    expect(screen.getByLabelText(/episode title/i)).toBeInTheDocument()
+  })
+
+  it('navigates back to the dashboard', async () => {
+    global.fetch = mockFetchRouter()
+    render(<ProjectPage />)
+    await screen.findByText('Pilot')
+
+    await userEvent.click(screen.getByRole('button', { name: '← Back to Dashboard' }))
+    expect(mockPush).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('shows an error toast when the project fails to load', async () => {
+    global.fetch = mockFetchRouter({ projectOk: false })
+    render(<ProjectPage />)
+
+    await waitFor(() => expect(showErrorToast).toHaveBeenCalledWith('Failed to load project'))
+  })
+
+  it('shows an error toast when episodes fail to load', async () => {
+    global.fetch = mockFetchRouter({ episodesOk: false })
+    render(<ProjectPage />)
+
+    await waitFor(() => expect(showErrorToast).toHaveBeenCalledWith('Failed to load episodes'))
+  })
+
+  it('shows a network error toast when the project fetch rejects', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('boom')) as jest.Mock
+    render(<ProjectPage />)
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to load project: Network error')
+    )
+  })
+
+  it('navigates to the episode page when a card is clicked', async () => {
+    global.fetch = mockFetchRouter()
+    render(<ProjectPage />)
+
+    await userEvent.click(await screen.findByRole('button', { name: /open episode: pilot/i }))
+    expect(mockPush).toHaveBeenCalledWith('/episodes/e1')
+  })
+
+  it('navigates to the episode page on Enter key', async () => {
+    global.fetch = mockFetchRouter()
+    render(<ProjectPage />)
+
+    const card = await screen.findByRole('button', { name: /open episode: pilot/i })
+    card.focus()
+    await userEvent.keyboard('{Enter}')
+    expect(mockPush).toHaveBeenCalledWith('/episodes/e1')
+  })
+
+  it('creates an episode and navigates to it', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/episodes' && (init?.method ?? 'GET') === 'POST', () =>
+      Promise.resolve({ ok: true, json: async () => ({ id: 'new-ep' }) })
+    )
+    global.fetch = fetchMock
+
+    render(<ProjectPage />)
+    await screen.findByText('Pilot')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Create Episode' }))
+    await userEvent.type(screen.getByLabelText(/episode title/i), 'New Episode')
+    const submitButtons = screen.getAllByRole('button', { name: /create episode/i })
+    await userEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/proxy/episodes',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            project_id: 'p1',
+            episode_metadata: { title: 'New Episode' },
+          }),
+        })
+      )
+    })
+    expect(showSuccessToast).toHaveBeenCalledWith('Episode created successfully')
+    expect(mockPush).toHaveBeenCalledWith('/episodes/new-ep')
+  })
+
+  it('closes the create dialog without submitting when cancelled', async () => {
+    global.fetch = mockFetchRouter()
+    render(<ProjectPage />)
+    await screen.findByText('Pilot')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Create Episode' }))
+    expect(screen.getByLabelText(/episode title/i)).toBeInTheDocument()
+
+    await userEvent.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByLabelText(/episode title/i)).not.toBeInTheDocument())
+  })
+
+  it('shows an error toast when episode creation fails', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/episodes' && (init?.method ?? 'GET') === 'POST', () =>
+      Promise.resolve({ ok: false, statusText: 'Bad Request' })
+    )
+    global.fetch = fetchMock
+
+    render(<ProjectPage />)
+    await screen.findByText('Pilot')
+    await userEvent.click(screen.getByRole('button', { name: 'Create Episode' }))
+    await userEvent.type(screen.getByLabelText(/episode title/i), 'New Episode')
+    const submitButtons = screen.getAllByRole('button', { name: /create episode/i })
+    await userEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to create episode: Bad Request')
+    )
+  })
+
+  it('shows a network error toast when episode creation throws', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/episodes' && (init?.method ?? 'GET') === 'POST', () =>
+      Promise.reject(new Error('boom'))
+    )
+    global.fetch = fetchMock
+
+    render(<ProjectPage />)
+    await screen.findByText('Pilot')
+    await userEvent.click(screen.getByRole('button', { name: 'Create Episode' }))
+    await userEvent.type(screen.getByLabelText(/episode title/i), 'New Episode')
+    const submitButtons = screen.getAllByRole('button', { name: /create episode/i })
+    await userEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to create episode: Network error')
+    )
+  })
+
+  it('updates the project title', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/projects/p1' && (init?.method ?? 'GET') === 'PUT', () =>
+      Promise.resolve({ ok: true, json: async () => ({}) })
+    )
+    global.fetch = fetchMock
+
+    render(<ProjectPage />)
+    await screen.findByRole('heading', { name: 'My Podcast' })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit project' }))
+    const titleInput = screen.getByLabelText(/project title/i)
+    await userEvent.clear(titleInput)
+    await userEvent.type(titleInput, 'Renamed Podcast')
+    await userEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() => expect(showSuccessToast).toHaveBeenCalledWith('Project updated'))
+    expect(await screen.findByRole('heading', { name: 'Renamed Podcast' })).toBeInTheDocument()
+  })
+
+  it('shows an error toast when project update fails', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/projects/p1' && (init?.method ?? 'GET') === 'PUT', () =>
+      Promise.resolve({ ok: false, statusText: 'Bad Request' })
+    )
+    global.fetch = fetchMock
+
+    render(<ProjectPage />)
+    await screen.findByRole('heading', { name: 'My Podcast' })
+    await userEvent.click(screen.getByRole('button', { name: 'Edit project' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to update project: Bad Request')
+    )
+  })
+
+  it('shows a network error toast when project update throws', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/projects/p1' && (init?.method ?? 'GET') === 'PUT', () =>
+      Promise.reject(new Error('boom'))
+    )
+    global.fetch = fetchMock
+
+    render(<ProjectPage />)
+    await screen.findByRole('heading', { name: 'My Podcast' })
+    await userEvent.click(screen.getByRole('button', { name: 'Edit project' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to update project: Network error')
+    )
+  })
+
+  it('closes the edit-project dialog without submitting when cancelled', async () => {
+    global.fetch = mockFetchRouter()
+    render(<ProjectPage />)
+    await screen.findByRole('heading', { name: 'My Podcast' })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit project' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => expect(screen.queryByLabelText(/project title/i)).not.toBeInTheDocument())
+  })
+
+  it('updates an episode title', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/episodes/e1' && (init?.method ?? 'GET') === 'PUT', () =>
+      Promise.resolve({ ok: true, json: async () => ({}) })
+    )
+    global.fetch = fetchMock
+
+    render(<ProjectPage />)
+    await screen.findByText('Pilot')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit Pilot' }))
+    const titleInput = screen.getByLabelText(/episode title/i)
+    await userEvent.clear(titleInput)
+    await userEvent.type(titleInput, 'Renamed Episode')
+    await userEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() => expect(showSuccessToast).toHaveBeenCalledWith('Episode updated'))
+    expect(await screen.findByText('Renamed Episode')).toBeInTheDocument()
+  })
+
+  it('shows an error toast when episode update fails', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/episodes/e1' && (init?.method ?? 'GET') === 'PUT', () =>
+      Promise.resolve({ ok: false, statusText: 'Bad Request' })
+    )
+    global.fetch = fetchMock
+
+    render(<ProjectPage />)
+    await screen.findByText('Pilot')
+    await userEvent.click(screen.getByRole('button', { name: 'Edit Pilot' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to update episode: Bad Request')
+    )
+  })
+
+  it('shows a network error toast when episode update throws', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/episodes/e1' && (init?.method ?? 'GET') === 'PUT', () =>
+      Promise.reject(new Error('boom'))
+    )
+    global.fetch = fetchMock
+
+    render(<ProjectPage />)
+    await screen.findByText('Pilot')
+    await userEvent.click(screen.getByRole('button', { name: 'Edit Pilot' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to update episode: Network error')
+    )
+  })
+
+  it('closes the edit-episode dialog without submitting when cancelled', async () => {
+    global.fetch = mockFetchRouter()
+    render(<ProjectPage />)
+    await screen.findByText('Pilot')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit Pilot' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => expect(screen.queryByLabelText(/episode title/i)).not.toBeInTheDocument())
+  })
+
+  it('deletes an episode', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/episodes/e1' && (init?.method ?? 'GET') === 'DELETE', () =>
+      Promise.resolve({ ok: true, json: async () => ({}) })
+    )
+    global.fetch = fetchMock
+
+    render(<ProjectPage />)
+    await screen.findByText('Pilot')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete Pilot' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(showSuccessToast).toHaveBeenCalledWith('Episode deleted successfully'))
+    expect(screen.queryByText('Pilot')).not.toBeInTheDocument()
+  })
+
+  it('shows an error toast when episode deletion fails', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/episodes/e1' && (init?.method ?? 'GET') === 'DELETE', () =>
+      Promise.resolve({ ok: false, statusText: 'Bad Request' })
+    )
+    global.fetch = fetchMock
+
+    render(<ProjectPage />)
+    await screen.findByText('Pilot')
+    await userEvent.click(screen.getByRole('button', { name: 'Delete Pilot' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to delete episode: Bad Request')
+    )
+  })
+
+  it('shows a network error toast when episode deletion throws', async () => {
+    const fetchMock = withOverride(mockFetchRouter(), (url, init) => url === '/api/proxy/episodes/e1' && (init?.method ?? 'GET') === 'DELETE', () =>
+      Promise.reject(new Error('boom'))
+    )
+    global.fetch = fetchMock
+
+    render(<ProjectPage />)
+    await screen.findByText('Pilot')
+    await userEvent.click(screen.getByRole('button', { name: 'Delete Pilot' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to delete episode: Network error')
+    )
+  })
+
+  it('closes the delete-episode dialog without deleting when cancelled', async () => {
+    global.fetch = mockFetchRouter()
+    render(<ProjectPage />)
+    await screen.findByText('Pilot')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete Pilot' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => expect(screen.queryByText('Delete Episode?')).not.toBeInTheDocument())
+    expect(screen.getByText('Pilot')).toBeInTheDocument()
+  })
+})

--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -32,7 +32,7 @@ const config = {
     '!src/**/__tests__/**',
     '!src/**/*.test.{js,jsx,ts,tsx}',
     '!src/**/*.spec.{js,jsx,ts,tsx}',
-    '!src/app/**', // Exclude Next.js app directory (layout, page files)
+    '!src/app/**/layout.tsx', // layout boilerplate only — pages and route handlers stay under coverage
     '!src/types/**', // Exclude type definitions
   ],
 

--- a/apps/web/test-utils/fetch-router.ts
+++ b/apps/web/test-utils/fetch-router.ts
@@ -1,0 +1,26 @@
+/**
+ * Layers a URL/method-matched mock response on top of an existing `fetch`
+ * mock, falling back to the base implementation for every other request.
+ * Lets a single `mock*FetchRouter()` cover a page's happy-path mount fetches
+ * while an individual test swaps in one endpoint's success/failure/network-
+ * error response.
+ *
+ * Deliberately placed outside `__tests__/` (jest's testMatch would otherwise
+ * pick this file up as a test suite with zero tests) and outside `src/`
+ * (jest.config.js's collectCoverageFrom would otherwise count it against
+ * frontend coverage).
+ */
+export function withOverride(
+  base: jest.Mock,
+  matcher: (url: string, init?: RequestInit) => boolean,
+  handler: () => Promise<unknown>
+): jest.Mock {
+  const baseImpl = base.getMockImplementation()!
+  base.mockImplementation((url: string, init?: RequestInit) => {
+    if (matcher(url, init)) {
+      return handler()
+    }
+    return baseImpl(url, init)
+  })
+  return base
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,19 +1,41 @@
-# #302 tail — restore green E2E signal (un-fixme'd specs must actually run)
+# Issue #303 — Coverage gates are hollow (P2.5)
 
-Context: #338 delivered the infra; #340 un-fixme'd the journey/isolation specs. But:
-- Staging nginx (installed from repo config during 07-01 VPS rebuild) 500s on /login:
-  `try_files $uri $uri/ /index.html` + `root` inside the `location /` proxy block →
-  internal redirection cycle (confirmed in /opt/podcaststudiohub/logs/frontend-error.log).
-- The #340 deploy failed at ssh-keyscan (transient fail2ban ban, now expired) → dev
-  still runs pre-#340 code, so project/episode creation is still broken there.
+**Branch**: fix/303-coverage-gates (from main). **PR**: TBD.
+(Previous entry: #302 tail complete, PR #344 merged 2026-07-05.)
 
-## Steps
-- [ ] 1. Live-fix staging nginx (backup, drop root/try_files from proxy location, nginx -t, reload); verify /login 200
-- [ ] 2. Re-run failed deploy run 28540506708 → dev gets #340 code; verify project create works
-- [ ] 3. Branch fix/302-e2e-green-tail:
-      - deployment/nginx/podcastfy.conf: remove root/try_files from proxy location; port 3003→3010
-      - tests/e2e/README.md: drop stale "BLOCKED on #337" section (specs are re-enabled)
-      - playwright-tests.yml thresholds: tighten from observed green-run numbers
-- [ ] 4. Re-run Playwright on main → confirm re-enabled specs pass against fixed dev
-- [ ] 5. Quality gate (lint, third-party review), PR with Known Limitations
-- [ ] 6. Demo evidence (CI signal numbers + curl proof), CI green, merge, close #302
+## Problem
+- Backend: `--cov-fail-under=0` in `apps/api/pytest.ini:21`, `.github/workflows/test.yml:84`, `.github/workflows/deploy-dev.yml:94` — gate enforces nothing.
+- Frontend: `jest.config.js:35` excludes all of `src/app/**` — every page + the token-injecting proxy route sit outside the 80% threshold.
+
+## Measured baseline (2026-07-06)
+- Frontend with src/app included: 63.85% stmts / 54.48% branch / 54.64% funcs / 65.32% lines (gate = 80 on all four).
+  - Zero coverage: projects/[id]/page.tsx (130 st), login/page.tsx (26 st), root page.tsx (12 st), nextauth route (5 st), layouts (12 st).
+  - Partial: dashboard 50/103 st, episodes 120/247 st. Proxy route already 89/97%.
+- Backend TOTAL: **81.96%** (6237 st, 1125 missed; 1587 passed, 1 known local-env failure test_audio_snippets::test_download_url_no_s3_config, 7 skipped). Need ~190 more covered statements for 85 + margin. Lowest: content router 40%, billing_service 41%, team_service 41%, episodes router 45%, rss_feed 48%, quality_metrics 55%, distribution_target_service 56%.
+
+## Plan
+1. **Frontend config** (`apps/web/jest.config.js`): drop `!src/app/**`; add boilerplate-only exclusions `!src/app/**/layout.tsx` (no loading/error/not-found files exist). Keep all page.tsx/route.ts under coverage.
+2. **Frontend backfill** (TDD, model on existing __tests__/app/* suites):
+   - New: `__tests__/app/login/page.test.tsx` (model: signup test)
+   - New: `__tests__/app/projects/[id]/page.test.tsx` (model: episodes test)
+   - New: `__tests__/app/page.test.tsx` (root redirect page)
+   - New: `__tests__/app/api/auth/nextauth-route.test.ts` (mock next-auth, assert GET/POST exports)
+   - Strengthen: dashboard page test (uncovered: 84,91-119,124-157,162-183,196-208,220-333), episodes page test (uncovered ranges incl. 204-285, 290-322, 618-665, 772-871)
+   - Target: ≥80% on all four global metrics with src/app included.
+3. **Backend gate**: set `--cov-fail-under` in pytest.ini + test.yml + deploy-dev.yml to measured target (≥85 per AC if reachable; else backfill to reach it — scope TBD from measurement).
+4. **Backend backfill** (if measured <85): add tests for lowest-covered modules until ≥85.
+5. Quality gate: full local test runs, lint, third-party review (opencode/GLM pre-PR + post-PR), deslop.
+6. PR → demo (coverage gate demonstrably fails when coverage drops / passes at threshold) → CI green → merge.
+
+## Progress (2026-07-07)
+- Frontend DONE+verified: jest gate green with src/app included — 95.97/83.11/97.23/97.66, 41 suites / 331 tests. Config: `!src/app/**` → `!src/app/**/layout.tsx`.
+- Backend DONE+verified: TOTAL 93.70% (gate 85 active in pytest.ini/test.yml/deploy-dev.yml), 1651 passed 0 failed 7 skipped. Key: `.coveragerc concurrency=greenlet` fixed async undercounting (real baseline was higher than 81.96%); new tests for content/episodes/billing/team/rss/quality_metrics/encryption modules.
+- Bonus fixes: audio_snippets patch-target bug (router-local import binding); episode tags filter double-JSON-encode bug in episode_service.py:181 (TDD RED→GREEN, regression test test_get_episodes_filters_by_tags).
+- Deslop scan: clean except 2 helper duplications — backend `_register_user`→tests/unit/conftest.py DONE (765 unit tests green); frontend `withOverride`→shared test-util IN PROGRESS.
+- Next: commit → opencode/GLM pre-PR review → PR → demo → CI gate → merge.
+
+## Acceptance criteria (from issue)
+- [ ] Backend `--cov-fail-under` set to real target (≥85) in gating workflow
+- [ ] `src/app/**` no longer wholesale-excluded; only layout/loading/error boilerplate excluded
+- [ ] page.tsx / route.ts files under coverage
+- [ ] Tests backfilled where coverage drops (gates actually pass)


### PR DESCRIPTION
Closes #303 (P2.5 — coverage gates are hollow).

## What changed

### Backend — gate is now real at 85%
- `--cov-fail-under=0` → `85` in `apps/api/pytest.ini`, `.github/workflows/test.yml`, `.github/workflows/deploy-dev.yml`.
- `.coveragerc`: `concurrency = greenlet, thread` — coverage.py was silently losing visibility into async SQLAlchemy code after `await db.execute()/commit()` (a known coverage+greenlet gotcha), undercounting nearly every DB-touching line. The measured baseline of 81.96% was an artifact; `thread` keeps Starlette threadpool code traced.
- Removed dead `[coverage:*]` sections from `pytest.ini` (coverage.py never reads them; `.coveragerc` is the source of truth).
- Test backfill for the genuinely weak modules: content 39.8%→99%, episodes router →100%, billing_service 41%→97.7%, team_service →100%, rss_feed →100%, quality_metrics →100%, encryption →100%.
- **Result: TOTAL 93.84%, 1652 passed / 0 failed / 7 skipped with the 85 gate active.**

### Frontend — src/app is now under the 80% gate
- `jest.config.js`: `!src/app/**` → `!src/app/**/layout.tsx` (layout boilerplate only; no loading/error/not-found files exist). Every page.tsx and route.ts — including the security-critical token-injecting `/api/proxy` route — now counts.
- New suites: login page, projects/[id] page, root page, nextauth route. Strengthened dashboard (3→21 tests) and episodes (4→38 tests) suites, including SSE handling via a captured RobustEventSource fake.
- Shared `test-utils/fetch-router.ts` helper (deduped from 3 specs; placed outside `__tests__/` and `src/` so it's neither a test suite nor coverage-counted).
- **Result: 95.97% stmts / 83.11% branch / 97.23% funcs / 97.66% lines, 41 suites / 331 tests, gate green.**

## Bugs found and fixed along the way
1. **Episode tags filter never matched** (`src/services/episode_service.py`): `cast(json.dumps([tag]), JSONB)` double-encoded the containment value into a JSONB *string*, so `?tags=` always returned zero rows. Fixed to `cast([tag], JSONB)`; TDD regression test `test_get_episodes_filters_by_tags` (RED `assert 0 == 2` → GREEN).
2. **`test_download_url_no_s3_config` patch-target bug**: patched the service module attribute, but the router had already bound the name via `from … import`; the real function ran. Patch now targets the router's binding.

## Review
- Deslop scan: clean; two helper duplications extracted (`_register_user` → `tests/unit/conftest.py`, `withOverride` → `test-utils/fetch-router.ts`).
- Cross-family review (opencode / GLM): **no Critical or Major findings**; episode_service fix and patch-target fix confirmed correct. Two Minor config findings applied (`thread` concurrency, dead pytest.ini sections).

## Known limitations (advisory Minor findings, deliberately not done here)
- Frontend `mockFetchRouter` returns a permissive catch-all for unmatched URLs; a throwing base router would be stricter but churns 331 passing tests.
- A few backfilled tests encode current behavior that could use contract comments (quota pre-flight coupling, broker-unavailable 201-vs-503 asymmetry between create and re-trigger paths, temp-file cleanup in `_fetch_rss_from_s3` unasserted).
- Pre-existing ruff errors in `alembic/env.py`, `scripts/test_credentials.py`, and two old test files are untouched (present on main, CI green with them).

## Verification
- Backend: full suite with gate active — `1652 passed, 7 skipped`, "Required test coverage of 85% reached. Total coverage: 93.84%".
- Frontend: `npx jest --coverage` exits 0 with all four thresholds met; `npm run typecheck` and `next lint` clean.
- Both gates demonstrably fail when coverage drops (that is the point of #303): pytest exits non-zero below 85, jest below 80.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved episode tag filtering and download URL error handling.
  * Enhanced extraction workflow behavior and extraction-status reporting when tasks can’t be queued.
  * Improved quality-metrics response accuracy (including stored timestamps and trend directions) and RSS regeneration validation feedback.
* **Tests**
  * Added extensive API and web coverage for downloads, quotas, extraction endpoints, billing/subscriptions, encryption, teams, episodes, quality metrics, RSS, and UI flows.
* **Chores**
  * Strengthened CI coverage gates (now failing under 85%) and adjusted coverage/testing configuration to count more web app code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->