### PR TITLE
fix(security): re-validate + IP-pin webhook test-connection, disable redirects (#305)

### DIFF
--- a/apps/api/src/services/distribution_target_service.py
+++ b/apps/api/src/services/distribution_target_service.py
@@ -650,6 +650,8 @@ async def _test_webhook_connection(db: AsyncSession, config: dict) -> dict:
 			"error": "url_not_allowed",
 		}
 	pinned_url, pin_headers, extensions = pin_httpx(url, resolved[0])
+	# The pinned Host deliberately overrides any user-configured Host header —
+	# TLS verification and virtual hosting must stay bound to the validated URL.
 	headers.update(pin_headers)
 
 	try:

--- a/apps/api/src/services/distribution_target_service.py
+++ b/apps/api/src/services/distribution_target_service.py
@@ -25,6 +25,8 @@ from ..schemas.distribution_target import (
 	DistributionTargetUpdate,
 )
 from ..utils.encryption import encrypt_credential, decrypt_credential, is_sensitive_header
+from ..utils.pinned_fetch import pin_httpx
+from ..utils.ssrf import SSRFValidationError, validate_public_url
 
 logger = logging.getLogger(__name__)
 
@@ -629,13 +631,38 @@ async def _test_webhook_connection(db: AsyncSession, config: dict) -> dict:
 	stored_headers = config.get("headers", {})
 	headers = await _decrypt_sensitive_headers(db, stored_headers) if stored_headers else {}
 
+	# Dispatch-time SSRF re-validation + IP pinning (issue #305): the URL was
+	# validated at create time, but DNS may have been re-pointed since (TOCTOU).
+	# Mirrors _distribute_via_webhook / source_validator_service.
 	try:
-		async with httpx.AsyncClient(timeout=10.0) as client:
+		resolved = validate_public_url(
+			url,
+			allowed_schemes=("https",),
+			allowed_ports={443},
+			block_on_resolution_failure=True,
+		)
+	except SSRFValidationError:
+		logger.warning("Webhook connection test blocked by SSRF guard")
+		return {
+			"success": False,
+			"platform": "webhook",
+			"message": "Webhook URL is not allowed",
+			"error": "url_not_allowed",
+		}
+	pinned_url, pin_headers, extensions = pin_httpx(url, resolved[0])
+	headers.update(pin_headers)
+
+	try:
+		async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as client:
 			test_payload = {"test": True, "event": "connection_test"}
 			if method == "POST":
-				response = await client.post(url, json=test_payload, headers=headers)
+				response = await client.post(
+					pinned_url, json=test_payload, headers=headers, extensions=extensions
+				)
 			else:
-				response = await client.get(url, headers=headers)
+				response = await client.get(
+					pinned_url, headers=headers, extensions=extensions
+				)
 
 			response.raise_for_status()
 			return {

--- a/apps/api/tests/test_distribution_targets.py
+++ b/apps/api/tests/test_distribution_targets.py
@@ -749,8 +749,12 @@ async def test_test_connection_webhook(client, auth_headers):
 	assert create_response.status_code == 201
 	target_id = create_response.json()["id"]
 
-	# Mock httpx for the test connection call
-	with patch("src.services.distribution_target_service.httpx") as mock_httpx:
+	# Mock httpx for the test connection call; the dispatch-time SSRF guard
+	# would otherwise resolve hooks.example.com for real (issue #305).
+	with patch(
+		"src.services.distribution_target_service.validate_public_url",
+		return_value=["93.184.216.34"],
+	), patch("src.services.distribution_target_service.httpx") as mock_httpx:
 		mock_client = AsyncMock()
 		mock_httpx.AsyncClient.return_value.__aenter__.return_value = mock_client
 		mock_httpx.AsyncClient.return_value.__aexit__.return_value = None
@@ -1059,8 +1063,12 @@ async def test_webhook_connection_test_with_encrypted_headers(client, auth_heade
 	assert create_response.status_code == 201
 	target_id = create_response.json()["id"]
 
-	# Mock httpx for the test connection call and capture what headers are sent
-	with patch("src.services.distribution_target_service.httpx") as mock_httpx:
+	# Mock httpx for the test connection call and capture what headers are sent.
+	# The dispatch-time SSRF guard is stubbed so no real DNS happens (issue #305).
+	with patch(
+		"src.services.distribution_target_service.validate_public_url",
+		return_value=["93.184.216.34"],
+	), patch("src.services.distribution_target_service.httpx") as mock_httpx:
 		mock_client = AsyncMock()
 		mock_httpx.AsyncClient.return_value.__aenter__.return_value = mock_client
 		mock_httpx.AsyncClient.return_value.__aexit__.return_value = None
@@ -1137,3 +1145,65 @@ def test_distribute_via_webhook_disables_redirects_for_public():
 	assert result["status"] == "success"
 	mock_pinned.assert_called_once_with("https://93.184.216.34/hook", "93.184.216.34")
 	assert session.post.call_args.kwargs.get("allow_redirects") is False
+
+
+# ============================================================================
+# WEBHOOK TEST-CONNECTION SSRF TESTS (issue #305)
+# ============================================================================
+
+@pytest.mark.parametrize("url", [
+	"https://169.254.169.254/latest/meta-data/",
+	"https://127.0.0.1/",
+	"https://10.0.0.1/hook",
+	"https://192.168.1.1/hook",
+])
+@pytest.mark.asyncio
+async def test_webhook_test_connection_blocks_internal(url):
+	"""SSRF: test-connection re-validates at dispatch time and never fires (issue #305)."""
+	from src.services.distribution_target_service import _test_webhook_connection
+
+	with patch("src.services.distribution_target_service.httpx") as mock_httpx:
+		result = await _test_webhook_connection(MagicMock(), {"url": url, "method": "POST"})
+
+	assert result["success"] is False
+	assert result["error"] == "url_not_allowed"
+	mock_httpx.AsyncClient.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_webhook_test_connection_pins_and_disables_redirects():
+	"""Test-connection pins to the validated IP, keeps Host/SNI, and disables redirects (issue #305)."""
+	from src.services.distribution_target_service import _test_webhook_connection
+
+	test_resp = MagicMock()
+	test_resp.status_code = 200
+	test_resp.raise_for_status = MagicMock()
+
+	mock_client = AsyncMock()
+	mock_client.post.return_value = test_resp
+
+	with patch(
+		"src.services.distribution_target_service.validate_public_url",
+		return_value=["93.184.216.34"],
+	) as mock_validate, patch(
+		"src.services.distribution_target_service.httpx"
+	) as mock_httpx:
+		mock_httpx.AsyncClient.return_value.__aenter__.return_value = mock_client
+		mock_httpx.AsyncClient.return_value.__aexit__.return_value = None
+
+		result = await _test_webhook_connection(
+			MagicMock(), {"url": "https://hooks.example.com/hook", "method": "POST"}
+		)
+
+	assert result["success"] is True
+	mock_validate.assert_called_once_with(
+		"https://hooks.example.com/hook",
+		allowed_schemes=("https",),
+		allowed_ports={443},
+		block_on_resolution_failure=True,
+	)
+	assert mock_httpx.AsyncClient.call_args.kwargs.get("follow_redirects") is False
+	call = mock_client.post.call_args
+	assert call.args[0] == "https://93.184.216.34/hook"
+	assert call.kwargs["headers"]["Host"] == "hooks.example.com"
+	assert call.kwargs["extensions"] == {"sni_hostname": "hooks.example.com"}

--- a/apps/api/tests/test_distribution_targets.py
+++ b/apps/api/tests/test_distribution_targets.py
@@ -1207,3 +1207,34 @@ async def test_webhook_test_connection_pins_and_disables_redirects():
 	assert call.args[0] == "https://93.184.216.34/hook"
 	assert call.kwargs["headers"]["Host"] == "hooks.example.com"
 	assert call.kwargs["extensions"] == {"sni_hostname": "hooks.example.com"}
+
+
+@pytest.mark.asyncio
+async def test_webhook_test_connection_get_method_also_pinned():
+	"""The GET test path uses the same pinned URL and SNI extension (issue #305)."""
+	from src.services.distribution_target_service import _test_webhook_connection
+
+	test_resp = MagicMock()
+	test_resp.status_code = 200
+	test_resp.raise_for_status = MagicMock()
+
+	mock_client = AsyncMock()
+	mock_client.get.return_value = test_resp
+
+	with patch(
+		"src.services.distribution_target_service.validate_public_url",
+		return_value=["93.184.216.34"],
+	), patch("src.services.distribution_target_service.httpx") as mock_httpx:
+		mock_httpx.AsyncClient.return_value.__aenter__.return_value = mock_client
+		mock_httpx.AsyncClient.return_value.__aexit__.return_value = None
+
+		result = await _test_webhook_connection(
+			MagicMock(), {"url": "https://hooks.example.com/hook", "method": "GET"}
+		)
+
+	assert result["success"] is True
+	mock_client.post.assert_not_called()
+	call = mock_client.get.call_args
+	assert call.args[0] == "https://93.184.216.34/hook"
+	assert call.kwargs["headers"]["Host"] == "hooks.example.com"
+	assert call.kwargs["extensions"] == {"sni_hostname": "hooks.example.com"}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,37 +1,21 @@
-# #304 — COMPLETE (PR #349 squash-merged 2026-07-09, issue closed)
+# #305 — SSRF-harden webhook test-connection (in progress)
 
-**Plan source**: self-authored (issue has acceptance criteria but no plan comment).
-**Branch**: `feature/issue-304-rls-defense-in-depth`. Migration head is `013` → new migration `014`.
+**Plan source**: CodeRabbit plan comment on issue, verified against code 2026-07-09.
+**Branch**: `fix/issue-305-webhook-test-ssrf`
 
-## Findings that shape the design
-- The 11 core tables have FORCE RLS + `tenant_isolation_{t}` (FOR ALL, USING + WITH CHECK tenant match) **plus** a redundant permissive `tenant_isolation_insert_{t}` `WITH CHECK (true)` (003:56-60). Policies OR together, so the permissive one nullifies the FOR ALL WITH CHECK on INSERT.
-- Registration (`auth_service.create_user`, auth_service.py:252-297) is the **only** pre-tenant INSERT; it generates `tenant_id = uuid4()` itself.
-- Login/registration duplicate-check read users by email with no tenant context — this is what `users_auth_lookup USING (true)` (003:69-73) exists for. It also exposes every user row (password_hash, encrypted_api_keys) cross-tenant.
-- billing_subscriptions / billing_usage / analytics_events (010/011) carry `tenant_id` but have **no RLS**. All access is request-scoped with tenant context armed, **except** the Stripe webhook (`billing.py:175-191` → `_handle_subscription_updated/deleted`, billing_service.py:256-294) which has no JWT → no tenant context and looks rows up by `stripe_customer_id`.
-- Celery workers never touch these three tables and rely on an RLS-exempt role for episodes — out of scope here, unaffected.
-- CI pre-creates `podcastfy_app` with its own password (test.yml:164-167), so 003's `CREATE ROLE IF NOT EXISTS` no-ops there. Local conftest defaults to `podcastfy_app:podcastfy_app_password`.
-
-## Design decisions (autonomous — no architectural fork)
-1. **Password**: 003 edited so fresh installs read the role password from env `APP_DB_PASSWORD` (fallback to old literal so local dev/CI keep working); new migration 014 does `ALTER ROLE podcastfy_app PASSWORD <env>` **only when `APP_DB_PASSWORD` is set** → rotation on real deploys, no-op in CI/local. Document rotation in deployment/README.md.
-2. **DB name**: 003 GRANT CONNECT uses `format('... %I ...', current_database())` in a DO block instead of literal `podcastfy`.
-3. **users SELECT**: 014 drops `users_auth_lookup`; adds `SECURITY DEFINER` functions `auth_lookup_user_by_email(text)` / `auth_lookup_user_by_id(uuid)` RETURNS SETOF users, `SET search_path = public, pg_temp`, owner = migration role (BYPASSRLS), REVOKE FROM PUBLIC + GRANT EXECUTE TO podcastfy_app. `auth_service.get_user_by_email` / `get_user_by_id` switch to `select(User).from_statement(text(...))`.
-4. **INSERT policies**: 014 **drops** all 11 `tenant_isolation_insert_{t}` policies — the FOR ALL policy's `WITH CHECK (tenant_id = current_setting('app.tenant_id', true)::uuid)` then governs INSERT, which is exactly the acceptance criterion's semantics. Registration fix: `create_user` calls `set_tenant_context(session, str(tenant_id))` before `session.add`.
-5. **Billing/analytics RLS**: 014 adds ENABLE + FORCE RLS + `tenant_isolation_{t}` (FOR ALL, USING + WITH CHECK tenant match) to billing_subscriptions, billing_usage, analytics_events. Webhook bootstrap: definer function `billing_tenant_for_stripe_customer(text) RETURNS uuid`; webhook handlers resolve tenant, `set_tenant_context`, then reuse existing ORM code (mirrors the auth bootstrap pattern).
+## Verified facts
+- `_test_webhook_connection` (distribution_target_service.py:625) fires raw `httpx.AsyncClient` from the stored URL — no re-validation, no pinning, default redirect handling.
+- `validate_public_url(url, *, allowed_schemes, allowed_ports, block_on_resolution_failure)` → `List[str]` of resolved public IPs; raises `SSRFValidationError` (src/utils/ssrf.py:88).
+- `pin_httpx(url, ip)` → `(pinned_url, {"Host": netloc}, {"sni_hostname": hostname})` (src/utils/pinned_fetch.py:91). Async httpx usage pattern proven in source_validator_service.py:148.
+- Existing test `test_webhook_connection_test_with_encrypted_headers` uses `hooks.example.com` — must patch `validate_public_url` after the change (adaptation, not weakening).
 
 ## Steps
-- [x] Explore codebase (RLS session plumbing, billing/webhook/registration paths, CI role provisioning)
-- [x] Branch `feature/issue-304-rls-defense-in-depth`
-- [x] TDD RED: tests — cross-tenant SELECT on billing/analytics blocked under podcastfy_app; INSERT with mismatched tenant_id rejected on a core table; users SELECT without context returns nothing; auth definer lookup returns user; registration still works; webhook subscription update works with no pre-set tenant context
-- [x] Migration 014 (policies, definer fns, conditional password rotation) + 003 edit (env password, current_database())
-- [x] App changes: auth_service lookups via definer fns; create_user arms tenant context; billing webhook resolves tenant via definer fn + set_tenant_context
-- [x] Update tests that assert "billing tables have no RLS" (test_usage_concurrency.py, test_episodes.py, test_analytics_aggregation.py) — spec change, not test-weakening
-- [x] .env.example / docs/env_inventory.md / deployment/README.md: APP_DB_PASSWORD + rotation note
-- [x] Full suite green under podcastfy_app (conftest already enforces), ruff clean
-- [x] Deslop scan → quality gate (opencode pre-PR review) → PR → post-PR review → demo (hard gate) → CI gate → docs sync → merge
+- [x] Branch `fix/issue-305-webhook-test-ssrf`
+- [ ] TDD RED: internal URL → success=False + httpx never called; public target → pinned URL, Host/SNI preserved, `follow_redirects=False`; update existing encrypted-headers test to patch `validate_public_url`
+- [ ] GREEN: in `_test_webhook_connection`, call `validate_public_url(url, allowed_schemes=("https",), allowed_ports={443}, block_on_resolution_failure=True)`; catch `SSRFValidationError` → standard failure dict; `pin_httpx(url, resolved[0])`; merge pinned Host into decrypted headers; pass extensions; `follow_redirects=False`
+- [ ] Deslop → quality gate (opencode pre-PR review) → PR → post-PR review → demo (hard gate) → CI gate → docs sync → merge
 
-## Acceptance criteria (from issue)
-- [x] Role password injected from a secret and rotated
-- [x] Blanket users SELECT replaced with narrow SECURITY DEFINER auth-lookup
-- [x] INSERT WITH CHECK scoped to `tenant_id = current_setting('app.tenant_id')` (achieved by dropping the redundant permissive policy; FOR ALL WITH CHECK governs)
-- [x] FORCE RLS + tenant_isolation policies on billing_subscriptions, billing_usage, analytics_events
-- [x] `current_database()` instead of literal db name
+## Acceptance criteria (issue #305)
+- [ ] Re-validate with `validate_public_url(url, allowed_schemes=('https',), allowed_ports={443}, block_on_resolution_failure=True)` immediately before the request
+- [ ] Pin to the validated IP (mirror `_distribute_via_webhook` / httpx pattern)
+- [ ] `follow_redirects=False`

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,4 +1,4 @@
-# #304 — RLS defense-in-depth: hardcoded DB password, USING(true) users SELECT, WITH CHECK(true) inserts, billing/analytics tables without RLS
+# #304 — COMPLETE (PR #349 squash-merged 2026-07-09, issue closed)
 
 **Plan source**: self-authored (issue has acceptance criteria but no plan comment).
 **Branch**: `feature/issue-304-rls-defense-in-depth`. Migration head is `013` → new migration `014`.
@@ -27,11 +27,11 @@
 - [x] Update tests that assert "billing tables have no RLS" (test_usage_concurrency.py, test_episodes.py, test_analytics_aggregation.py) — spec change, not test-weakening
 - [x] .env.example / docs/env_inventory.md / deployment/README.md: APP_DB_PASSWORD + rotation note
 - [x] Full suite green under podcastfy_app (conftest already enforces), ruff clean
-- [ ] Deslop scan → quality gate (opencode pre-PR review) → PR → post-PR review → demo (hard gate) → CI gate → docs sync → merge
+- [x] Deslop scan → quality gate (opencode pre-PR review) → PR → post-PR review → demo (hard gate) → CI gate → docs sync → merge
 
 ## Acceptance criteria (from issue)
-- [ ] Role password injected from a secret and rotated
-- [ ] Blanket users SELECT replaced with narrow SECURITY DEFINER auth-lookup
-- [ ] INSERT WITH CHECK scoped to `tenant_id = current_setting('app.tenant_id')` (achieved by dropping the redundant permissive policy; FOR ALL WITH CHECK governs)
-- [ ] FORCE RLS + tenant_isolation policies on billing_subscriptions, billing_usage, analytics_events
-- [ ] `current_database()` instead of literal db name
+- [x] Role password injected from a secret and rotated
+- [x] Blanket users SELECT replaced with narrow SECURITY DEFINER auth-lookup
+- [x] INSERT WITH CHECK scoped to `tenant_id = current_setting('app.tenant_id')` (achieved by dropping the redundant permissive policy; FOR ALL WITH CHECK governs)
+- [x] FORCE RLS + tenant_isolation policies on billing_subscriptions, billing_usage, analytics_events
+- [x] `current_database()` instead of literal db name


### PR DESCRIPTION
Closes #305.

## Problem
`_test_webhook_connection` fired a raw `httpx.AsyncClient` request at the stored webhook URL with no dispatch-time re-validation, no IP pinning, and no redirect restriction. A tenant could register a webhook that resolved public at create time, re-point DNS to an internal address (e.g. `169.254.169.254`), and trigger `POST /distribution-targets/{id}/test` — a DNS-rebinding TOCTOU SSRF. Every other outbound path already followed the validate-then-pin model.

## Fix (`apps/api/src/services/distribution_target_service.py`)
- Immediately before the request: `validate_public_url(url, allowed_schemes=("https",), allowed_ports={443}, block_on_resolution_failure=True)`.
- `pin_httpx(url, resolved[0])` pins the connection to the validated IP while preserving the original `Host` header and SNI (mirrors `source_validator_service` / `_distribute_via_webhook`).
- `follow_redirects=False` on the client.
- `SSRFValidationError` maps to the standard test-failure shape: `{"success": false, "error": "url_not_allowed"}` — no unhandled 500, no URL echoed to logs.

## Tests
- 4 parametrized internal targets (metadata IP, loopback, RFC1918) exercise the **real** validator hermetically (IP literals, no DNS) and assert httpx is never invoked.
- Pinning tests (POST + GET) assert the pinned URL, preserved `Host`/`sni_hostname`, and `follow_redirects=False`.
- Two pre-existing tests that reach this path now stub `validate_public_url` so no live DNS occurs (adaptation to the new guard, assertions unchanged).
- Full backend suite: 1674 passed, 7 skipped. Diff coverage 100% after GET-branch test (was 91.7%). Mutation check: redirect flip and error-code flip both killed.

## Independent review (opencode/GLM, pre-PR)
Verdict: **APPROVE**. Two non-blocking suggestions triaged with rebuttals:
- *`resolved[0]` could IndexError on empty list* — impossible on this path: `ssrf.py` raises `SSRFValidationError` on empty resolution when `block_on_resolution_failure=True`, which this call always passes.
- *Non-SSRF exceptions could escape the narrow `except`* — `validate_public_url` wraps parse errors into `SSRFValidationError` by contract; nothing else is reachable from this input.

## Known limitations
- The guard blocks at dispatch time only for the test-connection path (matching the issue scope); create-time validation is unchanged (#206).