### PR TITLE
fix(e2e): PR E2E runs against a PR-built stack; single failing-capable signal (#341)

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -185,6 +185,9 @@ jobs:
           CELERY_RESULT_BACKEND: redis://localhost:6379/0
           CORS_ORIGINS: '["http://localhost:3200"]'
           RATE_LIMIT_ENABLED: 'false'
+          # Same rationale as dev/staging (config.py): E2E users are free-tier,
+          # so quota enforcement would 402 the suite as coverage grows.
+          BILLING_ENFORCEMENT_ENABLED: 'false'
           # Web process env (inherited by the webServer-launched `npm start`)
           NEXTAUTH_SECRET: test-nextauth-secret-for-ci
           NEXTAUTH_URL: ${{ env.E2E_WEB_URL }}

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -26,6 +26,7 @@ on:
       - 'apps/api/**'
       - 'tests/e2e/**'
       - 'playwright.config.ts'
+      - '.github/workflows/playwright-tests.yml'
 
   workflow_dispatch:
     inputs:
@@ -174,8 +175,10 @@ jobs:
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD || 'E2e-ci-Passw0rd!' }}
           # API process env (inherited by the webServer-launched uvicorn).
           # podcastfy_app is RLS-subject — do not swap in a superuser here.
+          # ENVIRONMENT matches the dev host + local verification (with no
+          # .env in CI, config.py would otherwise default to production).
+          ENVIRONMENT: development
           DATABASE_URL: postgresql+asyncpg://podcastfy_app:postgres@localhost:5432/podcastfy
-          SECRET_KEY: test-secret-key-for-ci
           ENCRYPTION_KEY: test-encryption-key-for-ci-00000
           JWT_SECRET_KEY: test-jwt-secret-for-ci
           CELERY_BROKER_URL: redis://localhost:6379/0

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -1,5 +1,10 @@
 name: Playwright E2E Tests
 
+# PR/push runs exercise a PR-built local stack (API + web booted by Playwright's
+# webServer, Postgres/Redis as job services) so every PR validates its own code
+# (#341). workflow_dispatch is the optional dev-smoke path: it targets the
+# deployed dev host and is skipped (not failed) when dev is unhealthy.
+
 on:
   push:
     branches:
@@ -25,7 +30,7 @@ on:
   workflow_dispatch:
     inputs:
       test_suite:
-        description: 'Which test suite to run'
+        description: 'Which test suite to run (dev-smoke against the deployed dev host)'
         required: false
         default: 'all'
         type: choice
@@ -46,6 +51,12 @@ permissions:
   contents: read
   actions: read
 
+env:
+  # PR-built stack topology. Non-default ports so a local `npm run dev`
+  # (8000/3000) never collides. Mirrors rm-review.yml's verify job.
+  E2E_WEB_URL: http://localhost:3200
+  E2E_API_URL: http://localhost:8200
+
 jobs:
   test:
     name: Run Playwright Tests
@@ -58,6 +69,35 @@ jobs:
         # Reduced to 1 shard while E2E stability is fixed (see #94)
         shard: [1]
 
+    services:
+      # Bootstrap as `postgres` — NOT as the app user. The bootstrap role is a
+      # superuser, and superusers bypass RLS even under FORCE ROW LEVEL
+      # SECURITY, which silently disables tenant isolation (the isolation specs
+      # then fail: User B can read User A's data). Dev-parity roles are
+      # provisioned below instead (see test.yml's migrate-as-non-superuser).
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -69,22 +109,99 @@ jobs:
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
+      - name: Set up Python
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        run: pip install uv
+
       - name: Install dependencies
         run: npm ci
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Run Playwright tests
+      - name: Provision dev-parity roles and database
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        env:
+          PGPASSWORD: postgres
+        run: |
+          # Two-role model (issue #301): migrations run as the BYPASSRLS owner
+          # podcastfy_user; the API connects as podcastfy_app, which is subject
+          # to RLS — so the isolation specs test the real tenancy model.
+          # Throwaway CI credentials reuse the service password (no secret).
+          psql -h localhost -U postgres -v ON_ERROR_STOP=1 <<'SQL'
+          CREATE ROLE podcastfy_user LOGIN PASSWORD 'postgres' NOSUPERUSER NOCREATEDB NOCREATEROLE BYPASSRLS;
+          CREATE DATABASE podcastfy OWNER podcastfy_user;
+          CREATE ROLE podcastfy_app LOGIN PASSWORD 'postgres' NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT;
+          SQL
+
+      - name: Install API dependencies and migrate
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        working-directory: apps/api
+        env:
+          DATABASE_URL: postgresql+asyncpg://podcastfy_app:postgres@localhost:5432/podcastfy
+          MIGRATION_DATABASE_URL: postgresql+asyncpg://podcastfy_user:postgres@localhost:5432/podcastfy
+          ENCRYPTION_KEY: test-encryption-key-for-ci-00000
+          JWT_SECRET_KEY: test-jwt-secret-for-ci
+        run: |
+          uv sync
+          uv run alembic upgrade head
+
+      - name: Build frontend
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        working-directory: apps/web
+        env:
+          NEXT_PUBLIC_API_URL: ${{ env.E2E_API_URL }}
+        run: npm run build
+
+      # PR/push: Playwright's webServer boots the PR-built API + web against
+      # the service Postgres/Redis (see playwright.config.ts). The plain
+      # credential defaults are safe: the stack is throwaway and rate limiting
+      # is off, so no shared-tenant/dev-secret coupling.
+      - name: Run Playwright tests (PR-built stack)
         if: ${{ github.event_name != 'workflow_dispatch' }}
         run: npx playwright test --shard=${{ matrix.shard }}/${{ strategy.job-total }}
         env:
-          BASE_URL: https://dev.podcaststudiohub.me
-          E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
-          E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
+          BASE_URL: ${{ env.E2E_WEB_URL }}
+          API_URL: ${{ env.E2E_API_URL }}
+          NEXT_PUBLIC_API_URL: ${{ env.E2E_API_URL }}
+          E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL || 'e2e-ci@example.com' }}
+          E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD || 'E2e-ci-Passw0rd!' }}
+          # API process env (inherited by the webServer-launched uvicorn).
+          # podcastfy_app is RLS-subject — do not swap in a superuser here.
+          DATABASE_URL: postgresql+asyncpg://podcastfy_app:postgres@localhost:5432/podcastfy
+          SECRET_KEY: test-secret-key-for-ci
+          ENCRYPTION_KEY: test-encryption-key-for-ci-00000
+          JWT_SECRET_KEY: test-jwt-secret-for-ci
+          CELERY_BROKER_URL: redis://localhost:6379/0
+          CELERY_RESULT_BACKEND: redis://localhost:6379/0
+          CORS_ORIGINS: '["http://localhost:3200"]'
+          RATE_LIMIT_ENABLED: 'false'
+          # Web process env (inherited by the webServer-launched `npm start`)
+          NEXTAUTH_SECRET: test-nextauth-secret-for-ci
+          NEXTAUTH_URL: ${{ env.E2E_WEB_URL }}
 
-      - name: Run specific test suite (manual)
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_suite != 'all' }}
+      # Dev-smoke preflight: when the deployed dev host is down, skip the run
+      # with a warning instead of reporting a misleading hard failure (#341).
+      - name: Dev-smoke preflight
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        id: dev-health
+        run: |
+          if curl -sf --max-time 15 https://dev.podcaststudiohub.me/api/health > /dev/null; then
+            echo "healthy=true" >> "$GITHUB_OUTPUT"
+            echo "Dev host healthy — running smoke suite."
+          else
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Dev-smoke skipped::https://dev.podcaststudiohub.me/api/health is unreachable/unhealthy. Smoke run skipped (non-blocking) — fix the dev deployment, then re-dispatch."
+          fi
+
+      - name: Run specific test suite (dev-smoke)
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_suite != 'all' && steps.dev-health.outputs.healthy == 'true' }}
         # TEST_SUITE is a dispatch input (arbitrary via the API) — read from env, never
         # interpolated into the shell. The surrounding globs stay unquoted on purpose.
         run: npx playwright test tests/e2e/specs/*"$TEST_SUITE"*.spec.ts
@@ -94,8 +211,8 @@ jobs:
           E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
 
-      - name: Run all tests (manual)
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_suite == 'all' }}
+      - name: Run all tests (dev-smoke)
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_suite == 'all' && steps.dev-health.outputs.healthy == 'true' }}
         run: npx playwright test --shard=${{ matrix.shard }}/${{ strategy.job-total }}
         env:
           BASE_URL: https://dev.podcaststudiohub.me
@@ -105,7 +222,8 @@ jobs:
       # Restore real signal: a suite that silently skips its coverage must not
       # report green. Parses the JSON report and enforces a floor of really-run
       # tests plus a ceiling on skips. Runs even when tests fail so the counts
-      # are always surfaced.
+      # are always surfaced. Scoped to PR/push — the dev-smoke path is
+      # non-blocking by design and may legitimately be skipped.
       - name: Enforce test signal (skip-count gate)
         if: ${{ always() && github.event_name != 'workflow_dispatch' }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,54 +258,6 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Coverage reports uploaded as artifacts." >> $GITHUB_STEP_SUMMARY
 
-  test-e2e:
-    name: E2E Tests (Playwright)
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
-
-      - name: Install dependencies
-        working-directory: apps/web
-        run: npm ci
-
-      - name: Install Playwright browsers
-        working-directory: apps/web
-        run: npx playwright install --with-deps
-
-      - name: Run Playwright tests
-        working-directory: apps/web
-        env:
-          BASE_URL: https://dev.podcaststudiohub.me
-          API_URL: https://dev.podcaststudiohub.me/api
-        run: npm run test:e2e
-        continue-on-error: true
-
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: playwright-report
-          path: |
-            apps/web/playwright-report/
-            apps/web/test-results/
-          retention-days: 30
-
-      - name: E2E test summary
-        if: always()
-        run: |
-          echo "### E2E Test Results 🎭" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Playwright reports uploaded as artifacts." >> $GITHUB_STEP_SUMMARY
-
   test-deployment:
     name: Deployment Config Tests (nginx/TLS)
     runs-on: ubuntu-latest
@@ -370,7 +322,7 @@ jobs:
   quality-gate:
     name: Quality Gate
     runs-on: ubuntu-latest
-    needs: [test-backend, test-frontend, test-e2e, test-deployment]
+    needs: [test-backend, test-frontend, test-deployment]
     if: always()
 
     steps:
@@ -393,11 +345,7 @@ jobs:
             echo "✅ Frontend tests passed" >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [ "${{ needs.test-e2e.result }}" == "success" ]; then
-            echo "✅ E2E tests passed" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "⚠️  E2E tests had issues (non-blocking)" >> $GITHUB_STEP_SUMMARY
-          fi
+          # E2E is owned by playwright-tests.yml (PR-built stack, failing-capable) — see #341.
 
           if [ "${{ needs.test-deployment.result }}" != "success" ]; then
             echo "❌ Deployment config tests failed (nginx/TLS)" >> $GITHUB_STEP_SUMMARY

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,17 @@ import { defineConfig, devices } from '@playwright/test';
  * Playwright configuration for PodcastStudioHub E2E tests
  * See https://playwright.dev/docs/test-configuration
  */
+
+const baseURL = process.env.BASE_URL || 'https://dev.podcaststudiohub.me';
+// When BASE_URL points at localhost the suite runs against a PR-built local
+// stack (see #341): Playwright boots the API + web servers itself via
+// `webServer` below, and CI provides Postgres/Redis as job services. Any
+// other BASE_URL (e.g. the deployed dev host) is treated as an already-running
+// remote target and no local servers are launched.
+const isLocalStack = /^https?:\/\/(localhost|127\.0\.0\.1)(:|\/|$)/.test(baseURL);
+const apiURL = process.env.API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8200';
+const webPort = new URL(baseURL).port || '3200';
+
 export default defineConfig({
   testDir: './tests/e2e',
 
@@ -36,7 +47,7 @@ export default defineConfig({
   /* Shared settings for all the projects below */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.BASE_URL || 'https://dev.podcaststudiohub.me',
+    baseURL,
 
     /* Pre-authenticated session from global-setup */
     storageState: 'tests/e2e/.auth/user.json',
@@ -80,10 +91,31 @@ export default defineConfig({
     // },
   ],
 
-  /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run dev',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  /* PR-built local stack (#341): boot API + web when BASE_URL is localhost.
+   * Prereqs: `uv sync` in apps/api (+ migrated Postgres, Redis) and
+   * `npm run build:web`. Both processes inherit env (DATABASE_URL, JWT keys,
+   * NEXT_PUBLIC_API_URL, …) from the invoking shell / CI step. */
+  webServer: isLocalStack
+    ? [
+        {
+          command: `uv run uvicorn src.main:app --host 127.0.0.1 --port ${new URL(apiURL).port || '8200'}`,
+          cwd: 'apps/api',
+          url: `${apiURL}/health`,
+          reuseExistingServer: !process.env.CI,
+          timeout: 120_000,
+          stdout: 'pipe',
+          stderr: 'pipe',
+        },
+        {
+          command: 'npm start',
+          cwd: 'apps/web',
+          url: baseURL,
+          reuseExistingServer: !process.env.CI,
+          timeout: 120_000,
+          stdout: 'pipe',
+          stderr: 'pipe',
+          env: { PORT: webPort },
+        },
+      ]
+    : undefined,
 });

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,260 @@
+# Lessons
+
+## issue-lifecycle: skill invocation authorizes the whole flow through merge
+- **2026-06-26 (#296/PR #331):** During an autonomous tick I finished the
+  implementation but held push/PR/merge waiting for plan re-confirmation. User:
+  "What confirmation is outstanding? You should be approved to go all the way
+  through PR merge." When the user explicitly invokes `implementing-issue-plans`
+  (or `next-issue`), that invocation *is* the approval to run through merge —
+  especially when the plan came from an existing issue comment (not
+  self-authored). Don't pause the loop for re-confirmation; the real gates
+  (CI green, demo with outcome evidence, bot-finding triage) still protect the
+  merge. Hold only on genuinely new/irreversible decisions outside the
+  authorized lifecycle.
+
+## Mass-assignment fix: verify "nothing internal uses this" against actual callers
+- **2026-06-23 (#271/PR #278):** Plan 005 assumed only the Celery pipeline wrote
+  episode system fields and that nothing internal went through `update_episode`.
+  Grep proved **two** services (`script_generation_service`, `quality_metrics_service`)
+  wrote system fields *through* `update_episode` — a blanket service allowlist would
+  have silently dropped those writes. Before adding a guard to a shared mutator,
+  `grep` every caller; route legitimate internal writers through a dedicated bypass
+  (`set_episode_system_fields`) rather than weakening the guard.
+- **Latent bug surfaced:** `quality_metrics_service` was calling
+  `update_episode(db, episode_id, {dict})` — wrong signature; only "passed" because
+  the test mocked `update_episode`. Mocks hide signature drift; prefer a real-DB
+  persistence test for write paths.
+- **JSONB in-place mutation doesn't persist:** reassigning a plain (non-Mutable)
+  JSONB column with the *same* dict reference after mutating it in place is not
+  detected by SQLAlchemy → the write silently no-ops. Build a NEW dict
+  (`dict(obj.col or {})`) before adding keys. A regression test that fails on the
+  aliasing version and passes on the copy version is the proof.
+
+
+## Dependency security bumps: prefer `npm update <pkg>` over `npm audit fix`
+- **2026-06-23 (#272/PR #277):** `npm audit fix` (non-`--force`) on this workspaces
+  monorepo churned ~11k lockfile lines and bumped jest's transitive tooling
+  inconsistently → broke the test runner (`this._moduleMocker.clearMocksOnScope is
+  not a function`, 35/37 suites failed to *run*). Reverting and using
+  `npm update next` produced a small, targeted lockfile diff that cleared the HIGH
+  `next` advisory with all 244 web tests + build green.
+- **Pattern:** for a single-package security bump, do `git checkout package-lock.json`
+  (revert any broad fix) then `npm update <pkg>` to touch only that subtree. Reserve
+  `npm audit fix` for when you actually want the whole tree reconciled, and re-run
+  the full test suite immediately after.
+- **Verify it's a regression vs. pre-existing:** when a gate fails after a dep
+  change, check whether the failing package's lockfile entry actually changed
+  (`git diff package-lock.json | grep <pkg>`) before "fixing" — most of the
+  `tsc --noEmit` errors here were pre-existing on `main`, not caused by the bump.
+
+## tsc green locally but red in CI = phantom @types dependency (#280)
+- **Symptom:** `npm run typecheck` exits 0 locally; CI fails with `Cannot find name
+  'expect'/'it'/'describe'`, `Cannot use namespace 'jest' as a value`.
+- **Cause:** `@types/jest` was hoisted into the local root `node_modules` (from some
+  prior/global install) but declared in NO package.json and absent from the lockfile.
+  A clean `npm ci` in CI doesn't get it, so tsc loses the ambient test globals.
+- **Pattern:** before trusting a local `tsc` pass for a new CI gate, check that every
+  `@types/*` the code relies on is actually declared (`grep @types/ package.json`) and
+  in the lockfile (`grep node_modules/@types/<x> package-lock.json`). Fix by adding the
+  missing `@types/*` to the workspace devDeps — don't chase it as a code error.
+- **Related:** jest-dom only augments `jest.Matchers`; the base globals (`expect`/`it`/
+  `describe`/`jest`) come from `@types/jest`, a separate dependency.
+
+## Resource-leak fix: clean up on EVERY terminal path, not just the success path
+- **2026-06-25 (#275/PR #283):** Plan 009 scoped the composed-audio temp-file cleanup
+  to the success path only. But the file is disposable wherever **no retry will read it
+  again** — that's three terminal paths, not one: success, retries-exhausted
+  (`MaxRetriesExceededError` → return "failed"), and **non-retryable errors that
+  re-raise immediately** (the last one was missed in the first pass and caught by
+  `codex review`). The retry path is the only one that must keep the file.
+- **Pattern:** when fixing a "temp/resource leaks" bug on a Celery (or any retrying)
+  task, enumerate every exit: success return, each terminal-failure return, AND each
+  `raise`/re-raise branch. Anywhere the task ends with no further retry, the resource
+  is disposable. A success-only guard re-creates the same leak from the failed tail.
+- **Process:** a human reviewer (m13v) flagged the exhausted-retries gap on the issue;
+  `codex review` (cross-family) flagged the non-retryable-raise gap on the PR. Both
+  were real. Verify-before-fix held: each "missing cleanup" claim was confirmed against
+  the actual control flow (and that no later workflow task reads the local file) before
+  extending scope beyond the written plan.
+
+## Seeding analytics_events directly needs real episode/project FK parents (#274)
+- **2026-06-25 (#274/PR #289):** A characterization test that inserts `AnalyticsEvent`
+  rows on the `test_db` session with random `episode_id`/`project_id` UUIDs fails with
+  `ForeignKeyViolationError` — the table has FKs to `episodes`/`projects`. The
+  `analytics_events` table itself has **no RLS policy** (only a `tenant_id` column, no
+  FK), so `tenant_id=uuid4()` is fine, but the episode/project FKs are enforced.
+- **Pattern:** the `client` fixture yields the *same* session as `test_db`, so create the
+  real project + episode via the API first (`/auth/register` → `/projects` → `/episodes`),
+  then seed events directly with those IDs and custom `created_at`/`device`/`country`/
+  `metadata` the API can't set. Best of both: real FK parents + arbitrary event attrs.
+- **Contract preservation proof:** the strongest evidence a refactor preserves a return
+  shape is running the *new* characterization test against the *old* code (`git show
+  HEAD~1:path > svc.py`, swap, run) — it must pass on both. Identical output = contract held.
+
+## Postgres week numbering ≠ Python strftime("%W") (#274)
+- Don't reach for `to_char(created_at, 'IW')`/ISO week to replace
+  `dt.strftime("%Y-W%W")` — they use different week-numbering conventions and would
+  silently change a frontend-facing key. When pushing aggregation to SQL but a Python
+  date-format must be preserved exactly, `GROUP BY func.date(created_at)` (O(days), not
+  O(events)) and apply the *same* Python `strftime` to the grouped dates. Keeps the
+  format byte-for-byte while still avoiding row materialization.
+
+## Moving runtime state to Redis breaks existing integration tests (#273)
+- When converting an in-memory store (module dict) to a real Redis client, existing **integration** tests that exercise the endpoints now hit the real client. They pass locally if a Redis happens to be running, but the backend CI job has **no Redis server** (rate limiting is disabled; rate-limiter tests mock Redis).
+- Before pushing: run the affected gate with a dead `REDIS_URL` (e.g. `REDIS_URL=redis://localhost:1/0 uv run pytest ...`) to simulate CI, not just with local Redis up.
+- Fix pattern: back the store with a tiny in-memory fake via an autouse fixture (setex/getdel) — no new dependency, no infra.
+
+## DB backup/restore scripts: atomicity + scoped pruning (#293/PR #328)
+- **2026-06-26:** codex cross-family review caught two data-loss risks the first pass missed (CodeRabbit was rate-limited and never ran — its green check was a no-op, so the cross-family pass mattered).
+- `pg_restore --clean` is **not atomic**: a mid-restore failure leaves the live DB half-dropped. Always add `--single-transaction --exit-on-error` so a failed restore rolls back instead of corrupting prod.
+- A retention prune that deletes "everything older than N days under the prefix" will nuke **unrelated** objects sharing that prefix. Scope deletes (and "latest" selection) to the script's own filename pattern (`podcastfy-<stamp>.dump`), never the bare prefix.
+- Demo an infra script's risky logic for real even without the prod deps: ran the actual pg_dump→pg_restore round-trip inside the running `postgres:16` docker container (recovered exact rows), and replayed the prune date-comparison against simulated `aws s3 ls` output. Outcome evidence, not just "exit 0".
+
+## Celery `bind=True` error callbacks are dispatched OLD-STYLE (task_id only) (#294/PR #329)
+- **2026-06-26:** codex flagged it; verified against `celery/backends/base.py::BaseBackend._call_task_errbacks` in 5.5.3. For a `bind=True` errback task, `errback.type.__header__` is a `partial`, so Celery skips the new-style `errback(request, exc, traceback)` path and calls it with **only** `(task_id,)`. `on_workflow_failure(self, task_id, exc, traceback, ...)` therefore raised `TypeError` (missing exc/traceback) every time it fired as a `link_error` — so episodes were **never** marked failed, silently breaking the existing `build_generation_workflow` chain too. The 3-arg signature only works for *unbound* errbacks.
+- **Pattern:** a `link_error` errback that needs the exception must either be unbound, OR make `exc`/`traceback` optional and recover them from the result backend (`AsyncResult(task_id).result/.traceback`). Don't trust that a `.s(episode_id=...)`-style errback gets `(request, exc, traceback)` — prove it with a test that calls the errback the way Celery's old-style path does: `errback.run(task_id, **bound_kwargs)`.
+- **Eager mode does NOT run `link_error`**, so an eager test can't catch this. Test the errback function directly with the old-style arg shape instead.
+- **Verify-before-fix on a review finding:** codex's first claim ("link_error signature wrong") was initially doubted because the same pattern was already all over `build_generation_workflow` — but "already used" ≠ "works". Empirically reproducing the `TypeError` confirmed it was a real *latent* bug, not a regression I introduced.
+
+## Wiring previously-dead enforcement code breaks tests that assumed it was dead (#297/PR #332)
+- **2026-06-27:** `check_episode_limit`/`track_api_call` etc. had zero callers; wiring them in
+  silently broke existing tests written under the dead-code assumption: `test_pagination_basic`
+  (25 episodes for one **free** user → now 402 on the 6th) and `test_billing` asserting a new
+  user's `api_calls == 0` (reading usage is now itself a metered call). **Pattern:** before
+  activating dormant enforcement, grep tests for loops/asserts that depend on the *un*-enforced
+  behavior. Fix at the fixture level when possible (seed an enterprise/unlimited sub on the shared
+  `project_and_auth`) rather than editing each test.
+- **conftest `override_get_db` rolled back the SHARED test session on ANY exception incl.
+  `HTTPException`.** Production uses a session-per-request, so a 402/404 there never wipes other
+  requests' data — but the test session is shared across all requests in a test, so the rollback
+  nuked the registered user → FK violation on the next request. Fix: re-raise `HTTPException`
+  without rolling back; only roll back on genuine (non-HTTP) errors.
+- **Global metering on a deleted user → FK violation, not 401.** `billing_usage`'s only FK is
+  `user_id`; a metering insert for a token whose user was deleted raises `IntegrityError`. Catch
+  it, roll back, and let `get_current_user` return the real 401 — metering must not 500 or
+  pre-empt auth. Also use `verify_access_token` (not `verify_jwt_token`) in the soft user-id
+  helper so refresh/verification tokens aren't metered (auth returns 401, not a metering 402).
+- **api_calls = request meter (count at boundary, all authed requests incl. failures);
+  episodes_created = billing unit (track only after a successful create).** CodeRabbit suggested
+  moving api-call tracking to a post-2xx hook — declined: that lets a client spam failing requests
+  for free, defeating the abuse-prevention goal. Exempt `/billing/*` from the api-cap *gate* (still
+  counted) so an over-quota user can still view usage and upgrade — otherwise the recovery path 402s.
+- **`pytest.ini` `testpaths = tests tests/unit` makes bare `pytest` UNDER-collect (~half the
+  modules, silently).** CI runs `pytest tests/` (explicit path) and collects everything, so the
+  authoritative full run is `cd apps/api && uv run pytest tests/` (~1565 tests), NOT bare `pytest`
+  (~727). The local persistent DB also accumulates cross-run cruft → the full local suite flakes
+  (e.g. `test_audio_snippets::test_download_url_no_s3_config` fails on `main` too); CI's fresh
+  ephemeral DB is the real gate. Don't chase wandering local-suite failures that don't reproduce
+  on a clean DB / in CI.
+
+## RLS fail-loud migration guard interacts with CI's least-privilege migration job (#301/PR #336)
+- **2026-06-27:** Adding `SET LOCAL row_security = off` before the 006/012 backfills makes a
+  non-BYPASSRLS migration run **error** (`query would be affected by row-level security policy`)
+  instead of silently no-op'ing. That's the intended fix — but the existing CI job
+  `migrate-as-non-superuser` (test.yml) ran `alembic upgrade head` as a plain NOSUPERUSER owner
+  (no BYPASSRLS), so the guard would have turned that previously-green job RED. Before adding a
+  fail-loud DB guard, grep CI/deploy for every place that runs migrations under a non-privileged
+  role; that job's premise changes, not just the migration. Reframed it to the two-role model
+  (positive: BYPASSRLS migration role succeeds; negative: non-BYPASSRLS fails loudly).
+- **A negative CI test ("must fail") must assert the failure REASON, not just non-zero exit.**
+  `if uv run alembic upgrade head; then exit 1; fi` goes green on *any* break (an unrelated 003
+  GRANT error would satisfy it). Capture output and `grep -qi 'row-level security'` so the test
+  actually proves the guard fired. (Self-caught mid-flight; CodeRabbit independently flagged it Major.)
+- **A role attribute, not superuser, is the right lever:** `NOSUPERUSER NOCREATEDB NOCREATEROLE
+  BYPASSRLS` keeps the "migrations need no elevated DDL privileges" guard intact while letting
+  RLS-affected backfills see all rows. `FORCE ROW LEVEL SECURITY` makes even the table owner
+  subject to RLS — owning the table is not enough.
+- **Demo against a real DB, both directions:** spun up `postgres:16` in docker, provisioned the
+  exact role matrix, ran `upgrade head` under a BYPASSRLS role (succeeded through 006/012) and a
+  non-BYPASSRLS owner (failed with the precise RLS error). Outcome evidence, not "exit 0".
+
+## A task entry-guard races the dispatcher's status commit (#295/PR #330)
+- **2026-06-26:** Added an entry-time idempotency guard to `generate_podcast_task`
+  (short-circuit if `generation_status == "complete"`). codex flagged a P1: the
+  router dispatched the task **before** committing `generation_status="queued"`
+  (it needed `task.id` from `apply_async` for `generation_progress`). A fast worker
+  could read the stale `complete` status and skip a legitimate **regenerate**, then
+  the router commits `queued` → episode stuck until the reaper. Adding a guard that
+  reads a status the producer hasn't committed yet is a write-after-dispatch race.
+- **Fix pattern:** pre-generate the id (`task_id = str(uuid4())`), commit the
+  starting status **before** `apply_async(task_id=task_id, ...)`. Then a worker can
+  never observe a pre-transition status. Order: persist intent → enqueue.
+- **Reordering opens a new failure mode (two more codex P2s):** once you commit
+  `queued` before enqueue, a broker-down `apply_async` leaves a committed `queued`
+  with no task → wrap enqueue in try/except and **restore the prior status**, not a
+  blanket `failed` — clobbering a still-`complete` episode makes its existing audio
+  undownloadable (download endpoint gates on `complete`). Snapshot
+  `prior_status`/`prior_progress` before overwriting; restore + 503 on enqueue error.
+- **Celery retry vs. the guard:** with `acks_late=False`, `self.retry()` re-runs the
+  same task_id but the status is now the in-progress value the guard would skip on.
+  Make the Redis lock **re-entrant by task_id** and bypass the in-progress gate when
+  `self.request.retries > 0`, else retries silently no-op. Release the lock on every
+  *terminal* exit but NOT the retry path (TTL is the crash backstop).
+
+## E2E test-trust (#302) — re-enabling fixme'd tests verifies the APP, not just selectors
+- **A `fixme`'d E2E suite can hide a broken app, not just stale selectors.** Re-enabling
+  #302's specs surfaced that core project/episode **creation is broken** (web sends
+  `title`/`{language,explicit}`; backend `ProjectCreate` requires `name` +
+  `podcast_metadata{show_title,author,description}`; `GET /projects` 500s). Filed #337.
+  Lesson: when "fixing E2E selectors," actually RUN the flow against the deployed app
+  early — the cheapest probe is a direct `curl` to the API contract before driving the UI.
+- **Verify the web↔API contract by reading both schemas + the proxy.** `/api/proxy/[...path]`
+  is a transparent pass-through (no field remapping), so frontend `title` vs backend `name`
+  mismatches fail at runtime, never at build. Check `apps/api/src/schemas/*.py` field names
+  against the web `fetch` body before trusting a flow.
+- **Playwright `test.describe.fixme` ⇒ Playwright reports those as *skipped*, exit 0.** CI's
+  `needs.test.result` check then prints "Tests passed!" → false green. Gate on a real signal:
+  emit `['json',{outputFile}]` and fail when `stats.expected < MIN_PASSED` (an all-skipped
+  suite has `expected: 0`). `stats.expected` = passed; `-g` filtered-out tests are excluded
+  (not counted as skipped), but an unfiltered run counts `fixme` as `skipped`.
+- **Dev registration is rate-limited (3/hr/IP).** For two-session isolation, provision a
+  persistent second tenant once in `global-setup` (deterministic plus-addressed email,
+  idempotent register) rather than `signUpAndLogin()` per test — fewer regs, more stable.
+- **Shadcn/Radix dialog trap:** the open-trigger and the form submit often share a label
+  ("Create Project"). Scope the submit to `getByRole('dialog').locator('button[type=submit]')`
+  to avoid Playwright strict-mode ambiguity.
+
+## Web↔API contract (#337/#340)
+- **A "field mismatch" contract bug is usually more than field names.** #337 read as
+  `title` vs `name`, but exploration also found: the list read a non-existent envelope key
+  (`data.items` vs API's `{projects:[…]}`), a call to a route that doesn't exist
+  (`/episodes/projects/{id}/episodes` vs real `GET /episodes?project_id=`), and PATCH where the
+  API exposes PUT. When aligning a contract, verify envelope key + route path + HTTP method +
+  field shape — grep the actual router decorators and the `response_model`, don't trust the
+  frontend's assumed shape.
+- **Partial JSONB updates must merge, not replace.** `setattr(obj, "episode_metadata", value)`
+  overwrites the whole JSONB column, so a title-only edit silently drops description/format/
+  explicit/tags. Shallow-merge `{**existing, **provided}` in the service update fn (fixes all
+  callers) rather than making every caller resend the full object.
+- **Relax create-time validation where the UI doesn't collect the field, but keep the
+  completeness gate where it matters.** #337 dropped required show_title/author at *create*
+  (UI collects neither) while leaving the *distribution-time* `REQUIRED_METADATA_FIELDS` gate
+  intact — lightweight create, strict publish.
+
+## 2026-07-05 (#302 tail, PR #344)
+- **Verify reviewer claims empirically before fixing.** GLM's HIGH ("test passes for the wrong reason under the savepoint fixture") was disproven in 2 minutes by reverting the fix and watching the test fail. Plausible mechanism ≠ actual behavior.
+- **`gh workflow run --ref <branch>` races a just-pushed commit.** It resolved the pre-push SHA once; always check the run's `headSha` against local HEAD before trusting a dispatch.
+- **Persistent E2E users + hard billing quotas self-poison.** Shared tenants accumulate metered usage across runs (5 episodes/month burned in a day). Dev/staging needs an enforcement kill-switch (BILLING_ENFORCEMENT_ENABLED=false), same pattern as the rate-limit/email flags.
+- **A "test-trust" issue can conceal a bug stack.** Five layers here (nginx try_files, /api/* ownership, RLS-vs-commit, web route prefix, quota exhaustion) — each invisible until the previous was fixed. Re-run E2E after every layer; don't assume one fix is THE fix.
+
+## Removing "dead" INI sections can activate other dormant config (2026-07-07, PR #345)
+pytest.ini had `markers` and `filterwarnings` written BELOW `[coverage:run]`/`[coverage:report]`
+headers — INI parsing assigned them to those sections, so pytest never saw them. Deleting the
+"dead" sections hoisted `filterwarnings = error` into `[pytest]`, activating it for the first
+time and killing CI collection (pydub compile-time SyntaxWarning → SyntaxError, pytest exit 4).
+Lesson: before deleting an INI/TOML section, check what the *parser* attributes to it — entries
+after a section header belong to that section even if they visually look like part of an earlier
+one. When cleaning dead config, diff the *effective parsed config* before/after, not just the text.
+Also: it passed locally because pydub's .pyc was already compiled (SyntaxWarning only fires on
+first compile); fresh CI venvs recompile. Clear __pycache__ to reproduce compile-time warnings.
+
+## E2E/CI Postgres: never bootstrap the service as the app user when RLS is the product
+- **2026-07-08 (#341):** First local PR-built-stack E2E run had the 3 isolation
+  specs failing — User B could read User A's project. Root cause: the Postgres
+  container's bootstrap user (`POSTGRES_USER: podcastfy`) is a **superuser**, and
+  superusers bypass RLS even under `FORCE ROW LEVEL SECURITY`, so connecting the
+  API as it silently disables multi-tenancy. Any stack that exercises tenant
+  isolation must mirror the dev two-role model (#301): migrate as the BYPASSRLS
+  owner (`podcastfy_user`), run the app as the RLS-subject `podcastfy_app`.
+  `rm-review.yml` still uses the superuser-bootstrap pattern but only
+  health-checks, so it survives; copy its services block, not its DB role.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -7,14 +7,14 @@ Branch: `fix/341-e2e-pr-built-stack`. Plan adapted from CodeRabbit's issue comme
 - [x] Four #337 specs (02-projects isolation, 03-episodes isolation, 10-integration journey + concurrent) un-fixme'd in #338/#344; gate thresholds already MIN_PASSED=18 / MAX_SKIPPED=205.
 
 ## To do
-- [ ] 1. `playwright.config.ts`: env-gated `webServer` array (API uvicorn :8200 w/ `/health`, web `next start` :3200) — active only when BASE_URL is localhost; `reuseExistingServer: !CI`; bumped test/expect timeouts for cold boot.
-- [ ] 2. `tests/e2e/global-setup.ts`: apiURL = `API_URL || NEXT_PUBLIC_API_URL || ${baseURL}/api`; preflight API `/health` probe with actionable "unreachable/unhealthy vs login-failed" errors; keep screenshot-on-failure.
-- [ ] 3. `.github/workflows/playwright-tests.yml` PR/push path → PR-built stack: postgres:16 + redis:7 services, uv sync + alembic migrate, root `npm ci` (workspaces) + web build with `NEXT_PUBLIC_API_URL=http://localhost:8200`, run env per rm-review.yml conventions (`RATE_LIMIT_ENABLED=false`, CORS `http://localhost:3200`), plain-default E2E creds, keep skip-count gate unchanged as the single authoritative signal.
-- [ ] 4. Dev-smoke: keep `workflow_dispatch` path targeting dev; add preflight dev health check that ends the run as skipped/neutral (not failed) when dev is down.
-- [ ] 5. `.github/workflows/test.yml`: delete `test-e2e` job; remove from `quality-gate` needs + summary branch.
-- [ ] 6. `tests/e2e/README.md`: document PR-built-stack model, dev-smoke variant, local run instructions.
-- [ ] 7. Verify locally: run the full E2E suite against the locally-built stack (postgres container + redis), confirm passed>=18.
-- [ ] 8. Quality gate → PR → reviews → demo evidence → CI green → merge.
+- [x] 1. `playwright.config.ts`: env-gated `webServer` array (done; timeout bumps skipped — localhost prod build showed zero flakiness, 19 passed in 11s)
+- [x] 2. `tests/e2e/global-setup.ts`: preflight + diagnostics (negative path exercised: dead API → clear env-problem error)
+- [x] 3. `playwright-tests.yml` PR-built stack — **plus dev-parity RLS roles**: first local run FAILED isolation specs because the bootstrap superuser bypasses FORCE RLS; CI now migrates as BYPASSRLS `podcastfy_user`, API runs as RLS-subject `podcastfy_app` (lesson recorded)
+- [x] 4. Dev-smoke preflight (verified live: dispatch run 28989743173 — healthy dev detected, auth suite 15 passed against dev)
+- [x] 5. `test.yml` `test-e2e` deleted + quality-gate refs removed
+- [x] 6. README updated (execution model + exact local recipe)
+- [x] 7. Local verify: 19 passed / 0 failed / 200 skipped; CI PR run 28989440713 identical (passed=19 skipped=200)
+- [ ] 8. PR #347 open; opencode reviews done (pre-PR "ship it" + post-PR: billing-402 Major fixed in 7dcecb6); demo posted; awaiting CI green on HEAD → final triage → merge. GitGuardian red = false positive on documented throwaway CI literals (same convention as test.yml on main); no branch protection.
 
 ## Acceptance criteria mapping
 - PR-built stack via webServer/services → items 1–3

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,41 +1,27 @@
-# Issue #303 — Coverage gates are hollow (P2.5)
+# Issue #341 — [P2.4b] Restore real E2E CI signal (PR-built stack)
 
-**Branch**: fix/303-coverage-gates (from main). **PR**: TBD.
-(Previous entry: #302 tail complete, PR #344 merged 2026-07-05.)
+Branch: `fix/341-e2e-pr-built-stack`. Plan adapted from CodeRabbit's issue comment; approved autonomously (no architectural fork — both design choices match the AC wording and reuse existing plumbing).
 
-## Problem
-- Backend: `--cov-fail-under=0` in `apps/api/pytest.ini:21`, `.github/workflows/test.yml:84`, `.github/workflows/deploy-dev.yml:94` — gate enforces nothing.
-- Frontend: `jest.config.js:35` excludes all of `src/app/**` — every page + the token-injecting proxy route sit outside the 80% threshold.
+## Already done (verified 2026-07-08, no code needed)
+- [x] Dev `Deploy Frontend` ERESOLVE (lucide-react vs React 19): lucide-react no longer in `apps/web/package.json` (hugeicons migration); last two deploy-dev runs green; dev `/login` renders `input[type="email"]`, `/api/health` healthy.
+- [x] Four #337 specs (02-projects isolation, 03-episodes isolation, 10-integration journey + concurrent) un-fixme'd in #338/#344; gate thresholds already MIN_PASSED=18 / MAX_SKIPPED=205.
 
-## Measured baseline (2026-07-06)
-- Frontend with src/app included: 63.85% stmts / 54.48% branch / 54.64% funcs / 65.32% lines (gate = 80 on all four).
-  - Zero coverage: projects/[id]/page.tsx (130 st), login/page.tsx (26 st), root page.tsx (12 st), nextauth route (5 st), layouts (12 st).
-  - Partial: dashboard 50/103 st, episodes 120/247 st. Proxy route already 89/97%.
-- Backend TOTAL: **81.96%** (6237 st, 1125 missed; 1587 passed, 1 known local-env failure test_audio_snippets::test_download_url_no_s3_config, 7 skipped). Need ~190 more covered statements for 85 + margin. Lowest: content router 40%, billing_service 41%, team_service 41%, episodes router 45%, rss_feed 48%, quality_metrics 55%, distribution_target_service 56%.
+## To do
+- [ ] 1. `playwright.config.ts`: env-gated `webServer` array (API uvicorn :8200 w/ `/health`, web `next start` :3200) — active only when BASE_URL is localhost; `reuseExistingServer: !CI`; bumped test/expect timeouts for cold boot.
+- [ ] 2. `tests/e2e/global-setup.ts`: apiURL = `API_URL || NEXT_PUBLIC_API_URL || ${baseURL}/api`; preflight API `/health` probe with actionable "unreachable/unhealthy vs login-failed" errors; keep screenshot-on-failure.
+- [ ] 3. `.github/workflows/playwright-tests.yml` PR/push path → PR-built stack: postgres:16 + redis:7 services, uv sync + alembic migrate, root `npm ci` (workspaces) + web build with `NEXT_PUBLIC_API_URL=http://localhost:8200`, run env per rm-review.yml conventions (`RATE_LIMIT_ENABLED=false`, CORS `http://localhost:3200`), plain-default E2E creds, keep skip-count gate unchanged as the single authoritative signal.
+- [ ] 4. Dev-smoke: keep `workflow_dispatch` path targeting dev; add preflight dev health check that ends the run as skipped/neutral (not failed) when dev is down.
+- [ ] 5. `.github/workflows/test.yml`: delete `test-e2e` job; remove from `quality-gate` needs + summary branch.
+- [ ] 6. `tests/e2e/README.md`: document PR-built-stack model, dev-smoke variant, local run instructions.
+- [ ] 7. Verify locally: run the full E2E suite against the locally-built stack (postgres container + redis), confirm passed>=18.
+- [ ] 8. Quality gate → PR → reviews → demo evidence → CI green → merge.
 
-## Plan
-1. **Frontend config** (`apps/web/jest.config.js`): drop `!src/app/**`; add boilerplate-only exclusions `!src/app/**/layout.tsx` (no loading/error/not-found files exist). Keep all page.tsx/route.ts under coverage.
-2. **Frontend backfill** (TDD, model on existing __tests__/app/* suites):
-   - New: `__tests__/app/login/page.test.tsx` (model: signup test)
-   - New: `__tests__/app/projects/[id]/page.test.tsx` (model: episodes test)
-   - New: `__tests__/app/page.test.tsx` (root redirect page)
-   - New: `__tests__/app/api/auth/nextauth-route.test.ts` (mock next-auth, assert GET/POST exports)
-   - Strengthen: dashboard page test (uncovered: 84,91-119,124-157,162-183,196-208,220-333), episodes page test (uncovered ranges incl. 204-285, 290-322, 618-665, 772-871)
-   - Target: ≥80% on all four global metrics with src/app included.
-3. **Backend gate**: set `--cov-fail-under` in pytest.ini + test.yml + deploy-dev.yml to measured target (≥85 per AC if reachable; else backfill to reach it — scope TBD from measurement).
-4. **Backend backfill** (if measured <85): add tests for lowest-covered modules until ≥85.
-5. Quality gate: full local test runs, lint, third-party review (opencode/GLM pre-PR + post-PR), deslop.
-6. PR → demo (coverage gate demonstrably fails when coverage drops / passes at threshold) → CI green → merge.
+## Acceptance criteria mapping
+- PR-built stack via webServer/services → items 1–3
+- Single failing-capable E2E signal → item 5
+- Clear global-setup diagnostics + non-blocking dev-smoke → items 2, 4
+- ERESOLVE fixed → already done (verify only)
+- Four #337 specs green on PR-built stack → item 7 + PR CI run
 
-## Progress (2026-07-07)
-- Frontend DONE+verified: jest gate green with src/app included — 95.97/83.11/97.23/97.66, 41 suites / 331 tests. Config: `!src/app/**` → `!src/app/**/layout.tsx`.
-- Backend DONE+verified: TOTAL 93.70% (gate 85 active in pytest.ini/test.yml/deploy-dev.yml), 1651 passed 0 failed 7 skipped. Key: `.coveragerc concurrency=greenlet` fixed async undercounting (real baseline was higher than 81.96%); new tests for content/episodes/billing/team/rss/quality_metrics/encryption modules.
-- Bonus fixes: audio_snippets patch-target bug (router-local import binding); episode tags filter double-JSON-encode bug in episode_service.py:181 (TDD RED→GREEN, regression test test_get_episodes_filters_by_tags).
-- Deslop scan: clean except 2 helper duplications — backend `_register_user`→tests/unit/conftest.py DONE (765 unit tests green); frontend `withOverride`→shared test-util IN PROGRESS.
-- Next: commit → opencode/GLM pre-PR review → PR → demo → CI gate → merge.
-
-## Acceptance criteria (from issue)
-- [ ] Backend `--cov-fail-under` set to real target (≥85) in gating workflow
-- [ ] `src/app/**` no longer wholesale-excluded; only layout/loading/error boilerplate excluded
-- [ ] page.tsx / route.ts files under coverage
-- [ ] Tests backfilled where coverage drops (gates actually pass)
+## Archive: Issue #303 — COMPLETE (PR #345 squash-merged 2026-07-07 as a95684b)
+Coverage gates real (backend 85 enforced @93.84%, frontend covers src/app). Follow-up: #346 (pytest warnings policy).

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -46,9 +46,55 @@ plus-addressed account derived from `E2E_TEST_EMAIL`). Provisioning User B once 
 rather than signing up a fresh user per test — keeps the suite within the dev
 registration rate limit (3/hr/IP).
 
+## Execution model (#341)
+
+- **PRs and pushes** run against a **PR-built local stack**: when `BASE_URL`
+  points at localhost, `playwright.config.ts` boots the API (uvicorn) and the
+  built web app (`next start`) via Playwright's `webServer`, with Postgres/Redis
+  provided as CI job services. A PR therefore validates **its own code**, and a
+  dev-host outage can no longer fail (or falsely pass) a PR.
+- **Dev-smoke** is the optional `workflow_dispatch` path of
+  `.github/workflows/playwright-tests.yml`: it targets the deployed
+  `https://dev.podcaststudiohub.me` and is **skipped with a warning** (not
+  failed) when dev's `/api/health` is unreachable.
+- `global-setup` preflights the API health endpoint so an unreachable/unhealthy
+  target fails with an explicit environment error instead of an opaque
+  `input[type="email"]` timeout.
+
 ## Running Tests
 
-### Run all tests
+### Run against a local PR-built stack
+```bash
+# Prereqs: Postgres + Redis running, `uv sync` done in apps/api, and a web build:
+NEXT_PUBLIC_API_URL=http://localhost:8200 npm run build:web
+
+# One-time DB setup — the API MUST connect as the RLS-subject app role
+# (podcastfy_app), not the bootstrap superuser: superusers bypass RLS even
+# under FORCE ROW LEVEL SECURITY, so the isolation specs would (correctly)
+# fail with cross-tenant reads. Migrations run as the BYPASSRLS owner:
+#   CREATE ROLE podcastfy_user LOGIN PASSWORD 'postgres' NOSUPERUSER NOCREATEDB NOCREATEROLE BYPASSRLS;
+#   CREATE ROLE podcastfy_app  LOGIN PASSWORD 'postgres' NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT;
+#   CREATE DATABASE podcastfy_e2e OWNER podcastfy_user;
+# then (from apps/api):
+#   MIGRATION_DATABASE_URL=postgresql+asyncpg://podcastfy_user:postgres@localhost:5432/podcastfy_e2e \
+#   DATABASE_URL=postgresql+asyncpg://podcastfy_app:postgres@localhost:5432/podcastfy_e2e \
+#   ENCRYPTION_KEY=test-encryption-key-for-ci-00000 JWT_SECRET_KEY=test-jwt-secret-for-ci \
+#   uv run alembic upgrade head
+
+BASE_URL=http://localhost:3200 API_URL=http://localhost:8200 \
+NEXT_PUBLIC_API_URL=http://localhost:8200 \
+DATABASE_URL=postgresql+asyncpg://podcastfy_app:postgres@localhost:5432/podcastfy_e2e \
+SECRET_KEY=test-secret-key-for-ci ENCRYPTION_KEY=test-encryption-key-for-ci-00000 \
+JWT_SECRET_KEY=test-jwt-secret-for-ci NEXTAUTH_SECRET=test-nextauth-secret-for-ci \
+NEXTAUTH_URL=http://localhost:3200 CORS_ORIGINS='["http://localhost:3200"]' \
+RATE_LIMIT_ENABLED=false \
+E2E_TEST_EMAIL=e2e-ci@example.com E2E_TEST_PASSWORD='E2e-ci-Passw0rd!' \
+npx playwright test
+```
+Playwright starts uvicorn (:8200) and `next start` (:3200) itself and reuses
+already-running servers outside CI.
+
+### Run all tests (against the default remote target)
 ```bash
 npx playwright test
 ```
@@ -114,11 +160,14 @@ BASE_URL=https://podcaststudiohub.me npx playwright test
 ## CI/CD Integration
 
 Tests run automatically on:
-- Pull requests to main
-- Pushes to main
-- Manual workflow dispatch
+- Pull requests to main/develop — against the PR-built local stack
+- Pushes to main/develop — against the stack built from the merged code
+- Manual workflow dispatch — dev-smoke against the deployed dev host
+  (non-blocking: skipped when dev is down)
 
-See `.github/workflows/playwright-tests.yml`
+`.github/workflows/playwright-tests.yml` is the **single authoritative E2E
+signal** (with the skip-count gate); the old always-green `test-e2e` job in
+`test.yml` was removed (#341).
 
 ## Writing New Tests
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -84,10 +84,10 @@ NEXT_PUBLIC_API_URL=http://localhost:8200 npm run build:web
 BASE_URL=http://localhost:3200 API_URL=http://localhost:8200 \
 NEXT_PUBLIC_API_URL=http://localhost:8200 \
 DATABASE_URL=postgresql+asyncpg://podcastfy_app:postgres@localhost:5432/podcastfy_e2e \
-SECRET_KEY=test-secret-key-for-ci ENCRYPTION_KEY=test-encryption-key-for-ci-00000 \
+ENVIRONMENT=development ENCRYPTION_KEY=test-encryption-key-for-ci-00000 \
 JWT_SECRET_KEY=test-jwt-secret-for-ci NEXTAUTH_SECRET=test-nextauth-secret-for-ci \
 NEXTAUTH_URL=http://localhost:3200 CORS_ORIGINS='["http://localhost:3200"]' \
-RATE_LIMIT_ENABLED=false \
+RATE_LIMIT_ENABLED=false BILLING_ENFORCEMENT_ENABLED=false \
 E2E_TEST_EMAIL=e2e-ci@example.com E2E_TEST_PASSWORD='E2e-ci-Passw0rd!' \
 npx playwright test
 ```

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -45,12 +45,12 @@ async function provisionUser(
 
   const context = await browser.newContext({ baseURL });
   const page = await context.newPage();
-  await page.goto('/login');
-  await page.fill('input[type="email"]', email);
-  await page.fill('input[type="password"]', password);
-  await page.click('button[type="submit"]');
 
   try {
+    await page.goto('/login');
+    await page.fill('input[type="email"]', email);
+    await page.fill('input[type="password"]', password);
+    await page.click('button[type="submit"]');
     await page.waitForURL(/\/dashboard/, { timeout: 15000 });
   } catch {
     const screenshot = `tests/e2e/.auth/login-failure-${statePath.replace(/[/.]/g, '_')}.png`;
@@ -60,7 +60,9 @@ async function provisionUser(
     await context.close();
     throw new Error(
       `[global-setup] Browser login failed for ${email} — stayed at: ${currentURL}\n` +
-      `Page text: ${pageText.substring(0, 500)}\nScreenshot: ${screenshot}`
+      `Page text: ${pageText.substring(0, 500)}\nScreenshot: ${screenshot}\n` +
+      'The API passed its health preflight, so likely causes are: the web frontend is ' +
+      'down/stale and not rendering the login form, or the credentials are wrong for this target.'
     );
   }
 
@@ -83,7 +85,29 @@ async function globalSetup(config: FullConfig) {
   mkdirSync(dirname(USER_A_AUTH_PATH), { recursive: true });
 
   const baseURL = config.projects[0].use.baseURL || 'https://dev.podcaststudiohub.me';
-  const apiURL = process.env.NEXT_PUBLIC_API_URL || `${baseURL}/api`;
+  // API_URL wins (server-side/CI override), then the build-time public URL,
+  // then the nginx-style `/api` prefix used by the deployed hosts.
+  const apiURL = process.env.API_URL || process.env.NEXT_PUBLIC_API_URL || `${baseURL}/api`;
+
+  // Preflight: distinguish "target stack unreachable/unhealthy" from real
+  // login/spec failures, so an env outage reads as an env outage (#341).
+  let health: Response;
+  try {
+    health = await fetch(`${apiURL}/health`, { signal: AbortSignal.timeout(15000) });
+  } catch (err) {
+    throw new Error(
+      `[global-setup] API unreachable at ${apiURL}/health (baseURL=${baseURL}): ${err}\n` +
+      'The target stack is not running or not reachable — this is an environment problem, ' +
+      'not a spec failure. For a local run, check DATABASE_URL/Redis and that the webServer ' +
+      'processes can boot; for a dev-smoke run, check the deployed host.'
+    );
+  }
+  if (!health.ok) {
+    throw new Error(
+      `[global-setup] API unhealthy: ${apiURL}/health returned ${health.status}. ` +
+      'Fix the target environment before re-running the suite.'
+    );
+  }
 
   const browser = await chromium.launch();
   try {

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -85,9 +85,14 @@ async function globalSetup(config: FullConfig) {
   mkdirSync(dirname(USER_A_AUTH_PATH), { recursive: true });
 
   const baseURL = config.projects[0].use.baseURL || 'https://dev.podcaststudiohub.me';
-  // API_URL wins (server-side/CI override), then the build-time public URL,
-  // then the nginx-style `/api` prefix used by the deployed hosts.
-  const apiURL = process.env.API_URL || process.env.NEXT_PUBLIC_API_URL || `${baseURL}/api`;
+  // API_URL wins (server-side/CI override), then the build-time public URL.
+  // Fallback must mirror playwright.config.ts: local-stack runs get the
+  // webServer-booted API port; deployed hosts use the nginx `/api` prefix.
+  const isLocalStack = /^https?:\/\/(localhost|127\.0\.0\.1)(:|\/|$)/.test(baseURL);
+  const apiURL =
+    process.env.API_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    (isLocalStack ? 'http://localhost:8200' : `${baseURL}/api`);
 
   // Preflight: distinguish "target stack unreachable/unhealthy" from real
   // login/spec failures, so an env outage reads as an env outage (#341).


### PR DESCRIPTION
Closes #341.

## What changed
- **`playwright.config.ts`** — env-gated `webServer` array: when `BASE_URL` points at localhost, Playwright boots the API (uvicorn `:8200`, readiness on `/health`) and the built web app (`next start` `:3200`) itself. Remote targets (dev host) are untouched.
- **`tests/e2e/global-setup.ts`** — API health **preflight** with actionable diagnostics: "target unreachable/unhealthy" (environment problem) is now distinguishable from "login failed" (frontend down/stale vs bad credentials). `apiURL` honors `API_URL || NEXT_PUBLIC_API_URL || ${baseURL}/api`.
- **`.github/workflows/playwright-tests.yml`** — the PR/push path provisions `postgres:16` + `redis:7` services, **dev-parity DB roles**, migrates, builds the web app, and runs the suite against the PR's own code. The skip-count gate is unchanged and remains the single authoritative signal. `workflow_dispatch` is the dev-smoke path: a preflight **skips (never hard-fails)** the run when dev is unhealthy.
- **`.github/workflows/test.yml`** — deleted the `continue-on-error: true` `test-e2e` job (false-green by construction) and its quality-gate references.
- **`tests/e2e/README.md`** — documents the execution model and exact local-run recipe.

## Key finding during verification
The first local run failed its 3 isolation specs: **User B could read User A's project**. Root cause: the Postgres bootstrap user is a **superuser, and superusers bypass RLS even under `FORCE ROW LEVEL SECURITY`** — connecting the API as it silently disables multi-tenancy. The workflow now mirrors the two-role model from `test.yml`'s `migrate-as-non-superuser` job (#301): migrations as BYPASSRLS `podcastfy_user`, API as RLS-subject `podcastfy_app`. The E2E gate therefore exercises the *real* tenancy model.

## Acceptance criteria
- ✅ E2E on PRs runs against a PR-built stack (webServer + services) — a PR validates its own code
- ✅ Exactly one authoritative, failing-capable E2E signal (`test-e2e` deleted)
- ✅ `global-setup` fails with clear, actionable messages; dev-smoke skips (non-blocking) when dev is down
- ✅ Dev `Deploy Frontend` ERESOLVE — already resolved before this PR (lucide-react removed in the hugeicons migration; last deploys green; dev login renders, `/api/health` healthy 2026-07-08)
- ✅ Four #337 specs re-verified green against the PR-built stack (see evidence)

## Evidence (local PR-built stack)
```
200 skipped
19 passed (11.1s)
```
19 ≥ MIN_PASSED 18, 200 ≤ MAX_SKIPPED 205 — and the 19 include the four #337 isolation/journey specs, now under genuine RLS. Preflight failure path exercised: dead API → `[global-setup] API unreachable at http://localhost:59999/health (baseURL=…): … environment problem, not a spec failure`.

## Known limitations
- No `ALTER DEFAULT PRIVILEGES` for `podcastfy_app` (pre-existing): a future migration creating a table without an explicit `GRANT` will hit `permission denied` under the RLS-subject role — now surfaced by this E2E gate rather than at deploy time.
- Dev-smoke (`workflow_dispatch`) requires `E2E_TEST_EMAIL`/`E2E_TEST_PASSWORD` secrets (intentional — it targets the persistent dev DB; the plain CI defaults are only for the throwaway PR stack).
- `rm-review.yml` still bootstraps Postgres as the app user; it only health-checks (no isolation specs), so it is unaffected — flagged for a future cleanup.

## Reviews
Pre-PR cross-family review: opencode (GLM) — verdict "ship it"; its three Minor findings (workflow-path trigger, ENVIRONMENT parity, no-op SECRET_KEY) are fixed in 136a4cb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playwright end-to-end tests now run in CI against a PR-built, locally started web + API stack for more realistic coverage.
  * Manual “dev-smoke” runs health-check the deployed dev environment and skip safely when unavailable.
* **Bug Fixes**
  * Improved end-to-end setup and failure diagnostics for faster troubleshooting when authentication or connectivity fails.
* **Documentation**
  * Expanded E2E README to clarify CI vs local vs dev-smoke execution behavior and environment variables.
* **Refactor**
  * E2E reporting is now handled by the dedicated Playwright workflow, removing the separate E2E job from the main pipeline/quality gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->