### PR TITLE
fix(db): RLS defense-in-depth — secret role password, SECURITY DEFINER auth lookup, scoped INSERTs, RLS on billing/analytics (#304)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ podcaststudiohub/
 ├── apps/
 │   ├── api/              # FastAPI backend (Python, uv)
 │   │   ├── src/          # Application code (api, routers, services, tasks, models, schemas, middleware, utils)
-│   │   ├── alembic/      # DB migrations (versions/ up to 012_…)
+│   │   ├── alembic/      # DB migrations (versions/ up to 014_…)
 │   │   ├── tests/        # pytest + pytest-bdd
 │   │   └── pyproject.toml
 │   └── web/              # Next.js 15 frontend (TypeScript, App Router)

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -7,6 +7,13 @@
 # The podcastfy_app role is created by migration 003_force_rls.py.
 DATABASE_URL=postgresql+asyncpg://podcastfy_app:podcastfy_app_password@localhost:5432/podcastfy
 
+# Password for the podcastfy_app role, read by Alembic at migration time (#304):
+# migration 003 uses it when creating the role on a fresh install, and migration
+# 014 rotates the role password to it whenever it is set. Set this to a real
+# secret on any deployed environment (and put the same value in DATABASE_URL);
+# when unset, local dev/CI keep the default above.
+# APP_DB_PASSWORD=
+
 # Privileged URL used ONLY by Alembic migrations (issue #301). It must point at a
 # superuser or BYPASSRLS owner role so RLS-affected backfills (006/012) apply to
 # ALL rows. When unset, Alembic falls back to DATABASE_URL — but running migrations

--- a/apps/api/alembic/versions/003_force_rls.py
+++ b/apps/api/alembic/versions/003_force_rls.py
@@ -12,6 +12,7 @@ Revises: 002
 Create Date: 2025-10-20 21:00:00.000000
 
 """
+import os
 from typing import Sequence, Union
 
 from alembic import op
@@ -77,19 +78,32 @@ def upgrade() -> None:
 	# -------------------------------------------------------------------------
 	# Use DO block because CREATE ROLE IF NOT EXISTS is not supported directly
 	# in older PostgreSQL versions (<= 14 doesn't have CREATE ROLE IF NOT EXISTS)
-	op.execute("""
-		DO $$
+	# Fresh installs take the role password from APP_DB_PASSWORD; the literal
+	# fallback keeps local dev and CI working (migration 014 rotates it from
+	# the same env var on real deploys). Single quotes are SQL-escaped.
+	app_db_password = os.environ.get(
+		'APP_DB_PASSWORD', 'podcastfy_app_password'
+	).replace("'", "''")
+	op.execute(f"""
+		DO $do$
 		BEGIN
 			IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'podcastfy_app') THEN
 				CREATE ROLE podcastfy_app
 					NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT LOGIN
-					PASSWORD 'podcastfy_app_password';
+					PASSWORD '{app_db_password}';
 			END IF;
 		END
-		$$;
+		$do$;
 	""")
 
-	op.execute('GRANT CONNECT ON DATABASE podcastfy TO podcastfy_app')
+	# GRANT cannot take current_database() directly — go through format()
+	op.execute("""
+		DO $do$
+		BEGIN
+			EXECUTE format('GRANT CONNECT ON DATABASE %I TO podcastfy_app', current_database());
+		END
+		$do$;
+	""")
 	op.execute('GRANT USAGE ON SCHEMA public TO podcastfy_app')
 	op.execute('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO podcastfy_app')
 	op.execute('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO podcastfy_app')
@@ -100,7 +114,13 @@ def downgrade() -> None:
 	op.execute('REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM podcastfy_app')
 	op.execute('REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM podcastfy_app')
 	op.execute('REVOKE USAGE ON SCHEMA public FROM podcastfy_app')
-	op.execute('REVOKE CONNECT ON DATABASE podcastfy FROM podcastfy_app')
+	op.execute("""
+		DO $do$
+		BEGIN
+			EXECUTE format('REVOKE CONNECT ON DATABASE %I FROM podcastfy_app', current_database());
+		END
+		$do$;
+	""")
 
 	op.execute('DROP ROLE IF EXISTS podcastfy_app')
 

--- a/apps/api/alembic/versions/003_force_rls.py
+++ b/apps/api/alembic/versions/003_force_rls.py
@@ -15,6 +15,7 @@ Create Date: 2025-10-20 21:00:00.000000
 import os
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -80,17 +81,24 @@ def upgrade() -> None:
 	# in older PostgreSQL versions (<= 14 doesn't have CREATE ROLE IF NOT EXISTS)
 	# Fresh installs take the role password from APP_DB_PASSWORD; the literal
 	# fallback keeps local dev and CI working (migration 014 rotates it from
-	# the same env var on real deploys). Single quotes are SQL-escaped.
-	app_db_password = os.environ.get(
-		'APP_DB_PASSWORD', 'podcastfy_app_password'
-	).replace("'", "''")
-	op.execute(f"""
+	# the same env var on real deploys). The secret travels as a bound
+	# parameter into a transaction-local GUC, then through format(%L) — never
+	# interpolated into SQL text, so any password content is safe.
+	app_db_password = os.environ.get('APP_DB_PASSWORD', 'podcastfy_app_password')
+	op.get_bind().execute(
+		sa.text("SELECT set_config('app.bootstrap_pw', :pw, true)"),
+		{"pw": app_db_password},
+	)
+	op.execute("""
 		DO $do$
 		BEGIN
 			IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'podcastfy_app') THEN
-				CREATE ROLE podcastfy_app
-					NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT LOGIN
-					PASSWORD '{app_db_password}';
+				EXECUTE format(
+					'CREATE ROLE podcastfy_app '
+					'NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT LOGIN '
+					'PASSWORD %L',
+					current_setting('app.bootstrap_pw')
+				);
 			END IF;
 		END
 		$do$;

--- a/apps/api/alembic/versions/014_rls_defense_in_depth.py
+++ b/apps/api/alembic/versions/014_rls_defense_in_depth.py
@@ -56,6 +56,7 @@ BILLING_ANALYTICS_TABLES = [
 
 LOOKUP_FUNCTIONS = [
     'auth_lookup_user_by_email(text)',
+    'auth_lookup_user_by_id(uuid)',
     'billing_tenant_for_stripe_customer(text)',
 ]
 
@@ -115,6 +116,18 @@ def upgrade() -> None:
         SET search_path = public, pg_temp
         AS $fn$
             SELECT id, tenant_id FROM users WHERE lower(email) = lower(p_email)
+        $fn$
+    """)
+
+    # Same least-privilege shape, for flows that hold a user id but no JWT
+    # (e.g. the Spotify OAuth browser-redirect callback).
+    op.execute("""
+        CREATE OR REPLACE FUNCTION auth_lookup_user_by_id(p_id uuid)
+        RETURNS TABLE (id uuid, tenant_id uuid)
+        LANGUAGE sql STABLE SECURITY DEFINER
+        SET search_path = public, pg_temp
+        AS $fn$
+            SELECT id, tenant_id FROM users WHERE id = p_id
         $fn$
     """)
 

--- a/apps/api/alembic/versions/014_rls_defense_in_depth.py
+++ b/apps/api/alembic/versions/014_rls_defense_in_depth.py
@@ -1,0 +1,140 @@
+"""RLS defense-in-depth hardening (issue #304)
+
+- Adds ENABLE + FORCE ROW LEVEL SECURITY and tenant_isolation policies to the
+  billing_subscriptions, billing_usage and analytics_events tables (created in
+  010/011 with tenant_id columns but no RLS).
+- Drops the permissive tenant_isolation_insert_* WITH CHECK (true) policies:
+  policies OR together, so they nullified the FOR ALL policy's WITH CHECK on
+  INSERT. With them gone, INSERTs must satisfy
+  tenant_id = current_setting('app.tenant_id')::uuid. Registration (the one
+  pre-tenant INSERT) now arms the new tenant's context itself (auth_service).
+- Drops the blanket users_auth_lookup FOR SELECT USING (true) policy, which
+  exposed every user row (password_hash, encrypted_api_keys) across tenants.
+  Auth bootstraps through a narrow SECURITY DEFINER lookup instead; the Stripe
+  webhook gets an equivalent stripe_customer_id -> tenant_id lookup.
+- Rotates the podcastfy_app role password when APP_DB_PASSWORD is set (no-op
+  otherwise, so CI and local dev keep their locally provisioned passwords).
+
+Revision ID: 014
+Revises: 013
+Create Date: 2026-07-09 12:00:00.000000
+
+"""
+import os
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '014'
+down_revision: Union[str, None] = '013'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# The 11 core tenant-scoped tables from migration 003
+CORE_TABLES = [
+    'users',
+    'conversation_templates',
+    'tts_configurations',
+    'projects',
+    'episodes',
+    'content_sources',
+    'rss_feeds',
+    'distribution_targets',
+    'audio_snippets',
+    'episode_layouts',
+    'episode_compositions',
+]
+
+# Tenant-scoped tables added after 003 without RLS
+BILLING_ANALYTICS_TABLES = [
+    'billing_subscriptions',
+    'billing_usage',
+    'analytics_events',
+]
+
+LOOKUP_FUNCTIONS = [
+    'auth_lookup_user_by_email(text)',
+    'billing_tenant_for_stripe_customer(text)',
+]
+
+
+def upgrade() -> None:
+    # 1. Billing/analytics tables: same FORCE-RLS + tenant policy as the core
+    #    tables get in 003.
+    for table in BILLING_ANALYTICS_TABLES:
+        op.execute(f'ALTER TABLE {table} ENABLE ROW LEVEL SECURITY')
+        op.execute(f"""
+            CREATE POLICY tenant_isolation_{table} ON {table}
+                FOR ALL
+                USING  (tenant_id = current_setting('app.tenant_id', true)::uuid)
+                WITH CHECK (tenant_id = current_setting('app.tenant_id', true)::uuid)
+        """)
+        op.execute(f'ALTER TABLE {table} FORCE ROW LEVEL SECURITY')
+
+    # 2. Drop the permissive INSERT policies. The FOR ALL tenant_isolation
+    #    policy's WITH CHECK then governs INSERT on every core table.
+    for table in CORE_TABLES:
+        op.execute(f'DROP POLICY IF EXISTS tenant_isolation_insert_{table} ON {table}')
+
+    # 3. Replace the blanket users SELECT policy with narrow SECURITY DEFINER
+    #    lookups. Owner is the migration role (BYPASSRLS), so the function can
+    #    read through FORCE RLS; EXECUTE is granted only to the app role.
+    op.execute('DROP POLICY IF EXISTS users_auth_lookup ON users')
+
+    op.execute("""
+        CREATE OR REPLACE FUNCTION auth_lookup_user_by_email(p_email text)
+        RETURNS SETOF users
+        LANGUAGE sql STABLE SECURITY DEFINER
+        SET search_path = public, pg_temp
+        AS $fn$
+            SELECT * FROM users WHERE lower(email) = lower(p_email)
+        $fn$
+    """)
+
+    op.execute("""
+        CREATE OR REPLACE FUNCTION billing_tenant_for_stripe_customer(p_customer_id text)
+        RETURNS uuid
+        LANGUAGE sql STABLE SECURITY DEFINER
+        SET search_path = public, pg_temp
+        AS $fn$
+            SELECT tenant_id FROM billing_subscriptions
+            WHERE stripe_customer_id = p_customer_id
+        $fn$
+    """)
+
+    for fn in LOOKUP_FUNCTIONS:
+        op.execute(f'REVOKE ALL ON FUNCTION {fn} FROM PUBLIC')
+        op.execute(f'GRANT EXECUTE ON FUNCTION {fn} TO podcastfy_app')
+
+    # 4. Rotate the app role password when a secret is provided (deploys set
+    #    APP_DB_PASSWORD; CI/local keep their locally provisioned passwords).
+    app_db_password = os.environ.get('APP_DB_PASSWORD')
+    if app_db_password:
+        escaped = app_db_password.replace("'", "''")
+        op.execute(f"ALTER ROLE podcastfy_app PASSWORD '{escaped}'")
+
+
+def downgrade() -> None:
+    for fn in LOOKUP_FUNCTIONS:
+        op.execute(f'DROP FUNCTION IF EXISTS {fn}')
+
+    op.execute("""
+        CREATE POLICY users_auth_lookup ON users
+            FOR SELECT
+            USING (true)
+    """)
+
+    for table in CORE_TABLES:
+        op.execute(f"""
+            CREATE POLICY tenant_isolation_insert_{table} ON {table}
+                FOR INSERT
+                WITH CHECK (true)
+        """)
+
+    for table in BILLING_ANALYTICS_TABLES:
+        op.execute(f'ALTER TABLE {table} NO FORCE ROW LEVEL SECURITY')
+        op.execute(f'DROP POLICY IF EXISTS tenant_isolation_{table} ON {table}')
+        op.execute(f'ALTER TABLE {table} DISABLE ROW LEVEL SECURITY')
+
+    # Password rotation is intentionally not reverted.

--- a/apps/api/alembic/versions/014_rls_defense_in_depth.py
+++ b/apps/api/alembic/versions/014_rls_defense_in_depth.py
@@ -23,6 +23,7 @@ Create Date: 2026-07-09 12:00:00.000000
 import os
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -60,6 +61,27 @@ LOOKUP_FUNCTIONS = [
 
 
 def upgrade() -> None:
+    # 0. The SECURITY DEFINER functions below must be owned by a role that can
+    #    read through FORCE RLS, or auth breaks for every user. Fail loudly if
+    #    Alembic fell back to the RLS-subject app role (MIGRATION_DATABASE_URL
+    #    unset — issue #301).
+    op.execute("""
+        DO $do$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_roles
+                WHERE rolname = current_user AND (rolsuper OR rolbypassrls)
+            ) THEN
+                RAISE EXCEPTION
+                    'migration 014 must run as a superuser/BYPASSRLS role '
+                    '(set MIGRATION_DATABASE_URL); running as % would leave '
+                    'auth lookup functions unable to read through FORCE RLS',
+                    current_user;
+            END IF;
+        END
+        $do$;
+    """)
+
     # 1. Billing/analytics tables: same FORCE-RLS + tenant policy as the core
     #    tables get in 003.
     for table in BILLING_ANALYTICS_TABLES:
@@ -82,13 +104,17 @@ def upgrade() -> None:
     #    read through FORCE RLS; EXECUTE is granted only to the app role.
     op.execute('DROP POLICY IF EXISTS users_auth_lookup ON users')
 
+    # Least-privilege by construction: the function discloses ONLY
+    # (id, tenant_id) for a given email — never password_hash or
+    # encrypted_api_keys. Callers set that tenant's context and load the full
+    # row through the normal RLS-governed SELECT.
     op.execute("""
         CREATE OR REPLACE FUNCTION auth_lookup_user_by_email(p_email text)
-        RETURNS SETOF users
+        RETURNS TABLE (id uuid, tenant_id uuid)
         LANGUAGE sql STABLE SECURITY DEFINER
         SET search_path = public, pg_temp
         AS $fn$
-            SELECT * FROM users WHERE lower(email) = lower(p_email)
+            SELECT id, tenant_id FROM users WHERE lower(email) = lower(p_email)
         $fn$
     """)
 
@@ -109,10 +135,24 @@ def upgrade() -> None:
 
     # 4. Rotate the app role password when a secret is provided (deploys set
     #    APP_DB_PASSWORD; CI/local keep their locally provisioned passwords).
+    #    The secret travels as a bound parameter into a transaction-local GUC,
+    #    then through format(%L) — never interpolated into SQL text.
     app_db_password = os.environ.get('APP_DB_PASSWORD')
     if app_db_password:
-        escaped = app_db_password.replace("'", "''")
-        op.execute(f"ALTER ROLE podcastfy_app PASSWORD '{escaped}'")
+        op.get_bind().execute(
+            sa.text("SELECT set_config('app.bootstrap_pw', :pw, true)"),
+            {"pw": app_db_password},
+        )
+        op.execute("""
+            DO $do$
+            BEGIN
+                EXECUTE format(
+                    'ALTER ROLE podcastfy_app PASSWORD %L',
+                    current_setting('app.bootstrap_pw')
+                );
+            END
+            $do$;
+        """)
 
 
 def downgrade() -> None:

--- a/apps/api/src/routers/distribution_targets.py
+++ b/apps/api/src/routers/distribution_targets.py
@@ -13,11 +13,11 @@ from typing import Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import select
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import settings
-from ..database import get_db
+from ..database import arm_tenant_context, get_db, set_tenant_context
 from ..middleware.auth import get_current_user
 from ..models import User
 from ..schemas.distribution_target import (
@@ -178,17 +178,25 @@ async def spotify_callback(
 	except Exception:
 		show_info = {"id": "", "name": ""}
 
-	# Look up user from DB to get tenant_id
+	# Look up the user's tenant via the SECURITY DEFINER bootstrap (#304):
+	# this callback is a browser redirect from Spotify with no JWT, so no
+	# tenant context is armed and a plain users SELECT would see nothing.
 	user_result = await db.execute(
-		select(User).where(User.id == UUID(user_id_str))
+		text("SELECT id, tenant_id FROM auth_lookup_user_by_id(:uid)"),
+		{"uid": UUID(user_id_str)},
 	)
-	db_user = user_result.scalar_one_or_none()
+	db_user = user_result.one_or_none()
 
 	if not db_user:
 		raise HTTPException(
 			status_code=status.HTTP_400_BAD_REQUEST,
 			detail="User not found",
 		)
+
+	# Arm + set the user's tenant so the distribution_targets INSERT below
+	# passes the scoped WITH CHECK policy.
+	arm_tenant_context(db, str(db_user.tenant_id))
+	await set_tenant_context(db, str(db_user.tenant_id))
 
 	# Create distribution target
 	target = await create_spotify_target(

--- a/apps/api/src/services/auth_service.py
+++ b/apps/api/src/services/auth_service.py
@@ -240,16 +240,22 @@ async def get_user_by_email(session: AsyncSession, email: str) -> Optional["User
     """
     # Case-insensitive lookup: email is not identity-significant by case (#255);
     # the function lowercases both sides, matching legacy mixed-case rows too.
-    # Goes through the SECURITY DEFINER auth_lookup_user_by_email function
-    # (migration 014) because login/resend-verification run before any tenant
-    # context exists — the blanket users SELECT policy is gone (issue #304).
+    # Two-step bootstrap (issue #304): login/resend-verification run before any
+    # tenant context exists and the blanket users SELECT policy is gone. The
+    # SECURITY DEFINER function discloses only (id, tenant_id) for the email —
+    # never password_hash/encrypted_api_keys — then the full row is loaded
+    # through the normal RLS-governed SELECT under that tenant's context.
     result = await session.execute(
-        select(User).from_statement(
-            text("SELECT * FROM auth_lookup_user_by_email(:email)")
-        ),
+        text("SELECT id, tenant_id FROM auth_lookup_user_by_email(:email)"),
         {"email": email},
     )
-    return result.scalar_one_or_none()
+    row = result.one_or_none()
+    if row is None:
+        return None
+
+    await set_tenant_context(session, str(row.tenant_id))
+    full = await session.execute(select(User).where(User.id == row.id))
+    return full.scalar_one_or_none()
 
 
 # ============================================================================
@@ -353,7 +359,7 @@ async def authenticate_user(
         return None
 
     # Set tenant context so the UPDATE is allowed by RLS, then update last_login
-    await session.execute(text(f"SET LOCAL app.tenant_id = '{user.tenant_id}'"))
+    await set_tenant_context(session, str(user.tenant_id))
     user.last_login = datetime.now(timezone.utc).replace(tzinfo=None)
     await session.commit()
 

--- a/apps/api/src/services/auth_service.py
+++ b/apps/api/src/services/auth_service.py
@@ -6,7 +6,7 @@ from uuid import UUID, uuid4
 import bcrypt
 from jose import jwt, JWTError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, text, func
+from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 from fastapi import HTTPException
 
@@ -237,10 +237,16 @@ async def get_user_by_email(session: AsyncSession, email: str) -> Optional["User
     Returns:
         User instance or None if not found
     """
-    # Case-insensitive lookup: email is not identity-significant by case (#255).
-    # func.lower(...) also matches legacy mixed-case rows from before canonicalization.
+    # Case-insensitive lookup: email is not identity-significant by case (#255);
+    # the function lowercases both sides, matching legacy mixed-case rows too.
+    # Goes through the SECURITY DEFINER auth_lookup_user_by_email function
+    # (migration 014) because login/resend-verification run before any tenant
+    # context exists — the blanket users SELECT policy is gone (issue #304).
     result = await session.execute(
-        select(User).where(func.lower(User.email) == email.lower())
+        select(User).from_statement(
+            text("SELECT * FROM auth_lookup_user_by_email(:email)")
+        ),
+        {"email": email},
     )
     return result.scalar_one_or_none()
 
@@ -273,6 +279,12 @@ async def create_user(
     try:
         # Generate unique tenant_id for new user (each user is their own tenant)
         tenant_id = uuid4()
+
+        # Arm the new tenant's RLS context before the INSERT: registration is
+        # the one pre-tenant write, and since migration 014 the INSERT must
+        # satisfy WITH CHECK (tenant_id = current_setting('app.tenant_id')).
+        from ..database import set_tenant_context
+        await set_tenant_context(session, str(tenant_id))
 
         # Canonicalize email to lowercase so case is never identity-significant (#255).
         email = email.lower()
@@ -326,11 +338,8 @@ async def authenticate_user(
     Returns:
         User model instance if valid credentials, None otherwise
     """
-    # Query user by email (case-insensitive — case is not identity-significant, #255)
-    result = await session.execute(
-        select(User).where(func.lower(User.email) == email.lower())
-    )
-    user = result.scalar_one_or_none()
+    # Pre-tenant lookup via the SECURITY DEFINER function (case-insensitive)
+    user = await get_user_by_email(session, email)
 
     if user is None:
         return None

--- a/apps/api/src/services/auth_service.py
+++ b/apps/api/src/services/auth_service.py
@@ -358,8 +358,8 @@ async def authenticate_user(
     if not user.is_active:
         return None
 
-    # Set tenant context so the UPDATE is allowed by RLS, then update last_login
-    await set_tenant_context(session, str(user.tenant_id))
+    # get_user_by_email already set this user's tenant context in the current
+    # transaction, so the last_login UPDATE passes RLS.
     user.last_login = datetime.now(timezone.utc).replace(tzinfo=None)
     await session.commit()
 

--- a/apps/api/src/services/auth_service.py
+++ b/apps/api/src/services/auth_service.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException
 
 from sqlalchemy.orm.attributes import flag_modified
 
+from ..database import set_tenant_context
 from ..models.user import User
 from ..config import settings
 from ..utils.encryption import encrypt_credential, decrypt_credential
@@ -283,7 +284,6 @@ async def create_user(
         # Arm the new tenant's RLS context before the INSERT: registration is
         # the one pre-tenant write, and since migration 014 the INSERT must
         # satisfy WITH CHECK (tenant_id = current_setting('app.tenant_id')).
-        from ..database import set_tenant_context
         await set_tenant_context(session, str(tenant_id))
 
         # Canonicalize email to lowercase so case is never identity-significant (#255).

--- a/apps/api/src/services/billing_service.py
+++ b/apps/api/src/services/billing_service.py
@@ -6,9 +6,10 @@ from typing import Any, Dict, Optional
 from uuid import UUID
 
 from fastapi import HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from ..database import set_tenant_context
 from ..models.billing_subscription import BillingSubscription, SubscriptionStatus, SubscriptionTier
 from ..utils.pricing import PRICING_TIERS
 from ..utils.datetime_utils import utcnow
@@ -253,11 +254,36 @@ async def process_webhook(
 	return {"status": "processed", "event_type": event_type}
 
 
+async def _bootstrap_webhook_tenant(db: AsyncSession, customer_id: Optional[str]) -> bool:
+	"""Arm RLS tenant context for a Stripe webhook (no JWT -> no tenant context).
+
+	Resolves stripe_customer_id -> tenant_id through the SECURITY DEFINER
+	function from migration 014 (billing_subscriptions is FORCE-RLS'd, so a
+	plain SELECT would see nothing), then sets app.tenant_id so the existing
+	ORM code operates on the right tenant's rows. Returns False when the
+	customer matches no subscription.
+	"""
+	if not customer_id:
+		return False
+	result = await db.execute(
+		text("SELECT billing_tenant_for_stripe_customer(:cid)"),
+		{"cid": customer_id},
+	)
+	tenant_id = result.scalar_one_or_none()
+	if tenant_id is None:
+		return False
+	await set_tenant_context(db, str(tenant_id))
+	return True
+
+
 async def _handle_subscription_updated(db: AsyncSession, subscription_obj: Dict[str, Any]) -> None:
 	"""Update local subscription from Stripe data."""
 	stripe_sub_id = subscription_obj.get("id")
 	customer_id = subscription_obj.get("customer")
 	stripe_status = subscription_obj.get("status", "active")
+
+	if not await _bootstrap_webhook_tenant(db, customer_id):
+		return
 
 	result = await db.execute(
 		select(BillingSubscription).where(
@@ -277,6 +303,9 @@ async def _handle_subscription_updated(db: AsyncSession, subscription_obj: Dict[
 async def _handle_subscription_deleted(db: AsyncSession, subscription_obj: Dict[str, Any]) -> None:
 	"""Mark subscription as canceled."""
 	customer_id = subscription_obj.get("customer")
+
+	if not await _bootstrap_webhook_tenant(db, customer_id):
+		return
 
 	result = await db.execute(
 		select(BillingSubscription).where(

--- a/apps/api/src/services/billing_service.py
+++ b/apps/api/src/services/billing_service.py
@@ -9,7 +9,7 @@ from fastapi import HTTPException, status
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..database import set_tenant_context
+from ..database import arm_tenant_context, set_tenant_context
 from ..models.billing_subscription import BillingSubscription, SubscriptionStatus, SubscriptionTier
 from ..utils.pricing import PRICING_TIERS
 from ..utils.datetime_utils import utcnow
@@ -259,9 +259,11 @@ async def _bootstrap_webhook_tenant(db: AsyncSession, customer_id: Optional[str]
 
 	Resolves stripe_customer_id -> tenant_id through the SECURITY DEFINER
 	function from migration 014 (billing_subscriptions is FORCE-RLS'd, so a
-	plain SELECT would see nothing), then sets app.tenant_id so the existing
-	ORM code operates on the right tenant's rows. Returns False when the
-	customer matches no subscription.
+	plain SELECT would see nothing), then ARMS app.tenant_id (survives any
+	future mid-handler commit — one-shot SET LOCAL would silently drop the
+	event after the first commit) so the existing ORM code operates on the
+	right tenant's rows. Returns False when the customer matches no
+	subscription.
 	"""
 	if not customer_id:
 		return False
@@ -272,6 +274,9 @@ async def _bootstrap_webhook_tenant(db: AsyncSession, customer_id: Optional[str]
 	tenant_id = result.scalar_one_or_none()
 	if tenant_id is None:
 		return False
+	arm_tenant_context(db, str(tenant_id))
+	# Arming takes effect at the next transaction begin; set it for the
+	# already-open transaction too.
 	await set_tenant_context(db, str(tenant_id))
 	return True
 

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -115,14 +115,22 @@ async def client(test_db):
     This fixture properly handles tenant context for RLS by accepting the Request parameter.
     """
     from fastapi import HTTPException, Request
-    from src.database import set_tenant_context
+    from src.database import arm_tenant_context, set_tenant_context
 
     # Override the database dependency with proper tenant context support
     async def override_get_db(request: Request):
         """Override get_db to use test database with tenant context."""
         try:
-            # Set tenant context for RLS if available
+            # Arm AND set. Arming mirrors production get_db_session: mid-request
+            # commits (e.g. the usage-metering dependency) end the transaction
+            # and would leave app.tenant_id defined-but-empty, breaking every
+            # later RLS policy evaluation (issue #302). But the armed listener
+            # only fires on the NEXT transaction begin — unlike production,
+            # this session is shared across requests, so a different user's
+            # request arriving mid-transaction also needs an immediate
+            # SET LOCAL to switch tenant now.
             if hasattr(request.state, 'tenant_id') and request.state.tenant_id:
+                arm_tenant_context(test_db, str(request.state.tenant_id))
                 await set_tenant_context(test_db, str(request.state.tenant_id))
 
             yield test_db

--- a/apps/api/tests/test_analytics_aggregation.py
+++ b/apps/api/tests/test_analytics_aggregation.py
@@ -23,13 +23,19 @@ from src.services.analytics_service import (
 
 
 async def _setup_project_episode(client):
-    """Register a user and create a project + episode; return (project_id, episode_id) as UUIDs."""
+    """Register a user and create a project + episode.
+
+    Returns (project_id, episode_id, tenant_id) as UUIDs — events must carry
+    the registering user's real tenant_id now that analytics_events is
+    RLS-protected (migration 014).
+    """
     resp = await client.post("/auth/register", json={
         "email": f"test_{uuid4()}@example.com",
         "password": "SecurePass123!",
         "full_name": "Test User",
     })
     assert resp.status_code == 201, resp.text
+    tenant_id = UUID(resp.json()["user"]["tenant_id"])
     headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
 
     resp = await client.post("/projects", json={
@@ -51,13 +57,13 @@ async def _setup_project_episode(client):
     assert resp.status_code == 201, resp.text
     episode_id = UUID(resp.json()["id"])
 
-    return project_id, episode_id
+    return project_id, episode_id, tenant_id
 
 
-def _mk_event(*, episode_id, project_id, event_type, created_at,
+def _mk_event(*, tenant_id, episode_id, project_id, event_type, created_at,
               device_type=None, app_name=None, country=None, metadata=None):
     return AnalyticsEvent(
-        tenant_id=uuid4(),  # no FK / no RLS on analytics_events
+        tenant_id=tenant_id,  # must match app.tenant_id (RLS WITH CHECK, #304)
         episode_id=episode_id,
         project_id=project_id,
         event_type=event_type,
@@ -72,36 +78,36 @@ def _mk_event(*, episode_id, project_id, event_type, created_at,
 @pytest.mark.asyncio
 async def test_get_episode_analytics_characterization(client, test_db):
     """Exact dict for a mixed set of events within an explicit date window."""
-    proj, ep = await _setup_project_episode(client)
+    proj, ep, tenant = await _setup_project_episode(client)
     date_from = datetime(2026, 6, 1)
     date_to = datetime(2026, 6, 30, 23, 59, 59)
 
     events = [
-        _mk_event(episode_id=ep, project_id=proj, event_type="download",
+        _mk_event(tenant_id=tenant, episode_id=ep, project_id=proj, event_type="download",
                   created_at=datetime(2026, 6, 10), device_type="mobile",
                   app_name="apple_podcasts", country="US"),
-        _mk_event(episode_id=ep, project_id=proj, event_type="download",
+        _mk_event(tenant_id=tenant, episode_id=ep, project_id=proj, event_type="download",
                   created_at=datetime(2026, 6, 11), device_type="desktop",
                   app_name="spotify", country="GB"),
-        _mk_event(episode_id=ep, project_id=proj, event_type="play",
+        _mk_event(tenant_id=tenant, episode_id=ep, project_id=proj, event_type="play",
                   created_at=datetime(2026, 6, 12), device_type="mobile",
                   app_name="apple_podcasts", country="US",
                   metadata={"duration_listened_seconds": 120, "completed": True}),
-        _mk_event(episode_id=ep, project_id=proj, event_type="play",
+        _mk_event(tenant_id=tenant, episode_id=ep, project_id=proj, event_type="play",
                   created_at=datetime(2026, 6, 13), device_type="tablet",
                   app_name="overcast", country="US",
                   metadata={"duration_listened_seconds": 60, "completed": False}),
         # play with empty metadata + NULL device/app/country: counted as play only
-        _mk_event(episode_id=ep, project_id=proj, event_type="play",
+        _mk_event(tenant_id=tenant, episode_id=ep, project_id=proj, event_type="play",
                   created_at=datetime(2026, 6, 14), metadata={}),
-        _mk_event(episode_id=ep, project_id=proj, event_type="stream",
+        _mk_event(tenant_id=tenant, episode_id=ep, project_id=proj, event_type="stream",
                   created_at=datetime(2026, 6, 15), device_type="desktop",
                   app_name="other", country="GB"),
-        _mk_event(episode_id=ep, project_id=proj, event_type="share",
+        _mk_event(tenant_id=tenant, episode_id=ep, project_id=proj, event_type="share",
                   created_at=datetime(2026, 6, 16), device_type="mobile",
                   app_name="other", country="US"),
         # outside the window -> excluded entirely
-        _mk_event(episode_id=ep, project_id=proj, event_type="download",
+        _mk_event(tenant_id=tenant, episode_id=ep, project_id=proj, event_type="download",
                   created_at=datetime(2026, 7, 5), device_type="mobile",
                   app_name="apple_podcasts", country="US"),
     ]
@@ -158,29 +164,29 @@ async def test_get_episode_analytics_zero_events(test_db):
 @pytest.mark.asyncio
 async def test_get_project_analytics_characterization(client, test_db):
     """Exact dict for a project summary using now-relative dates (default 30d window)."""
-    proj, ep = await _setup_project_episode(client)
+    proj, ep, tenant = await _setup_project_episode(client)
     now = utcnow()
 
     in_window = [
-        _mk_event(episode_id=ep, project_id=proj, event_type="download",
+        _mk_event(tenant_id=tenant, episode_id=ep, project_id=proj, event_type="download",
                   created_at=now - timedelta(days=2)),
-        _mk_event(episode_id=ep, project_id=proj, event_type="download",
+        _mk_event(tenant_id=tenant, episode_id=ep, project_id=proj, event_type="download",
                   created_at=now - timedelta(days=3)),
-        _mk_event(episode_id=ep, project_id=proj, event_type="play",
+        _mk_event(tenant_id=tenant, episode_id=ep, project_id=proj, event_type="play",
                   created_at=now - timedelta(days=4),
                   metadata={"duration_listened_seconds": 120, "completed": True}),
-        _mk_event(episode_id=ep, project_id=proj, event_type="play",
+        _mk_event(tenant_id=tenant, episode_id=ep, project_id=proj, event_type="play",
                   created_at=now - timedelta(days=5),
                   metadata={"duration_listened_seconds": 60}),
-        _mk_event(episode_id=ep, project_id=proj, event_type="play",
+        _mk_event(tenant_id=tenant, episode_id=ep, project_id=proj, event_type="play",
                   created_at=now - timedelta(days=6), metadata={}),
-        _mk_event(episode_id=ep, project_id=proj, event_type="stream",
+        _mk_event(tenant_id=tenant, episode_id=ep, project_id=proj, event_type="stream",
                   created_at=now - timedelta(days=7)),
-        _mk_event(episode_id=ep, project_id=proj, event_type="share",
+        _mk_event(tenant_id=tenant, episode_id=ep, project_id=proj, event_type="share",
                   created_at=now - timedelta(days=8)),
     ]
     # outside the 30-day window -> excluded
-    outside = _mk_event(episode_id=ep, project_id=proj, event_type="download",
+    outside = _mk_event(tenant_id=tenant, episode_id=ep, project_id=proj, event_type="download",
                         created_at=now - timedelta(days=40))
     for e in in_window + [outside]:
         test_db.add(e)

--- a/apps/api/tests/test_distribution_targets.py
+++ b/apps/api/tests/test_distribution_targets.py
@@ -374,6 +374,70 @@ async def test_spotify_callback_creates_target(client, auth_headers):
 
 
 @pytest.mark.asyncio
+async def test_spotify_callback_works_without_request_tenant_context(client, auth_headers, test_db):
+	"""Regression (#304 post-PR review): the OAuth callback is a browser
+	redirect with no JWT, so the request arms no tenant context. The handler
+	must bootstrap the user's tenant itself — for the users lookup AND the
+	distribution_targets INSERT (scoped WITH CHECK). Simulate production by
+	arming an unrelated tenant on the shared test session first."""
+	from src.database import arm_tenant_context, set_tenant_context
+
+	with patch("src.routers.distribution_targets.settings") as mock_settings:
+		mock_settings.SPOTIFY_CLIENT_ID = "test-client-id"
+		mock_settings.SPOTIFY_REDIRECT_URI = "https://api.example.com/callback"
+		auth_response = await client.post(
+			"/distribution-targets/spotify/authorize",
+			headers=auth_headers
+		)
+	assert auth_response.status_code == 200
+	state = auth_response.json()["state"]
+
+	mock_token_response = {
+		"access_token": "spotify-access-token",
+		"refresh_token": "spotify-refresh-token",
+		"expires_in": 3600,
+		"token_type": "Bearer"
+	}
+	mock_show_response = {"id": "show-id-456", "name": "Ctx Test Show"}
+
+	with patch("src.services.distribution_target_service.httpx") as mock_httpx:
+		mock_client = AsyncMock()
+		mock_httpx.AsyncClient.return_value.__aenter__.return_value = mock_client
+		mock_httpx.AsyncClient.return_value.__aexit__.return_value = None
+
+		token_resp = MagicMock()
+		token_resp.status_code = 200
+		token_resp.json.return_value = mock_token_response
+		token_resp.raise_for_status = MagicMock()
+
+		show_resp = MagicMock()
+		show_resp.status_code = 200
+		show_resp.json.return_value = mock_show_response
+		show_resp.raise_for_status = MagicMock()
+
+		mock_client.post.return_value = token_resp
+		mock_client.get.return_value = show_resp
+
+		with patch("src.routers.distribution_targets.settings") as mock_settings:
+			mock_settings.SPOTIFY_CLIENT_ID = "test-client-id"
+			mock_settings.SPOTIFY_CLIENT_SECRET = "test-client-secret"
+			mock_settings.SPOTIFY_REDIRECT_URI = "https://api.example.com/callback"
+
+			# Production has NO tenant context on the callback's fresh session;
+			# the shared test session inherits the authorize request's armed
+			# context, which masks the bug — overwrite it with a foreign tenant.
+			foreign = str(uuid4())
+			arm_tenant_context(test_db, foreign)
+			await set_tenant_context(test_db, foreign)
+
+			response = await client.get(
+				f"/distribution-targets/spotify/callback?code=auth-code-456&state={state}"
+			)
+
+	assert response.status_code in (200, 302)
+
+
+@pytest.mark.asyncio
 async def test_spotify_callback_invalid_state(client, auth_headers):
 	"""Test that Spotify callback with invalid state returns 400."""
 	response = await client.get(

--- a/apps/api/tests/test_rls_hardening.py
+++ b/apps/api/tests/test_rls_hardening.py
@@ -1,0 +1,283 @@
+"""RLS defense-in-depth hardening (issue #304).
+
+Verifies the DB-layer backstops added by migration 014:
+- billing_subscriptions / billing_usage / analytics_events are FORCE-RLS'd with
+  tenant_isolation policies (cross-tenant reads return nothing, mismatched-tenant
+  writes are rejected).
+- The permissive ``tenant_isolation_insert_*`` WITH CHECK (true) policies are gone:
+  INSERTs whose tenant_id doesn't match app.tenant_id are rejected on core tables.
+- The blanket ``users_auth_lookup`` USING (true) SELECT policy is gone; auth
+  bootstraps through narrow SECURITY DEFINER lookup functions instead.
+- The Stripe webhook (no JWT -> no tenant context) still updates subscriptions by
+  bootstrapping tenant context from the stripe_customer_id definer lookup.
+
+All tests run on the non-superuser podcastfy_app role (see conftest) so FORCE RLS
+is actually exercised.
+"""
+from datetime import date
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.exc import DBAPIError
+
+from src.database import set_tenant_context
+from src.models.billing_subscription import BillingSubscription
+from src.models.billing_usage import BillingUsage
+from src.models.analytics_event import AnalyticsEvent
+from src.models.user import User
+from src.services.auth_service import authenticate_user, create_user, get_user_by_email
+from src.services.billing_service import (
+    _handle_subscription_deleted,
+    _handle_subscription_updated,
+)
+
+
+async def _make_user(test_db, email: str) -> User:
+    """Create a user through the real registration path (arms its own context)."""
+    return await create_user(
+        session=test_db, email=email, password="Str0ng!pass", full_name="RLS Test"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Billing / analytics tables: FORCE RLS + tenant_isolation policies
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_billing_subscription_hidden_from_other_tenant(test_db):
+    user = await _make_user(test_db, f"rls-billing-{uuid4().hex[:8]}@example.com")
+
+    await set_tenant_context(test_db, str(user.tenant_id))
+    sub = BillingSubscription(
+        id=uuid4(),
+        user_id=user.id,
+        tenant_id=user.tenant_id,
+        tier="pro",
+        stripe_customer_id=f"cus_{uuid4().hex[:12]}",
+    )
+    test_db.add(sub)
+    await test_db.flush()
+
+    # Same tenant sees it
+    result = await test_db.execute(
+        select(BillingSubscription).where(BillingSubscription.user_id == user.id)
+    )
+    assert result.scalar_one_or_none() is not None
+
+    # Another tenant's context sees nothing, even without a WHERE tenant filter
+    await set_tenant_context(test_db, str(uuid4()))
+    result = await test_db.execute(
+        select(BillingSubscription).where(BillingSubscription.user_id == user.id)
+    )
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_billing_usage_hidden_from_other_tenant(test_db):
+    user = await _make_user(test_db, f"rls-usage-{uuid4().hex[:8]}@example.com")
+
+    await set_tenant_context(test_db, str(user.tenant_id))
+    usage = BillingUsage(
+        id=uuid4(),
+        user_id=user.id,
+        tenant_id=user.tenant_id,
+        period_start=date(2026, 7, 1),
+        period_end=date(2026, 7, 31),
+    )
+    test_db.add(usage)
+    await test_db.flush()
+
+    await set_tenant_context(test_db, str(uuid4()))
+    result = await test_db.execute(
+        select(BillingUsage).where(BillingUsage.user_id == user.id)
+    )
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_analytics_events_hidden_from_other_tenant(test_db):
+    user = await _make_user(test_db, f"rls-analytics-{uuid4().hex[:8]}@example.com")
+
+    await set_tenant_context(test_db, str(user.tenant_id))
+    event = AnalyticsEvent(
+        id=uuid4(),
+        tenant_id=user.tenant_id,
+        event_type="download",
+    )
+    test_db.add(event)
+    await test_db.flush()
+
+    await set_tenant_context(test_db, str(uuid4()))
+    result = await test_db.execute(
+        select(AnalyticsEvent).where(AnalyticsEvent.id == event.id)
+    )
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_analytics_insert_with_mismatched_tenant_rejected(test_db):
+    """WITH CHECK on the new analytics policy rejects a spoofed tenant_id."""
+    user = await _make_user(test_db, f"rls-spoof-{uuid4().hex[:8]}@example.com")
+    await set_tenant_context(test_db, str(user.tenant_id))
+
+    event = AnalyticsEvent(id=uuid4(), tenant_id=uuid4(), event_type="download")
+    test_db.add(event)
+    with pytest.raises(DBAPIError, match="row-level security"):
+        await test_db.flush()
+    await test_db.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Core tables: permissive INSERT WITH CHECK (true) policies removed
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_core_table_insert_with_mismatched_tenant_rejected(test_db):
+    """Inserting a project whose tenant_id != app.tenant_id must fail (backstop
+    against tenant-id-from-input bugs). Previously allowed by
+    tenant_isolation_insert_projects WITH CHECK (true)."""
+    user = await _make_user(test_db, f"rls-proj-{uuid4().hex[:8]}@example.com")
+    await set_tenant_context(test_db, str(user.tenant_id))
+
+    with pytest.raises(DBAPIError, match="row-level security"):
+        await test_db.execute(
+            text(
+                "INSERT INTO projects (id, tenant_id, user_id, name, created_at, updated_at) "
+                "VALUES (:id, :tenant_id, :user_id, 'spoof', now(), now())"
+            ),
+            {"id": uuid4(), "tenant_id": uuid4(), "user_id": user.id},
+        )
+    await test_db.rollback()
+
+
+@pytest.mark.asyncio
+async def test_registration_insert_still_works_without_prior_context(test_db):
+    """create_user is the one pre-tenant INSERT: it must arm the new tenant's
+    context itself so the scoped WITH CHECK passes."""
+    email = f"rls-register-{uuid4().hex[:8]}@example.com"
+    user = await _make_user(test_db, email)
+    assert user.id is not None
+    assert user.tenant_id is not None
+
+
+# ---------------------------------------------------------------------------
+# users table: blanket USING (true) SELECT replaced by SECURITY DEFINER lookup
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_users_direct_select_blocked_across_tenants(test_db):
+    """A plain SELECT on users under another tenant's context must return
+    nothing — the users_auth_lookup USING (true) policy is gone."""
+    email = f"rls-users-{uuid4().hex[:8]}@example.com"
+    user = await _make_user(test_db, email)
+
+    await set_tenant_context(test_db, str(uuid4()))
+    result = await test_db.execute(select(User).where(User.id == user.id))
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_auth_lookup_by_email_works_across_contexts(test_db):
+    """get_user_by_email must keep working with no/foreign tenant context via
+    the SECURITY DEFINER lookup (login + resend-verification bootstrap)."""
+    email = f"rls-lookup-{uuid4().hex[:8]}@example.com"
+    created = await _make_user(test_db, email)
+
+    # Foreign tenant context — the definer function must still find the user
+    await set_tenant_context(test_db, str(uuid4()))
+    found = await get_user_by_email(test_db, email.upper())  # case-insensitive
+    assert found is not None
+    assert found.id == created.id
+
+
+@pytest.mark.asyncio
+async def test_authenticate_user_works_without_tenant_context(test_db):
+    """Login: authenticate_user must find the user pre-tenant and still update
+    last_login under the user's own context."""
+    email = f"rls-login-{uuid4().hex[:8]}@example.com"
+    await _make_user(test_db, email)
+
+    await set_tenant_context(test_db, str(uuid4()))
+    user = await authenticate_user(test_db, email, "Str0ng!pass")
+    assert user is not None
+    assert user.last_login is not None
+
+
+# ---------------------------------------------------------------------------
+# Stripe webhook: bootstraps tenant context from stripe_customer_id
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_webhook_subscription_updated_without_tenant_context(test_db):
+    user = await _make_user(test_db, f"rls-hook-{uuid4().hex[:8]}@example.com")
+    customer_id = f"cus_{uuid4().hex[:12]}"
+
+    await set_tenant_context(test_db, str(user.tenant_id))
+    sub = BillingSubscription(
+        id=uuid4(),
+        user_id=user.id,
+        tenant_id=user.tenant_id,
+        tier="pro",
+        status="active",
+        stripe_customer_id=customer_id,
+    )
+    test_db.add(sub)
+    await test_db.flush()
+
+    # Simulate the webhook's session state: some unrelated (effectively no)
+    # tenant context — the handler must bootstrap the right tenant itself.
+    await set_tenant_context(test_db, str(uuid4()))
+    await _handle_subscription_updated(
+        test_db,
+        {"id": f"sub_{uuid4().hex[:12]}", "customer": customer_id, "status": "past_due"},
+    )
+
+    await set_tenant_context(test_db, str(user.tenant_id))
+    result = await test_db.execute(
+        select(BillingSubscription).where(
+            BillingSubscription.stripe_customer_id == customer_id
+        )
+    )
+    refreshed = result.scalar_one()
+    assert refreshed.status == "past_due"
+
+
+@pytest.mark.asyncio
+async def test_webhook_subscription_deleted_without_tenant_context(test_db):
+    user = await _make_user(test_db, f"rls-hookdel-{uuid4().hex[:8]}@example.com")
+    customer_id = f"cus_{uuid4().hex[:12]}"
+
+    await set_tenant_context(test_db, str(user.tenant_id))
+    sub = BillingSubscription(
+        id=uuid4(),
+        user_id=user.id,
+        tenant_id=user.tenant_id,
+        tier="pro",
+        status="active",
+        stripe_customer_id=customer_id,
+    )
+    test_db.add(sub)
+    await test_db.flush()
+
+    await set_tenant_context(test_db, str(uuid4()))
+    await _handle_subscription_deleted(test_db, {"customer": customer_id})
+
+    await set_tenant_context(test_db, str(user.tenant_id))
+    result = await test_db.execute(
+        select(BillingSubscription).where(
+            BillingSubscription.stripe_customer_id == customer_id
+        )
+    )
+    refreshed = result.scalar_one()
+    assert refreshed.status == "canceled"
+    assert refreshed.canceled_at is not None
+
+
+@pytest.mark.asyncio
+async def test_webhook_unknown_customer_is_noop(test_db):
+    await set_tenant_context(test_db, str(uuid4()))
+    # Must not raise for a customer id that matches no subscription
+    await _handle_subscription_updated(
+        test_db, {"id": "sub_x", "customer": "cus_does_not_exist", "status": "active"}
+    )

--- a/apps/api/tests/test_rls_hardening.py
+++ b/apps/api/tests/test_rls_hardening.py
@@ -192,6 +192,16 @@ async def test_auth_lookup_by_email_works_across_contexts(test_db):
 
 
 @pytest.mark.asyncio
+async def test_auth_lookup_function_exposes_only_id_and_tenant(test_db):
+    """The SECURITY DEFINER lookup must never disclose password_hash or
+    encrypted_api_keys — it returns only (id, tenant_id)."""
+    result = await test_db.execute(
+        text("SELECT * FROM auth_lookup_user_by_email('nobody@example.com')")
+    )
+    assert set(result.keys()) == {"id", "tenant_id"}
+
+
+@pytest.mark.asyncio
 async def test_authenticate_user_works_without_tenant_context(test_db):
     """Login: authenticate_user must find the user pre-tenant and still update
     last_login under the user's own context."""

--- a/apps/api/tests/test_usage_concurrency.py
+++ b/apps/api/tests/test_usage_concurrency.py
@@ -41,29 +41,22 @@ async def committing_session_factory():
 	"""
 	engine = create_async_engine(TEST_DATABASE_URL, poolclass=NullPool, echo=False)
 	factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-	created_user_ids: list = []
+	created_users: list = []  # (user_id, tenant_id) pairs
 
 	async def cleanup():
+		# billing_usage and users are both FORCE RLS (#304) — every delete
+		# needs the owning tenant's context, so work per-user/per-transaction.
 		async with factory() as session:
-			# billing_usage has no RLS — deletes unconditionally.
-			await session.execute(
-				delete(BillingUsage).where(BillingUsage.user_id.in_(created_user_ids))
-			)
-			# users is FORCE RLS; DELETE needs a matching tenant context.
-			for uid in created_user_ids:
-				row = (
-					await session.execute(select(User).where(User.id == uid))
-				).scalar_one_or_none()
-				if row is not None:
-					await session.execute(
-						text(f"SET LOCAL app.tenant_id = '{row.tenant_id}'")
-					)
-					await session.execute(delete(User).where(User.id == uid))
-					await session.commit()
-			await session.commit()
+			for uid, tid in created_users:
+				await session.execute(text(f"SET LOCAL app.tenant_id = '{tid}'"))
+				await session.execute(
+					delete(BillingUsage).where(BillingUsage.user_id == uid)
+				)
+				await session.execute(delete(User).where(User.id == uid))
+				await session.commit()
 		await engine.dispose()
 
-	yield factory, created_user_ids
+	yield factory, created_users
 
 	await cleanup()
 
@@ -73,7 +66,8 @@ async def _make_user(factory) -> tuple:
 	user_id = uuid4()
 	tenant_id = uuid4()
 	async with factory() as session:
-		# INSERT works without tenant context (permissive insert-only policy).
+		# INSERT must satisfy WITH CHECK (tenant_id = app.tenant_id) since #304.
+		await session.execute(text(f"SET LOCAL app.tenant_id = '{tenant_id}'"))
 		session.add(
 			User(
 				id=user_id,
@@ -86,8 +80,9 @@ async def _make_user(factory) -> tuple:
 	return user_id, tenant_id
 
 
-async def _count_rows(factory, user_id, period_start) -> int:
+async def _count_rows(factory, user_id, tenant_id, period_start) -> int:
 	async with factory() as session:
+		await session.execute(text(f"SET LOCAL app.tenant_id = '{tenant_id}'"))
 		return (
 			await session.execute(
 				select(func.count())
@@ -100,8 +95,9 @@ async def _count_rows(factory, user_id, period_start) -> int:
 		).scalar_one()
 
 
-async def _get_usage(factory, user_id, period_start) -> BillingUsage:
+async def _get_usage(factory, user_id, tenant_id, period_start) -> BillingUsage:
 	async with factory() as session:
+		await session.execute(text(f"SET LOCAL app.tenant_id = '{tenant_id}'"))
 		# scalar_one() raises MultipleResultsFound if duplicates leaked through.
 		return (
 			await session.execute(
@@ -117,20 +113,21 @@ async def _get_usage(factory, user_id, period_start) -> BillingUsage:
 async def test_concurrent_episode_tracking_no_duplicates_or_lost_updates(
 	committing_session_factory,
 ):
-	factory, created_user_ids = committing_session_factory
+	factory, created_users = committing_session_factory
 	user_id, tenant_id = await _make_user(factory)
-	created_user_ids.append(user_id)
+	created_users.append((user_id, tenant_id))
 	period_start, _ = _current_period_dates()
 
 	async def track_once():
 		# Independent session/connection per coroutine = genuine parallel commits.
 		async with factory() as session:
+			await session.execute(text(f"SET LOCAL app.tenant_id = '{tenant_id}'"))
 			await track_episode_creation(session, user_id, tenant_id)
 
 	await asyncio.gather(*(track_once() for _ in range(CONCURRENCY)))
 
-	assert await _count_rows(factory, user_id, period_start) == 1
-	usage = await _get_usage(factory, user_id, period_start)
+	assert await _count_rows(factory, user_id, tenant_id, period_start) == 1
+	usage = await _get_usage(factory, user_id, tenant_id, period_start)
 	assert usage.episodes_created == CONCURRENCY
 
 
@@ -138,17 +135,18 @@ async def test_concurrent_episode_tracking_no_duplicates_or_lost_updates(
 async def test_concurrent_api_call_tracking_no_duplicates_or_lost_updates(
 	committing_session_factory,
 ):
-	factory, created_user_ids = committing_session_factory
+	factory, created_users = committing_session_factory
 	user_id, tenant_id = await _make_user(factory)
-	created_user_ids.append(user_id)
+	created_users.append((user_id, tenant_id))
 	period_start, _ = _current_period_dates()
 
 	async def track_once():
 		async with factory() as session:
+			await session.execute(text(f"SET LOCAL app.tenant_id = '{tenant_id}'"))
 			await track_api_call(session, user_id, tenant_id)
 
 	await asyncio.gather(*(track_once() for _ in range(CONCURRENCY)))
 
-	assert await _count_rows(factory, user_id, period_start) == 1
-	usage = await _get_usage(factory, user_id, period_start)
+	assert await _count_rows(factory, user_id, tenant_id, period_start) == 1
+	usage = await _get_usage(factory, user_id, tenant_id, period_start)
 	assert usage.api_calls == CONCURRENCY

--- a/apps/api/tests/unit/test_billing_unit.py
+++ b/apps/api/tests/unit/test_billing_unit.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 import pytest
 from fastapi import HTTPException
 
+from src.database import arm_tenant_context
 from tests.unit.conftest import _register_user
 
 
@@ -313,6 +314,7 @@ class TestGetSubscriptionPlain:
 		from src.services.billing_service import get_or_create_subscription, get_subscription
 		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
 		tenant_id = uuid4()
+		arm_tenant_context(test_db, str(tenant_id))
 		created = await get_or_create_subscription(test_db, user_id, tenant_id)
 		fetched = await get_subscription(test_db, user_id)
 		assert fetched is not None
@@ -366,6 +368,7 @@ class TestCreateCheckoutStripeEnabled:
 		bs = _enable_fake_stripe_sdk(monkeypatch)
 		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
 		tenant_id = uuid4()
+		arm_tenant_context(test_db, str(tenant_id))
 
 		result = await bs.create_checkout_session(test_db, user_id, tenant_id, "pro")
 
@@ -380,6 +383,7 @@ class TestCreateCheckoutStripeEnabled:
 		bs = _enable_fake_stripe_sdk(monkeypatch)
 		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
 		tenant_id = uuid4()
+		arm_tenant_context(test_db, str(tenant_id))
 		sub = await bs.get_or_create_subscription(test_db, user_id, tenant_id)
 		sub.stripe_customer_id = "cus_existing"
 		await test_db.commit()
@@ -396,8 +400,10 @@ class TestCreateCheckoutStripeEnabled:
 	) -> None:
 		bs = _enable_fake_stripe_sdk(monkeypatch)
 		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
+		tenant_id = uuid4()
+		arm_tenant_context(test_db, str(tenant_id))
 		with pytest.raises(HTTPException) as exc:
-			await bs.create_checkout_session(test_db, user_id, uuid4(), "enterprise")
+			await bs.create_checkout_session(test_db, user_id, tenant_id, "enterprise")
 		assert exc.value.status_code == 400
 
 
@@ -431,6 +437,7 @@ class TestHandleSubscriptionUpdatedDirect:
 		)
 		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
 		tenant_id = uuid4()
+		arm_tenant_context(test_db, str(tenant_id))
 		sub = await get_or_create_subscription(test_db, user_id, tenant_id)
 		sub.stripe_customer_id = "cus_matched"
 		await test_db.commit()
@@ -453,7 +460,9 @@ class TestHandleSubscriptionUpdatedDirect:
 		# Seed an existing subscription in a state distinct from what a match
 		# would produce, so a false match would be visible below.
 		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
-		sub = await get_or_create_subscription(test_db, user_id, uuid4())
+		tenant_id = uuid4()
+		arm_tenant_context(test_db, str(tenant_id))
+		sub = await get_or_create_subscription(test_db, user_id, tenant_id)
 		sub.stripe_customer_id = "cus_unrelated"
 		sub.status = SubscriptionStatus.PAST_DUE
 		sub.stripe_subscription_id = "sub_preexisting"
@@ -480,6 +489,7 @@ class TestHandleSubscriptionDeletedDirect:
 		)
 		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
 		tenant_id = uuid4()
+		arm_tenant_context(test_db, str(tenant_id))
 		sub = await get_or_create_subscription(test_db, user_id, tenant_id)
 		await update_subscription_tier(test_db, user_id, tenant_id, "pro")
 		sub.stripe_customer_id = "cus_deleted"
@@ -504,6 +514,7 @@ class TestHandleSubscriptionDeletedDirect:
 		# and downgrade it, which the assertions below would catch.
 		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
 		tenant_id = uuid4()
+		arm_tenant_context(test_db, str(tenant_id))
 		sub = await get_or_create_subscription(test_db, user_id, tenant_id)
 		await update_subscription_tier(test_db, user_id, tenant_id, "pro")
 		sub.stripe_customer_id = "cus_unrelated_2"
@@ -533,7 +544,9 @@ class TestProcessWebhookDispatchesToHandlers:
 		})
 		bs, _ = _enable_stripe(monkeypatch, construct_event)
 		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
-		sub = await bs.get_or_create_subscription(test_db, user_id, uuid4())
+		tenant_id = uuid4()
+		arm_tenant_context(test_db, str(tenant_id))
+		sub = await bs.get_or_create_subscription(test_db, user_id, tenant_id)
 		sub.stripe_customer_id = "cus_dispatch"
 		await test_db.commit()
 
@@ -554,7 +567,9 @@ class TestProcessWebhookDispatchesToHandlers:
 		})
 		bs, _ = _enable_stripe(monkeypatch, construct_event)
 		user_id = await _register_user(client, email_prefix="billing_unit_", full_name="Billing Unit Test User")
-		sub = await bs.get_or_create_subscription(test_db, user_id, uuid4())
+		tenant_id = uuid4()
+		arm_tenant_context(test_db, str(tenant_id))
+		sub = await bs.get_or_create_subscription(test_db, user_id, tenant_id)
 		sub.stripe_customer_id = "cus_dispatch2"
 		await test_db.commit()
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -265,6 +265,11 @@ DATABASE_URL=postgresql+asyncpg://podcastfy_app:pass@localhost/podcastfy
 # Alembic-only privileged role (superuser/BYPASSRLS owner) — required so RLS-affected
 # backfills apply to all rows (issue #301). Falls back to DATABASE_URL when unset.
 MIGRATION_DATABASE_URL=postgresql+asyncpg://podcastfy:pass@localhost/podcastfy
+# Secret password for the podcastfy_app role (issue #304). Alembic reads it at
+# migration time: migration 014 rotates the role password to this value whenever
+# it is set (fresh installs use it in 003). Generate with `openssl rand -hex 32`
+# and keep it in sync with the password embedded in DATABASE_URL above.
+APP_DB_PASSWORD=<same-password-as-in-DATABASE_URL>
 REDIS_URL=redis://localhost:6379/0
 JWT_SECRET_KEY=<generate-with-openssl-rand-hex-32>
 JWT_ALGORITHM=HS256

--- a/docs/env_inventory.md
+++ b/docs/env_inventory.md
@@ -20,6 +20,7 @@
 | POSTGRES_DB | ✅ | ❌ | Missing | Critical |
 | DATABASE_URL | ✅ | ✅ | **Present** | Critical |
 | MIGRATION_DATABASE_URL | ✅ | ⚠️ optional | Alembic-only privileged URL; falls back to DATABASE_URL (issue #301) | High |
+| APP_DB_PASSWORD | ✅ | ⚠️ optional | podcastfy_app role password, read by Alembic (003 fresh-install / 014 rotation, issue #304); unset keeps the dev default | High |
 
 ### Redis Configuration (Critical)
 | Variable | Expected | Present | Status | Priority |

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -20,13 +20,13 @@
 
 ## Steps
 - [x] Explore codebase (RLS session plumbing, billing/webhook/registration paths, CI role provisioning)
-- [ ] Branch `feature/issue-304-rls-defense-in-depth`
-- [ ] TDD RED: tests — cross-tenant SELECT on billing/analytics blocked under podcastfy_app; INSERT with mismatched tenant_id rejected on a core table; users SELECT without context returns nothing; auth definer lookup returns user; registration still works; webhook subscription update works with no pre-set tenant context
-- [ ] Migration 014 (policies, definer fns, conditional password rotation) + 003 edit (env password, current_database())
-- [ ] App changes: auth_service lookups via definer fns; create_user arms tenant context; billing webhook resolves tenant via definer fn + set_tenant_context
-- [ ] Update tests that assert "billing tables have no RLS" (test_usage_concurrency.py, test_episodes.py, test_analytics_aggregation.py) — spec change, not test-weakening
-- [ ] .env.example / docs/env_inventory.md / deployment/README.md: APP_DB_PASSWORD + rotation note
-- [ ] Full suite green under podcastfy_app (conftest already enforces), ruff clean
+- [x] Branch `feature/issue-304-rls-defense-in-depth`
+- [x] TDD RED: tests — cross-tenant SELECT on billing/analytics blocked under podcastfy_app; INSERT with mismatched tenant_id rejected on a core table; users SELECT without context returns nothing; auth definer lookup returns user; registration still works; webhook subscription update works with no pre-set tenant context
+- [x] Migration 014 (policies, definer fns, conditional password rotation) + 003 edit (env password, current_database())
+- [x] App changes: auth_service lookups via definer fns; create_user arms tenant context; billing webhook resolves tenant via definer fn + set_tenant_context
+- [x] Update tests that assert "billing tables have no RLS" (test_usage_concurrency.py, test_episodes.py, test_analytics_aggregation.py) — spec change, not test-weakening
+- [x] .env.example / docs/env_inventory.md / deployment/README.md: APP_DB_PASSWORD + rotation note
+- [x] Full suite green under podcastfy_app (conftest already enforces), ruff clean
 - [ ] Deslop scan → quality gate (opencode pre-PR review) → PR → post-PR review → demo (hard gate) → CI gate → docs sync → merge
 
 ## Acceptance criteria (from issue)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,23 +1,37 @@
-# #346 — COMPLETE (PR #348 squash-merged 2026-07-09 as e989616, issue closed)
+# #304 — RLS defense-in-depth: hardcoded DB password, USING(true) users SELECT, WITH CHECK(true) inserts, billing/analytics tables without RLS
 
-## Baseline (measured, `uv run pytest -q --no-cov`: 765 passed, 102 warnings)
-- `datetime.utcnow()` DeprecationWarning — 62 refs across 29 files (src models/services/utils + tests); model `default=datetime.utcnow` also fires via SQLAlchemy `schema.py`
-- FastAPI `on_event` deprecation — `src/main.py:50` (2 warning sources)
-- `RuntimeWarning: coroutine '_extract_content_async' was never awaited` — tests patch `asyncio.run` but still build the real coroutine (`tests/unit/test_content_extraction_task.py`)
-- Third-party import-time (not fixable in-repo): pydub `audioop` DeprecationWarning, pydub SyntaxWarning (cold compile only), pydub ffmpeg RuntimeWarning (runner without ffmpeg)
+**Plan source**: self-authored (issue has acceptance criteria but no plan comment).
+**Branch**: `feature/issue-304-rls-defense-in-depth`. Migration head is `013` → new migration `014`.
 
-## Decisions
-- **Policy**: `filterwarnings = error` + targeted ignores for the three pydub third-party warnings only. All first-party warnings get fixed, not ignored.
-- **utcnow replacement**: new helper `src/utils/datetime_utils.py::utcnow()` returning **naive UTC** (`datetime.now(timezone.utc).replace(tzinfo=None)`) — columns are `DateTime` without timezone; aware datetimes would break asyncpg writes/comparisons. Not migrating columns to tz-aware (out of scope).
-- **Markers**: `unit`/`integration`/`slow` — zero usages in tests (`--strict-markers` already on and green) → stay dropped for good.
+## Findings that shape the design
+- The 11 core tables have FORCE RLS + `tenant_isolation_{t}` (FOR ALL, USING + WITH CHECK tenant match) **plus** a redundant permissive `tenant_isolation_insert_{t}` `WITH CHECK (true)` (003:56-60). Policies OR together, so the permissive one nullifies the FOR ALL WITH CHECK on INSERT.
+- Registration (`auth_service.create_user`, auth_service.py:252-297) is the **only** pre-tenant INSERT; it generates `tenant_id = uuid4()` itself.
+- Login/registration duplicate-check read users by email with no tenant context — this is what `users_auth_lookup USING (true)` (003:69-73) exists for. It also exposes every user row (password_hash, encrypted_api_keys) cross-tenant.
+- billing_subscriptions / billing_usage / analytics_events (010/011) carry `tenant_id` but have **no RLS**. All access is request-scoped with tenant context armed, **except** the Stripe webhook (`billing.py:175-191` → `_handle_subscription_updated/deleted`, billing_service.py:256-294) which has no JWT → no tenant context and looks rows up by `stripe_customer_id`.
+- Celery workers never touch these three tables and rely on an RLS-exempt role for episodes — out of scope here, unaffected.
+- CI pre-creates `podcastfy_app` with its own password (test.yml:164-167), so 003's `CREATE ROLE IF NOT EXISTS` no-ops there. Local conftest defaults to `podcastfy_app:podcastfy_app_password`.
+
+## Design decisions (autonomous — no architectural fork)
+1. **Password**: 003 edited so fresh installs read the role password from env `APP_DB_PASSWORD` (fallback to old literal so local dev/CI keep working); new migration 014 does `ALTER ROLE podcastfy_app PASSWORD <env>` **only when `APP_DB_PASSWORD` is set** → rotation on real deploys, no-op in CI/local. Document rotation in deployment/README.md.
+2. **DB name**: 003 GRANT CONNECT uses `format('... %I ...', current_database())` in a DO block instead of literal `podcastfy`.
+3. **users SELECT**: 014 drops `users_auth_lookup`; adds `SECURITY DEFINER` functions `auth_lookup_user_by_email(text)` / `auth_lookup_user_by_id(uuid)` RETURNS SETOF users, `SET search_path = public, pg_temp`, owner = migration role (BYPASSRLS), REVOKE FROM PUBLIC + GRANT EXECUTE TO podcastfy_app. `auth_service.get_user_by_email` / `get_user_by_id` switch to `select(User).from_statement(text(...))`.
+4. **INSERT policies**: 014 **drops** all 11 `tenant_isolation_insert_{t}` policies — the FOR ALL policy's `WITH CHECK (tenant_id = current_setting('app.tenant_id', true)::uuid)` then governs INSERT, which is exactly the acceptance criterion's semantics. Registration fix: `create_user` calls `set_tenant_context(session, str(tenant_id))` before `session.add`.
+5. **Billing/analytics RLS**: 014 adds ENABLE + FORCE RLS + `tenant_isolation_{t}` (FOR ALL, USING + WITH CHECK tenant match) to billing_subscriptions, billing_usage, analytics_events. Webhook bootstrap: definer function `billing_tenant_for_stripe_customer(text) RETURNS uuid`; webhook handlers resolve tenant, `set_tenant_context`, then reuse existing ORM code (mirrors the auth bootstrap pattern).
 
 ## Steps
-- [x] Branch `fix/346-pytest-warnings-policy`
-- [x] TDD: test for `utcnow()` helper (naive, ~now UTC), then implement helper
-- [x] Replace all 62 `datetime.utcnow` refs in src/ and tests/ with the helper (imports normalized to relative in src/)
-- [x] Convert `main.py` `@app.on_event("startup")` → lifespan handler
-- [x] Fix content-extraction task tests: patch `_extract_content_async` so no coroutine is created
-- [x] Add `filterwarnings` (error + pydub ignores, module-scoped, ffprobe variant covered) to `[pytest]`
-- [x] Verify: 767 passed / 0 warnings with coverage gate; cold-compile pydub green; ruff clean
-- [x] Pre-PR opencode review (no blocking; sweeps verified, ignores scoped) → PR #348 → post-PR review (no blocking; ffprobe fix applied) → demo PASSED (evidence on PR)
-- [x] CI green → merged. First CI run exposed that `testpaths = tests tests/unit` made local bare `pytest` run only 767 of 1662 tests; fixed testpaths, swept starlette deprecated status constants, fixed two `asyncio.to_thread` coroutine leaks in wait_for mocks, and enabled ruff W605 (CodeRabbit catch — the pytest.ini comment had overclaimed it). Final: 1655 passed / 7 skipped / 0 warnings.
+- [x] Explore codebase (RLS session plumbing, billing/webhook/registration paths, CI role provisioning)
+- [ ] Branch `feature/issue-304-rls-defense-in-depth`
+- [ ] TDD RED: tests — cross-tenant SELECT on billing/analytics blocked under podcastfy_app; INSERT with mismatched tenant_id rejected on a core table; users SELECT without context returns nothing; auth definer lookup returns user; registration still works; webhook subscription update works with no pre-set tenant context
+- [ ] Migration 014 (policies, definer fns, conditional password rotation) + 003 edit (env password, current_database())
+- [ ] App changes: auth_service lookups via definer fns; create_user arms tenant context; billing webhook resolves tenant via definer fn + set_tenant_context
+- [ ] Update tests that assert "billing tables have no RLS" (test_usage_concurrency.py, test_episodes.py, test_analytics_aggregation.py) — spec change, not test-weakening
+- [ ] .env.example / docs/env_inventory.md / deployment/README.md: APP_DB_PASSWORD + rotation note
+- [ ] Full suite green under podcastfy_app (conftest already enforces), ruff clean
+- [ ] Deslop scan → quality gate (opencode pre-PR review) → PR → post-PR review → demo (hard gate) → CI gate → docs sync → merge
+
+## Acceptance criteria (from issue)
+- [ ] Role password injected from a secret and rotated
+- [ ] Blanket users SELECT replaced with narrow SECURITY DEFINER auth-lookup
+- [ ] INSERT WITH CHECK scoped to `tenant_id = current_setting('app.tenant_id')` (achieved by dropping the redundant permissive policy; FOR ALL WITH CHECK governs)
+- [ ] FORCE RLS + tenant_isolation policies on billing_subscriptions, billing_usage, analytics_events
+- [ ] `current_database()` instead of literal db name


### PR DESCRIPTION
Closes #304.

## What

Migration `014` + minimal app changes closing the four DB-layer gaps from the audit:

1. **Billing/analytics RLS** — `billing_subscriptions`, `billing_usage`, `analytics_events` get ENABLE + FORCE ROW LEVEL SECURITY and the same `tenant_isolation_*` (FOR ALL, USING + WITH CHECK on `app.tenant_id`) policies as the 11 core tables.
2. **Scoped INSERTs** — the permissive `tenant_isolation_insert_* WITH CHECK (true)` policies are dropped. Policies OR together, so they were nullifying the FOR ALL policy's WITH CHECK on INSERT; with them gone, every INSERT must satisfy `tenant_id = current_setting('app.tenant_id')::uuid`. Registration (the one pre-tenant INSERT) now arms the new tenant's context itself.
3. **Narrow auth lookup** — the blanket `users_auth_lookup FOR SELECT USING (true)` policy (which exposed `password_hash`/`encrypted_api_keys` cross-tenant) is replaced by a SECURITY DEFINER function that discloses **only `(id, tenant_id)`** for an email; the app then loads the full row through the normal RLS-governed SELECT under that tenant's context. The Stripe webhook (no JWT → no tenant context) gets the same bootstrap via `billing_tenant_for_stripe_customer(text) → uuid`.
4. **Secret-injected role password + portable GRANTs** — migration 003 reads the fresh-install `podcastfy_app` password from `APP_DB_PASSWORD` (dev-literal fallback keeps local/CI working) and 014 rotates the role password whenever `APP_DB_PASSWORD` is set. Passwords travel as bound parameters into a transaction-local GUC and through `format(%L)` — never interpolated into SQL text. `GRANT/REVOKE CONNECT` use `current_database()` instead of the literal `podcastfy`.

Migration 014 also **fails loudly** when run without a superuser/BYPASSRLS role (definer functions owned by an RLS-subject role would brick auth) — same posture as the #301 guard.

## Tests

- New `tests/test_rls_hardening.py` (13 tests): cross-tenant SELECT blocked on all three new tables; mismatched-tenant INSERT rejected on core + analytics tables; users SELECT blocked across tenants while login/lookup/registration still work; webhook update/delete work with no pre-set tenant context; lookup function column surface pinned to `{id, tenant_id}`.
- Full backend suite: **1668 passed, 7 skipped**, coverage gate met, under the non-superuser `podcastfy_app` role (FORCE RLS actually exercised).
- Fresh-DB migration run + `014` downgrade/upgrade round-trip verified locally, including the `APP_DB_PASSWORD` rotation path.
- Test-infra fix: the conftest client override now **arms** tenant context (mirrors production `get_db_session`, issue #302) and sets it immediately for mid-transaction user switches; previously the one-shot SET LOCAL was masked by the blanket users policy constant-folding the tenant cast away.
- Updated tests that had pinned the old "billing/analytics have no RLS" behavior (seeding now happens under a matching tenant context) — spec change, not test-weakening.

## Deploy notes

- Set `APP_DB_PASSWORD` (same value as the password inside `DATABASE_URL`) in the API env before running migrations on the VPS — 014 rotates the role password to it. Documented in `deployment/README.md`, `.env.example`, `docs/env_inventory.md`.
- CI needs no changes: it pre-creates `podcastfy_app` (003's `IF NOT EXISTS` no-ops) and doesn't set `APP_DB_PASSWORD` (rotation no-ops).

## Known limitations

- The Celery worker still relies on an RLS-exempt DB role (it sets no tenant context); it never touches the three newly-protected tables, so this PR doesn't change worker behavior — a dedicated worker-role design remains a follow-up.
- `APP_DB_PASSWORD` is read at migration time only; rotating it later requires re-running 014 logic manually (`ALTER ROLE`) or a future migration.
- Pre-PR review: opencode (GLM). Its Major finding (lookup over-disclosure) and three Minors (password quoting, BYPASSRLS guard, webhook arming) are addressed in d8021ce; its Nit on `pg_temp` in `search_path` was rejected (placing `pg_temp` last is the PostgreSQL-documented safe form).