### PR TITLE
fix(security): nonce-based CSP without 'unsafe-inline' script-src + real build gates (#307)

### DIFF
--- a/apps/web/__tests__/middleware.test.ts
+++ b/apps/web/__tests__/middleware.test.ts
@@ -1,36 +1,43 @@
 /**
  * @jest-environment node
  *
- * Tests for server-side route protection (issue #222).
+ * Tests for the app middleware: server-side route protection (issue #222) and
+ * the nonce-based Content-Security-Policy (issue #307).
  *
  * Runs in the node environment: NextRequest needs the global Request/Response
  * Web primitives, which jsdom does not provide.
  *
- * The middleware must redirect unauthenticated requests to /login *before* any
- * protected page renders, instead of relying solely on the client-side redirect.
+ * Route protection: unauthenticated requests to protected paths must redirect
+ * to /login *before* any protected page renders.
+ *
+ * CSP: every matched page response (public and protected) must carry a
+ * per-request nonce CSP whose script-src has no 'unsafe-inline'.
  */
 import { NextRequest } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 
 jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }))
 
-// withAuth reads the secret from the environment at call time.
 process.env.NEXTAUTH_SECRET = 'test-secret'
 
-// Imported after the mock so withAuth captures the mocked getToken.
+// Imported after the mock so the middleware captures the mocked getToken.
 import middleware from '@/middleware'
 
 const mockGetToken = getToken as jest.Mock
 
 function callMiddleware(path: string) {
   const req = new NextRequest(new URL(`http://localhost${path}`))
-  // withAuth ignores the NextFetchEvent for redirect decisions.
-  return middleware(req as never, {} as never)
+  return middleware(req)
+}
+
+function directive(csp: string, name: string): string {
+  const match = csp.split(';').find((d) => d.trim().startsWith(`${name} `) || d.trim() === name)
+  return match?.trim() ?? ''
 }
 
 afterEach(() => mockGetToken.mockReset())
 
-describe('route protection middleware', () => {
+describe('route protection', () => {
   it('redirects unauthenticated access to /login before render', async () => {
     mockGetToken.mockResolvedValue(null)
 
@@ -48,9 +55,83 @@ describe('route protection middleware', () => {
 
     const res = await callMiddleware('/dashboard')
 
-    // withAuth returns undefined (or a pass-through NextResponse.next()) when the
-    // session is valid — never a redirect to /login.
     expect(res?.status).not.toBe(307)
     expect(res?.headers.get('location') ?? '').not.toContain('/login')
+  })
+
+  it('lets unauthenticated requests reach public pages', async () => {
+    mockGetToken.mockResolvedValue(null)
+
+    const res = await callMiddleware('/login')
+
+    expect(res?.status).not.toBe(307)
+  })
+})
+
+describe('Content-Security-Policy (issue #307)', () => {
+  beforeEach(() => mockGetToken.mockResolvedValue(null))
+
+  it('sets a CSP on public pages — including /login', async () => {
+    const res = await callMiddleware('/login')
+    expect(res?.headers.get('content-security-policy')).toBeTruthy()
+  })
+
+  it('sets a CSP on authenticated pages', async () => {
+    mockGetToken.mockResolvedValue({ userId: 'u1' })
+    const res = await callMiddleware('/dashboard')
+    expect(res?.headers.get('content-security-policy')).toBeTruthy()
+  })
+
+  it('uses a nonce + strict-dynamic script-src with no unsafe-inline', async () => {
+    const res = await callMiddleware('/login')
+    const scriptSrc = directive(res!.headers.get('content-security-policy')!, 'script-src')
+
+    expect(scriptSrc).toMatch(/'nonce-[A-Za-z0-9+/=]+'/)
+    expect(scriptSrc).toContain("'strict-dynamic'")
+    expect(scriptSrc).not.toContain("'unsafe-inline'")
+  })
+
+  it('generates a fresh nonce per request', async () => {
+    const nonceOf = async () =>
+      /'nonce-([^']+)'/.exec((await callMiddleware('/login'))!.headers.get('content-security-policy')!)?.[1]
+
+    expect(await nonceOf()).not.toBe(await nonceOf())
+  })
+
+  it('forwards the nonce to the app via the x-nonce request header', async () => {
+    const res = await callMiddleware('/login')
+    const csp = res!.headers.get('content-security-policy')!
+    const nonce = /'nonce-([^']+)'/.exec(csp)?.[1]
+
+    // NextResponse.next({ request }) records overridden request headers here.
+    const forwarded = res!.headers.get('x-middleware-request-x-nonce')
+    expect(forwarded).toBe(nonce)
+  })
+
+  it('keeps unsafe-inline for styles (Radix inline style attributes)', async () => {
+    const res = await callMiddleware('/login')
+    const styleSrc = directive(res!.headers.get('content-security-policy')!, 'style-src')
+    expect(styleSrc).toContain("'unsafe-inline'")
+  })
+
+  it('still allows S3 episode audio in media-src and connect-src', async () => {
+    const res = await callMiddleware('/login')
+    const csp = res!.headers.get('content-security-policy')!
+    for (const src of ['media-src', 'connect-src']) {
+      const value = directive(csp, src)
+      expect(value).toContain('https://podcaststudiohub-audio.s3.amazonaws.com')
+      expect(value).toContain('https://podcaststudiohub-audio.s3.us-east-1.amazonaws.com')
+    }
+  })
+
+  it('keeps the hardening directives from the old nginx policy', async () => {
+    const res = await callMiddleware('/login')
+    const csp = res!.headers.get('content-security-policy')!
+
+    expect(directive(csp, 'object-src')).toContain("'none'")
+    expect(directive(csp, 'frame-ancestors')).toContain("'none'")
+    expect(directive(csp, 'base-uri')).toContain("'self'")
+    expect(directive(csp, 'form-action')).toContain("'self'")
+    expect(csp).toContain('upgrade-insecure-requests')
   })
 })

--- a/apps/web/__tests__/middleware.test.ts
+++ b/apps/web/__tests__/middleware.test.ts
@@ -124,6 +124,30 @@ describe('Content-Security-Policy (issue #307)', () => {
     }
   })
 
+  it('allows the configured API origin in connect-src (signup posts to it cross-origin in dev/CI)', async () => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8200'
+    try {
+      const res = await callMiddleware('/signup')
+      const connectSrc = directive(res!.headers.get('content-security-policy')!, 'connect-src')
+      expect(connectSrc).toContain('http://localhost:8200')
+    } finally {
+      delete process.env.NEXT_PUBLIC_API_URL
+    }
+  })
+
+  it('ignores a same-path API URL cleanly (prod: API is same-origin behind nginx)', async () => {
+    process.env.NEXT_PUBLIC_API_URL = '/api'
+    try {
+      const res = await callMiddleware('/signup')
+      // Relative URL has no origin — CSP must stay valid with just 'self' + S3.
+      const connectSrc = directive(res!.headers.get('content-security-policy')!, 'connect-src')
+      expect(connectSrc).toContain("'self'")
+      expect(connectSrc).not.toContain('/api')
+    } finally {
+      delete process.env.NEXT_PUBLIC_API_URL
+    }
+  })
+
   it('keeps the hardening directives from the old nginx policy', async () => {
     const res = await callMiddleware('/login')
     const csp = res!.headers.get('content-security-policy')!

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,11 +1,7 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
-};
+// No eslint.ignoreDuringBuilds / typescript.ignoreBuildErrors (issue #307):
+// every `next build` — CI, local, and the on-VPS rebuild in deploy-dev.yml —
+// must fail on type or lint errors, not silently ship them.
+const nextConfig = {};
 
 export default nextConfig;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { Nunito_Sans } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/components/providers/auth-provider";
@@ -16,15 +17,20 @@ export const metadata: Metadata = {
   description: "AI-powered podcast generation platform",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Per-request CSP nonce from the middleware (issue #307) — without it the
+  // theme-flash script below is blocked, since script-src has no
+  // 'unsafe-inline' anymore.
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `try{var t=localStorage.getItem('theme')||'system';var d=t==='dark'||(t==='system'&&window.matchMedia('(prefers-color-scheme: dark)').matches);if(d)document.documentElement.classList.add('dark');else document.documentElement.classList.remove('dark');}catch(e){}`,
           }}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -29,9 +29,22 @@ const PROTECTED_PATHS = ['/dashboard', '/episodes', '/projects']
 const S3_AUDIO =
   'https://podcaststudiohub-audio.s3.amazonaws.com https://podcaststudiohub-audio.s3.us-east-1.amazonaws.com'
 
+// The signup page fetches ${NEXT_PUBLIC_API_URL}/auth/register from the
+// browser. Behind nginx that URL is same-origin ('self' covers it), but in
+// dev/CI the API runs on its own port — its origin must be in connect-src or
+// signup breaks. Relative/unset URLs have no origin and add nothing.
+function apiOrigin(): string {
+  try {
+    return new URL(process.env.NEXT_PUBLIC_API_URL ?? '').origin
+  } catch {
+    return ''
+  }
+}
+
 function buildCsp(nonce: string): string {
   // React dev tooling (fast refresh) needs eval; production must not allow it.
   const scriptExtra = process.env.NODE_ENV === 'development' ? " 'unsafe-eval'" : ''
+  const api = apiOrigin()
   return [
     "default-src 'self'",
     `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${scriptExtra}`,
@@ -41,7 +54,7 @@ function buildCsp(nonce: string): string {
     "img-src 'self' data: https:",
     "font-src 'self' data:",
     `media-src 'self' ${S3_AUDIO}`,
-    `connect-src 'self' ${S3_AUDIO}`,
+    `connect-src 'self' ${S3_AUDIO}${api ? ` ${api}` : ''}`,
     "object-src 'none'",
     "base-uri 'self'",
     "frame-ancestors 'none'",

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -62,7 +62,9 @@ export default async function middleware(req: NextRequest) {
     }
   }
 
-  const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
+  // btoa, not Buffer: Web API only, so the middleware has no Node-runtime
+  // coupling regardless of where it executes.
+  const nonce = btoa(crypto.randomUUID())
   const csp = buildCsp(nonce)
 
   const requestHeaders = new Headers(req.headers)

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,24 +1,84 @@
 /**
- * Server-side route protection for the (auth) route group (issue #222).
+ * App middleware: route protection (issue #222) + nonce-based CSP (issue #307).
  *
- * Previously the (auth) pages were gated only client-side (a post-hydration
- * useEffect redirect), so protected page bundles were served to unauthenticated
- * users and the gate could be bypassed by disabling JS or racing the redirect.
+ * Route protection — the (auth) route group pages must be gated server-side,
+ * before the page renders, not just by the client-side useEffect redirect.
+ * Uses getToken (the same session-JWT check next-auth's withAuth runs
+ * internally) and reproduces withAuth's /login?callbackUrl=… redirect.
  *
- * next-auth's withAuth runs in middleware before the page renders: it reads the
- * session JWT (httpOnly cookie) via NEXTAUTH_SECRET and redirects requests
- * without a valid session to /login. The client-side redirect stays as a
- * secondary, defense-in-depth guard. Data is also protected by backend authz.
+ * CSP — the document Content-Security-Policy carries a fresh per-request nonce
+ * and 'strict-dynamic' instead of 'unsafe-inline', so injected inline scripts
+ * no longer execute. Next.js reads the policy from the forwarded request
+ * header and stamps the nonce onto its own framework/hydration scripts; the
+ * root layout reads x-nonce for the theme-flash inline script. nginx no longer
+ * sets a document CSP (two CSP headers enforce their intersection, which would
+ * block the nonce'd scripts) — see deployment/nginx/podcastfy.conf.
+ *
+ * Not withAuth: next-auth v4's withAuth skips the signIn page, /api/auth/* and
+ * /_next entirely, so a CSP set inside a wrapped middleware would never reach
+ * /login — the most exposed unauthenticated page.
  */
-import { withAuth } from 'next-auth/middleware'
+import { NextRequest, NextResponse } from 'next/server'
+import { getToken } from 'next-auth/jwt'
 
-// Default authorized check is `!!token`; we only override the sign-in page so
-// redirects land on our /login route instead of next-auth's built-in page.
-export default withAuth({
-  pages: { signIn: '/login' },
-})
+const PROTECTED_PATHS = ['/dashboard', '/episodes', '/projects']
+
+// media-src / connect-src allow the S3 audio bucket the app streams and
+// downloads episode audio from (episodes page + DownloadButton). The host must
+// match AWS_S3_BUCKET / AWS_REGION (default us-east-1).
+const S3_AUDIO =
+  'https://podcaststudiohub-audio.s3.amazonaws.com https://podcaststudiohub-audio.s3.us-east-1.amazonaws.com'
+
+function buildCsp(nonce: string): string {
+  // React dev tooling (fast refresh) needs eval; production must not allow it.
+  const scriptExtra = process.env.NODE_ENV === 'development' ? " 'unsafe-eval'" : ''
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${scriptExtra}`,
+    // 'unsafe-inline' stays for styles only: Radix/shadcn set inline style
+    // attributes, which style-src nonces cannot cover.
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: https:",
+    "font-src 'self' data:",
+    `media-src 'self' ${S3_AUDIO}`,
+    `connect-src 'self' ${S3_AUDIO}`,
+    "object-src 'none'",
+    "base-uri 'self'",
+    "frame-ancestors 'none'",
+    "form-action 'self'",
+    'upgrade-insecure-requests',
+  ].join('; ')
+}
+
+export default async function middleware(req: NextRequest) {
+  const { pathname, search } = req.nextUrl
+
+  if (PROTECTED_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`))) {
+    const token = await getToken({ req })
+    if (!token) {
+      const loginUrl = new URL('/login', req.nextUrl.origin)
+      loginUrl.searchParams.set('callbackUrl', `${pathname}${search}`)
+      return NextResponse.redirect(loginUrl)
+    }
+  }
+
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
+  const csp = buildCsp(nonce)
+
+  const requestHeaders = new Headers(req.headers)
+  requestHeaders.set('x-nonce', nonce)
+  // Next.js picks the nonce up from this request header and applies it to the
+  // framework scripts it injects.
+  requestHeaders.set('Content-Security-Policy', csp)
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } })
+  response.headers.set('Content-Security-Policy', csp)
+  return response
+}
 
 export const config = {
-  // Route group "(auth)" is not part of the URL, so match the actual paths.
-  matcher: ['/dashboard/:path*', '/episodes/:path*', '/projects/:path*'],
+  // Every page (public ones included) needs the CSP; static assets and API
+  // responses do not. Route group "(auth)" is not part of the URL, so the
+  // protected paths above match the real paths.
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
 }

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -450,8 +450,16 @@ Nginx reverse proxy configuration is in `deployment/nginx/podcastfy.conf`.
 - `https://dev.podcaststudiohub.me` → `localhost:3010` (Frontend)
 
 The config terminates TLS 1.2/1.3 only and sends every request through a
-301 HTTP→HTTPS redirect, plus HSTS / CSP / X-Frame-Options /
+301 HTTP→HTTPS redirect, plus HSTS / X-Frame-Options /
 X-Content-Type-Options / Referrer-Policy. Port 80 never reaches the app.
+
+The document Content-Security-Policy is **not** set by nginx: it is a
+per-request nonce policy (no `'unsafe-inline'` script-src) minted by the
+Next.js middleware (`apps/web/src/middleware.ts`, issue #307). Do not add a
+CSP `add_header` back to the server block — browsers enforce the intersection
+of multiple CSP headers, which would block every nonce'd script. The
+`/static/` location keeps its own strict CSP for assets nginx serves
+directly.
 
 ## SSL / TLS (Let's Encrypt)
 

--- a/deployment/nginx/podcastfy.conf
+++ b/deployment/nginx/podcastfy.conf
@@ -58,10 +58,12 @@ server {
 
 	# Security headers (AC2)
 	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-	# media-src / connect-src allow the S3 audio bucket the app streams and
-	# downloads episode audio from (apps/web episodes page + DownloadButton).
-	# The host must match AWS_S3_BUCKET / AWS_REGION (default us-east-1).
-	add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' https://podcaststudiohub-audio.s3.amazonaws.com https://podcaststudiohub-audio.s3.us-east-1.amazonaws.com; connect-src 'self' https://podcaststudiohub-audio.s3.amazonaws.com https://podcaststudiohub-audio.s3.us-east-1.amazonaws.com; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests;" always;
+	# NO Content-Security-Policy here (issue #307): the document CSP is a
+	# per-request *nonce* policy set by the Next.js middleware
+	# (apps/web/src/middleware.ts) — nginx cannot mint nonces, and a second
+	# static CSP header would stack with it (browsers enforce the intersection),
+	# blocking every nonce'd script. The /static/ block below keeps a strict CSP
+	# for assets nginx serves directly.
 	add_header X-Frame-Options "DENY" always;
 	add_header X-Content-Type-Options "nosniff" always;
 	add_header Referrer-Policy "strict-origin-when-cross-origin" always;
@@ -184,7 +186,9 @@ server {
 		# add_header would DROP the server-level security headers, so they
 		# must be repeated here alongside Cache-Control.
 		add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-		add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' https://podcaststudiohub-audio.s3.amazonaws.com https://podcaststudiohub-audio.s3.us-east-1.amazonaws.com; connect-src 'self' https://podcaststudiohub-audio.s3.amazonaws.com https://podcaststudiohub-audio.s3.us-east-1.amazonaws.com; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests;" always;
+		# Static assets are never documents, so a strict no-inline CSP is safe
+		# here and satisfies defense-in-depth (issue #307).
+		add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self' data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests;" always;
 		add_header X-Frame-Options "DENY" always;
 		add_header X-Content-Type-Options "nosniff" always;
 		add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/deployment/tests/test_nginx_config.py
+++ b/deployment/tests/test_nginx_config.py
@@ -79,7 +79,6 @@ def test_security_headers_present(server_blocks: list[str]):
 	https_block = _block_matching(server_blocks, "listen 443 ssl")
 	required = [
 		"Strict-Transport-Security",
-		"Content-Security-Policy",
 		"X-Frame-Options",
 		"X-Content-Type-Options",
 		"Referrer-Policy",
@@ -106,26 +105,28 @@ def test_frame_options_denies_frame(server_blocks: list[str]):
 	assert "deny" in m.group(1).lower() or "sameorigin" in m.group(1).lower()
 
 
-def test_csp_allows_s3_audio(server_blocks: list[str]):
-	"""Episode audio streams / downloads from S3 (apps/web episode page +
-	DownloadButton). CSP must not block it — both media-src (<audio>) and
-	connect-src (fetch download) must allow an S3 origin."""
+def test_no_server_level_csp_header(server_blocks: list[str]):
+	"""The document CSP is a per-request nonce policy set by the Next.js
+	middleware (issue #307). nginx must NOT also add_header a CSP at server
+	level: browsers enforce the intersection of multiple CSP headers, so a
+	second policy without the nonce would block every framework script.
+	The /static/ location keeps its own CSP for on-disk assets, which is why
+	this walks server-level lines only (location bodies excluded)."""
 	https_block = _block_matching(server_blocks, "listen 443 ssl")
-	m = re.search(r"Content-Security-Policy\s+\"([^\"]+)\"", https_block, re.I)
-	assert m, "Content-Security-Policy header missing"
-	csp = m.group(1)
-
-	def directive(src: str) -> str:
-		match = re.search(rf"{src}\s+([^;]+)", csp)
-		return match.group(1) if match else ""
-
-	# An S3 host must be permitted for both media playback and fetch downloads.
-	assert any(".s3." in tok for tok in directive("media-src").split()), (
-		"media-src must allow the S3 audio host (episode playback)"
+	server_level = re.split(r"location\s", https_block)[0]
+	assert "content-security-policy" not in server_level.lower(), (
+		"server-level CSP would stack with the app's nonce CSP — remove it"
 	)
-	assert any(".s3." in tok for tok in directive("connect-src").split()), (
-		"connect-src must allow the S3 audio host (download fetch)"
-	)
+
+
+def test_no_unsafe_inline_script_src(nginx_conf_raw: str):
+	"""Issue #307: no CSP shipped by nginx may allow inline scripts."""
+	for csp in re.findall(r"Content-Security-Policy\s+\"([^\"]+)\"", nginx_conf_raw, re.I):
+		m = re.search(r"script-src\s+([^;]+)", csp)
+		if m:
+			assert "'unsafe-inline'" not in m.group(1), (
+				"script-src must not allow 'unsafe-inline'"
+			)
 
 
 # ── AC1: Let's Encrypt cert paths + renewal webroot ─────────────────────────

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,22 +180,6 @@
         }
       }
     },
-    "apps/web/node_modules/@jest/environment": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
-      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/fake-timers": "30.3.0",
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "jest-mock": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "apps/web/node_modules/@jest/expect": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
@@ -205,37 +189,6 @@
       "dependencies": {
         "expect": "30.3.0",
         "jest-snapshot": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "apps/web/node_modules/@jest/expect-utils": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
-      "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "apps/web/node_modules/@jest/fake-timers": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
-      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@sinonjs/fake-timers": "^15.0.0",
-        "@types/node": "*",
-        "jest-message-util": "30.3.0",
-        "jest-mock": "30.3.0",
-        "jest-util": "30.3.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -386,179 +339,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "apps/web/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "apps/web/node_modules/@next/env": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.20.tgz",
-      "integrity": "sha512-dXh51Wvddf8daEyBXryZZEe1FdVxEWx9lgaTseLZUtC1XP/W8Wri+Z+VPOElHlByk23CyqHdc2oVByX7wsTWsw==",
-      "license": "MIT"
-    },
-    "apps/web/node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.20.tgz",
-      "integrity": "sha512-in0yXG7/pRBVjWeEl7f7ZZETpletSMFKXVS4GJgHENTPVrJFNJKPrYewa9rpZcvdjwFece5fZP0CK34G4PxowA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.20.tgz",
-      "integrity": "sha512-0hsFshdPnTzGJdDTHeHJ+XPUShOpnyp9pUFDwDhqctsA0Cd8NcIVGRPtptYhgYY9DjkKgCDRkXxmgRc+CgT5Wg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.20.tgz",
-      "integrity": "sha512-DMvkoBtAABOzE6pMZRW/xNm7sKqql3wzzzZJ1R/d/rp4BCxv6LykouD3tHjGY8WdQqGpZs11t+R9AtjPxvvljw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.20.tgz",
-      "integrity": "sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.20.tgz",
-      "integrity": "sha512-DkWLEdKajJwdGt27M3i1VEO2kelTvZrK6Pcb7JvW2BY+nofWm7FBsBNDj7g7Pr1NuQ5PLJvqEqYa20GTsBDnKQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.20.tgz",
-      "integrity": "sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.20.tgz",
-      "integrity": "sha512-Hp3zFsN8N8Kj9+vY6L4vnZ9EtA9eXyATu0q4EfGbZTiocgPUNSfz8NWhym6xvaOmHpJ8EuoypuU1WejCPsTFtg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.20.tgz",
-      "integrity": "sha512-T/L7CXpR1M0wij/xbF3rT1+7KvSkfOLr7C+ToHHWZTG2eKmb52C5WvsyGCBNtkVvDEUESWkRUbbqSH4rSbOCYQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@sinonjs/fake-timers": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
-      "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1"
-      }
-    },
-    "apps/web/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "apps/web/node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -663,93 +443,6 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "apps/web/node_modules/cssstyle": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
-      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/css-color": "^3.2.0",
-        "rrweb-cssom": "^0.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/data-urls": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/expect": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
-      "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/expect-utils": "30.3.0",
-        "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.3.0",
-        "jest-message-util": "30.3.0",
-        "jest-mock": "30.3.0",
-        "jest-util": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "apps/web/node_modules/html-encoding-sniffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-encoding": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "apps/web/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "apps/web/node_modules/istanbul-lib-source-maps": {
       "version": "5.0.6",
@@ -924,22 +617,6 @@
         }
       }
     },
-    "apps/web/node_modules/jest-diff": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
-      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/diff-sequences": "30.3.0",
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "pretty-format": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "apps/web/node_modules/jest-docblock": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
@@ -1047,68 +724,6 @@
         "@jest/get-type": "30.1.0",
         "pretty-format": "30.3.0"
       },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "apps/web/node_modules/jest-matcher-utils": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
-      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "jest-diff": "30.3.0",
-        "pretty-format": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "apps/web/node_modules/jest-message-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
-      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.3.0",
-        "@types/stack-utils": "^2.0.3",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3",
-        "pretty-format": "30.3.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "apps/web/node_modules/jest-mock": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
-      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "jest-util": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "apps/web/node_modules/jest-regex-util": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
-      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -1248,24 +863,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "apps/web/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "apps/web/node_modules/jest-validate": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz",
@@ -1321,126 +918,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "apps/web/node_modules/jsdom": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssstyle": "^4.2.1",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.5.0",
-        "html-encoding-sniffer": "^4.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.16",
-        "parse5": "^7.2.1",
-        "rrweb-cssom": "^0.8.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^5.1.1",
-        "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.1.1",
-        "ws": "^8.18.0",
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "canvas": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/next": {
-      "version": "15.5.20",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.20.tgz",
-      "integrity": "sha512-cvyS3/geydan1xLtE3FA8VCgdoQ/Gg/dlOldFkFCbB5VcVYJV7090hQLBnvTW2PwT76Z/dHdzDZCsVhZpoOlUA==",
-      "license": "MIT",
-      "dependencies": {
-        "@next/env": "15.5.20",
-        "@swc/helpers": "0.5.15",
-        "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
-        "styled-jsx": "5.1.6"
-      },
-      "bin": {
-        "next": "dist/bin/next"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
-      },
-      "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.20",
-        "@next/swc-darwin-x64": "15.5.20",
-        "@next/swc-linux-arm64-gnu": "15.5.20",
-        "@next/swc-linux-arm64-musl": "15.5.20",
-        "@next/swc-linux-x64-gnu": "15.5.20",
-        "@next/swc-linux-x64-musl": "15.5.20",
-        "@next/swc-win32-arm64-msvc": "15.5.20",
-        "@next/swc-win32-x64-msvc": "15.5.20",
-        "sharp": "^0.34.3"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.1.0",
-        "@playwright/test": "^1.51.1",
-        "babel-plugin-react-compiler": "*",
-        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
-        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
-        "sass": "^1.3.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@playwright/test": {
-          "optional": true
-        },
-        "babel-plugin-react-compiler": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "apps/web/node_modules/pretty-format": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
@@ -1479,70 +956,6 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
-    },
-    "apps/web/node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^6.1.32"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "apps/web/node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
     },
     "apps/web/node_modules/write-file-atomic": {
       "version": "5.0.1",
@@ -1598,40 +1011,6 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
-      "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/nwsapi": "^2.3.9",
-        "bidi-js": "^1.0.3",
-        "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.7"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@asamuzakjp/nwsapi": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -2159,19 +1538,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@bramus/specificity": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
-      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-tree": "^3.0.0"
-      },
-      "bin": {
-        "specificity": "bin/cli.js"
-      }
-    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -2266,31 +1632,6 @@
       },
       "peerDependencies": {
         "@csstools/css-tokenizer": "^3.0.4"
-      }
-    },
-    "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
-      "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "peerDependencies": {
-        "css-tree": "^3.2.1"
-      },
-      "peerDependenciesMeta": {
-        "css-tree": {
-          "optional": true
-        }
       }
     },
     "node_modules/@csstools/css-tokenizer": {
@@ -2408,24 +1749,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@exodus/bytes": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
-      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@noble/hashes": "^1.8.0 || ^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@noble/hashes": {
-          "optional": true
-        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -3029,13 +2352,13 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -3171,6 +2494,22 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@jest/environment": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment-jsdom-abstract": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.3.0.tgz",
@@ -3199,82 +2538,6 @@
         }
       }
     },
-    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/environment": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
-      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/fake-timers": "30.3.0",
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "jest-mock": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/fake-timers": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
-      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@sinonjs/fake-timers": "^15.0.0",
-        "@types/node": "*",
-        "jest-message-util": "30.3.0",
-        "jest-mock": "30.3.0",
-        "jest-util": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/schemas": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/environment-jsdom-abstract/node_modules/@sinonjs/fake-timers": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
-      "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1"
-      }
-    },
     "node_modules/@jest/environment-jsdom-abstract/node_modules/@types/jsdom": {
       "version": "21.1.7",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
@@ -3287,103 +2550,32 @@
         "parse5": "^7.0.0"
       }
     },
-    "node_modules/@jest/environment-jsdom-abstract/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-message-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
-      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.3.0",
-        "@types/stack-utils": "^2.0.3",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3",
-        "pretty-format": "30.3.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-mock": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
-      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "jest-util": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
-      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/environment-jsdom-abstract/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@jest/expect-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
-      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+      "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@sinonjs/fake-timers": "^15.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -3409,16 +2601,6 @@
         "@types/node": "*",
         "jest-regex-util": "30.0.1"
       },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
-      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -3452,20 +2634,7 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/snapshot-utils/node_modules/@jest/schemas": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/snapshot-utils/node_modules/@jest/types": {
+    "node_modules/@jest/types": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
       "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
@@ -3484,34 +2653,14 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/types": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+    "node_modules/@jest/types/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/pattern": "30.4.0",
-        "@jest/schemas": "30.4.1",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/types/node_modules/@jest/pattern": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-regex-util": "30.4.0"
+        "@sinclair/typebox": "^0.34.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -3581,9 +2730,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
-      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.20.tgz",
+      "integrity": "sha512-dXh51Wvddf8daEyBXryZZEe1FdVxEWx9lgaTseLZUtC1XP/W8Wri+Z+VPOElHlByk23CyqHdc2oVByX7wsTWsw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -3627,9 +2776,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
-      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.20.tgz",
+      "integrity": "sha512-in0yXG7/pRBVjWeEl7f7ZZETpletSMFKXVS4GJgHENTPVrJFNJKPrYewa9rpZcvdjwFece5fZP0CK34G4PxowA==",
       "cpu": [
         "arm64"
       ],
@@ -3643,9 +2792,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
-      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.20.tgz",
+      "integrity": "sha512-0hsFshdPnTzGJdDTHeHJ+XPUShOpnyp9pUFDwDhqctsA0Cd8NcIVGRPtptYhgYY9DjkKgCDRkXxmgRc+CgT5Wg==",
       "cpu": [
         "x64"
       ],
@@ -3659,9 +2808,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
-      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.20.tgz",
+      "integrity": "sha512-DMvkoBtAABOzE6pMZRW/xNm7sKqql3wzzzZJ1R/d/rp4BCxv6LykouD3tHjGY8WdQqGpZs11t+R9AtjPxvvljw==",
       "cpu": [
         "arm64"
       ],
@@ -3675,9 +2824,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
-      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.20.tgz",
+      "integrity": "sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==",
       "cpu": [
         "arm64"
       ],
@@ -3691,9 +2840,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
-      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.20.tgz",
+      "integrity": "sha512-DkWLEdKajJwdGt27M3i1VEO2kelTvZrK6Pcb7JvW2BY+nofWm7FBsBNDj7g7Pr1NuQ5PLJvqEqYa20GTsBDnKQ==",
       "cpu": [
         "x64"
       ],
@@ -3707,9 +2856,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
-      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.20.tgz",
+      "integrity": "sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==",
       "cpu": [
         "x64"
       ],
@@ -3723,9 +2872,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
-      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.20.tgz",
+      "integrity": "sha512-Hp3zFsN8N8Kj9+vY6L4vnZ9EtA9eXyATu0q4EfGbZTiocgPUNSfz8NWhym6xvaOmHpJ8EuoypuU1WejCPsTFtg==",
       "cpu": [
         "arm64"
       ],
@@ -3739,9 +2888,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
-      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.20.tgz",
+      "integrity": "sha512-T/L7CXpR1M0wij/xbF3rT1+7KvSkfOLr7C+ToHHWZTG2eKmb52C5WvsyGCBNtkVvDEUESWkRUbbqSH4rSbOCYQ==",
       "cpu": [
         "x64"
       ],
@@ -4770,6 +3919,16 @@
         "type-detect": "4.0.8"
       }
     },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
@@ -5290,13 +4449,6 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
@@ -5678,6 +4830,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -6047,26 +5209,24 @@
         "@babel/core": "^7.0.0 || ^8.0.0-0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.42",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
       "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/bidi-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
-      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -6080,6 +5240,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
@@ -6537,20 +5708,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-tree": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.27.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -6571,6 +5728,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -6586,17 +5757,17 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-urls": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0"
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/data-view-buffer": {
@@ -7444,18 +6615,24 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7621,18 +6798,18 @@
       }
     },
     "node_modules/expect": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
-      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "30.4.1",
+        "@jest/expect-utils": "30.3.0",
         "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1"
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8036,13 +7213,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
@@ -8211,9 +7381,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8224,16 +7394,16 @@
       }
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.6.0"
+        "whatwg-encoding": "^3.1.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/html-escaper": {
@@ -8242,6 +7412,34 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -8482,13 +7680,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8957,27 +8155,30 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
-      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/diff-sequences": "30.4.0",
+        "@jest/diff-sequences": "30.3.0",
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "pretty-format": "30.4.1"
+        "pretty-format": "30.3.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-diff/node_modules/@jest/diff-sequences": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
-      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+    "node_modules/jest-diff/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -8996,32 +8197,51 @@
       }
     },
     "node_modules/jest-diff/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "30.4.1",
+        "@jest/schemas": "30.0.5",
         "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
+        "react-is": "^18.3.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-diff/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jest-matcher-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
-      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "jest-diff": "30.4.1",
-        "pretty-format": "30.4.1"
+        "jest-diff": "30.3.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -9041,38 +8261,56 @@
       }
     },
     "node_modules/jest-matcher-utils/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "30.4.1",
+        "@jest/schemas": "30.0.5",
         "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
+        "react-is": "^18.3.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-matcher-utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jest-message-util": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.4.1",
+        "@jest/types": "30.3.0",
         "@types/stack-utils": "^2.0.3",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
-        "jest-util": "30.4.1",
         "picomatch": "^4.0.3",
-        "pretty-format": "30.4.1",
+        "pretty-format": "30.3.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -9092,31 +8330,37 @@
       }
     },
     "node_modules/jest-message-util/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "30.4.1",
+        "@jest/schemas": "30.0.5",
         "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
+        "react-is": "^18.3.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-message-util/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jest-mock": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
-      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.4.1",
+        "@jest/types": "30.3.0",
         "@types/node": "*",
-        "jest-util": "30.4.1"
+        "jest-util": "30.3.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -9141,9 +8385,9 @@
       }
     },
     "node_modules/jest-regex-util": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9151,13 +8395,13 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.4.1",
+        "@jest/types": "30.3.0",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
@@ -9219,36 +8463,36 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "29.0.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
-      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@asamuzakjp/css-color": "^5.0.1",
-        "@asamuzakjp/dom-selector": "^7.0.3",
-        "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
-        "@exodus/bytes": "^1.15.0",
-        "css-tree": "^3.2.1",
-        "data-urls": "^7.0.0",
-        "decimal.js": "^10.6.0",
-        "html-encoding-sniffer": "^6.0.0",
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.7",
-        "parse5": "^8.0.0",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.1",
-        "undici": "^7.24.5",
+        "tough-cookie": "^5.1.1",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.1",
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.1",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+        "node": ">=18"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -9257,173 +8501,6 @@
         "canvas": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jsdom/node_modules/@asamuzakjp/css-color": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
-      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/css-calc": "^3.1.1",
-        "@csstools/css-color-parser": "^4.0.2",
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.2.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jsdom/node_modules/@csstools/color-helpers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "node_modules/jsdom/node_modules/@csstools/css-calc": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "node_modules/jsdom/node_modules/@csstools/css-color-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
-      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "node_modules/jsdom/node_modules/@csstools/css-parser-algorithms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "node_modules/jsdom/node_modules/@csstools/css-tokenizer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "node_modules/jsdom/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/jsdom/node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/jsdom/node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/jsesc": {
@@ -9669,13 +8746,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/mdn-data": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -9738,24 +8808,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/minimatch/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/minimist": {
@@ -9839,14 +8891,13 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
-      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.20.tgz",
+      "integrity": "sha512-cvyS3/geydan1xLtE3FA8VCgdoQ/Gg/dlOldFkFCbB5VcVYJV7090hQLBnvTW2PwT76Z/dHdzDZCsVhZpoOlUA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.10",
+        "@next/env": "15.5.20",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -9855,18 +8906,18 @@
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=20.9.0"
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.10",
-        "@next/swc-darwin-x64": "16.2.10",
-        "@next/swc-linux-arm64-gnu": "16.2.10",
-        "@next/swc-linux-arm64-musl": "16.2.10",
-        "@next/swc-linux-x64-gnu": "16.2.10",
-        "@next/swc-linux-x64-musl": "16.2.10",
-        "@next/swc-win32-arm64-msvc": "16.2.10",
-        "@next/swc-win32-x64-msvc": "16.2.10",
-        "sharp": "^0.34.5"
+        "@next/swc-darwin-arm64": "15.5.20",
+        "@next/swc-darwin-x64": "15.5.20",
+        "@next/swc-linux-arm64-gnu": "15.5.20",
+        "@next/swc-linux-arm64-musl": "15.5.20",
+        "@next/swc-linux-x64-gnu": "15.5.20",
+        "@next/swc-linux-x64-musl": "15.5.20",
+        "@next/swc-win32-arm64-msvc": "15.5.20",
+        "@next/swc-win32-x64-msvc": "15.5.20",
+        "sharp": "^0.34.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -9949,6 +9000,35 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
+      "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-exports-info/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/node-int64": {
@@ -10407,6 +9487,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11064,23 +10145,14 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -11311,9 +10383,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "devOptional": true,
       "license": "ISC",
       "bin": {
@@ -12228,49 +11300,29 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "tldts": "^7.0.5"
+        "tldts": "^6.1.32"
       },
       "engines": {
         "node": ">=16"
       }
     },
-    "node_modules/tough-cookie/node_modules/tldts": {
-      "version": "7.0.27",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
-      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tldts-core": "^7.0.27"
-      },
-      "bin": {
-        "tldts": "bin/cli.js"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/tldts-core": {
-      "version": "7.0.27",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
-      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tr46": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/tree-kill": {
@@ -12493,16 +11545,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -12697,39 +11739,42 @@
         "node": ">=12"
       }
     },
-    "node_modules/whatwg-mimetype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
+        "iconv-lite": "0.6.3"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=18"
       }
     },
-    "node_modules/whatwg-url/node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -12933,13 +11978,13 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,38 +1,60 @@
-# #306 — COMPLETE (PR #351 squash-merged 2026-07-09, issue closed)
+# Issue #307 — CSP nonce (drop 'unsafe-inline' script-src) + real build gates
 
 **Plan source**: self-authored (no plan comment on issue), verified against code 2026-07-09.
-**Branch**: `fix/issue-306-cve-alerting-dep-hardening`
+**Branch**: `fix/307-csp-nonce-and-build-gates`
 
-## Verified facts
-- `.github/dependabot.yml` has only `github-actions`; no pip/uv or npm ecosystems.
-- passlib has **zero imports** anywhere (src/tests/alembic) — `auth_service.py` already uses direct `bcrypt`. passlib exists in pyproject only to supply bcrypt via its extra.
-- python-jose used in exactly 2 source files (`src/utils/jwt.py`, `src/services/auth_service.py`) + 3 test files (jose→jwt import at 4 sites), all HS256 encode/decode — trivially PyJWT-shaped. python-jose 3.5.0 still hard-depends on `ecdsa` (won't-fix PYSEC-2026-1325), so a pip-audit gate can only pass by removing jose → **migrate to PyJWT** (issue offers this option).
-- pip-audit on current uv.lock: 108 findings / ~35 packages (lock is stale). podcastfy 0.4.1 caret caps: `setuptools<76`, `wheel<0.45` block fixes → `[tool.uv]` overrides; `langchain<0.4`, `pytest<9` cap some fixes → documented `--ignore-vuln`s; litellm/requests/pymupdf/aiohttp/etc. fixes fit within caps → `uv lock --upgrade`.
-- npm: apps/web has 2 high findings; root (playwright/concurrently devDeps) also fails `--audit-level=high`.
-- CI = `.github/workflows/test.yml` with a `quality-gate` job aggregating results.
+## Why this shape
 
-## Steps
-- [x] Explore + author plan
-- [x] Branch `fix/issue-306-cve-alerting-dep-hardening`
-- [x] pyproject: `python-jose[cryptography]` → `pyjwt>=2.10.1`; `passlib[bcrypt]` → `bcrypt>=4.0`; `[tool.uv]` overrides `setuptools>=78.1.1`, `wheel>=0.46.2`
-- [x] Migrate jose→PyJWT in 2 src + 3 test files; 1675 backend tests green
-- [x] `uv lock --upgrade` (108 findings → 16; fastapi 0.139/starlette 1.3.1; typer needed reinstall — corrupted wheel extract)
-- [x] pip-audit gate green via `apps/api/scripts/security-audit.sh` (17 documented ignores, all podcastfy-capped: litellm needs openai>=2.20 vs podcastfy openai<2)
-- [x] `npm audit fix` — workspace root lockfile covers apps/web; high-gate green both; web typecheck + 331 jest green
-- [x] test.yml `security-audit` job wired into quality-gate; dep files added to push paths
-- [x] dependabot.yml: `uv` (/apps/api) + `npm` (/) — npm workspaces mean root covers web
-- [x] pytest.ini: ignore google.generativeai EOL FutureWarning ([\s\S]* — message starts with newline)
-- [x] Deslop + opencode pre-PR review (approve; watch-items: dependabot `uv` ecosystem recognition, first real Actions run of the gate)
-- [x] PR #351 → post-PR review (approve) → demo (caught CI JWT-key-length landmine, fixed) → CI green incl. new security-audit job → docs sync (.env.example 32-char note) → squash-merged
+nginx cannot mint per-request nonces (no native module on the VPS), so the CSP for
+HTML documents moves to Next.js middleware — the official Next 15 pattern
+(nonce + `'strict-dynamic'`, `'unsafe-eval'` in dev only). nginx keeps every other
+security header; its `/static/` block keeps a CSP with `script-src 'self'` (no
+unsafe-inline). Hash-based CSP is unworkable: Next's hydration payload changes
+every request.
 
-## Acceptance criteria (issue #306)
-- [ ] pip + npm Dependabot ecosystems added
-- [ ] CI pip-audit / `npm audit --audit-level=high` gate
-- [ ] python-jose floor ≥3.4.0 **or migrate to PyJWT** → migrating to PyJWT (kills ecdsa too)
-- [ ] Password hashing on pwdlib/direct bcrypt → already direct bcrypt; drop passlib, declare bcrypt
-- [ ] uv overrides so security transitives float independent of podcastfy pin
+**Gotcha that forced a middleware rewrite**: next-auth v4 `withAuth` early-returns
+for the signIn page (`/login`), `/api/auth/*` and `/_next` — wrapped middleware
+never runs there, so the login page would get **no CSP**. Replace `withAuth` with a
+plain middleware: nonce-CSP for all matched pages + auth gate via `getToken`
+(what withAuth uses internally) with the same `/login?callbackUrl=` redirect.
 
----
+## Steps (TDD)
 
-# #305 — COMPLETE (PR #350 squash-merged 2026-07-09, issue closed)
-(archived — see git history for details)
+- [ ] 1. Branch off main.
+- [ ] 2. RED — extend `apps/web/__tests__/middleware.test.ts`:
+  - existing auth tests keep passing unchanged (redirect w/ callbackUrl; authed pass-through)
+  - CSP response header present on protected AND public (`/login`) routes
+  - `script-src` contains a base64 nonce + `'strict-dynamic'`, NOT `'unsafe-inline'`
+  - `style-src` keeps `'unsafe-inline'` (Radix/shadcn inline style attrs)
+  - media-src/connect-src keep both S3 hosts (episode audio streaming/download)
+  - nonce differs across requests; `x-nonce` request header forwarded
+- [ ] 3. RED — update `deployment/tests/test_nginx_config.py`:
+  - server block no longer sets CSP (moved to app); other headers still asserted
+  - `/static/` CSP has no `'unsafe-inline'` in script-src
+  - drop/replace `test_csp_allows_s3_audio` (S3 allowance asserted in jest now)
+- [ ] 4. GREEN — rewrite `apps/web/src/middleware.ts` (plain middleware, matcher
+  `/((?!api|_next/static|_next/image|favicon.ico).*)` — no prefetch `missing`
+  exclusions, preserving #222 auth-on-prefetch behavior).
+- [ ] 5. GREEN — `apps/web/src/app/layout.tsx`: async, read `x-nonce` via
+  `headers()`, pass `nonce` to the theme-flash inline script.
+- [ ] 6. GREEN — `deployment/nginx/podcastfy.conf`: remove server-level CSP
+  add_header (comment: owned by Next middleware); `/static/` CSP drops
+  unsafe-inline from script-src.
+- [ ] 7. `apps/web/next.config.mjs`: delete `eslint.ignoreDuringBuilds` +
+  `typescript.ignoreBuildErrors` (lint + typecheck verified green locally; CI
+  gates already blocking; server-side rebuild in deploy-dev.yml now also gated).
+- [ ] 8. Verify: jest w/ coverage (≥80 gate), deployment pytest, `next build`
+  (flags removed → build runs lint+types), lint, typecheck.
+- [ ] 9. Deslop scan; quality gate incl. opencode (GLM) review pre-PR.
+- [ ] 10. PR; demo: `next start` + curl -I → CSP header w/ nonce, no
+  unsafe-inline in script-src; browser loads login/dashboard with zero CSP
+  violations; build fails when a type error is injected (gate proof, reverted).
+- [ ] 11. Post-PR opencode review comment; CI green; docs sync; merge.
+
+## Risks
+
+- Nonce CSP forces dynamic rendering of all pages — fine for an authed SaaS
+  behind PM2 (`next start`); Playwright E2E runs prod mode, so a broken CSP
+  fails E2E loudly.
+- style-src keeps unsafe-inline deliberately (inline `style=` attrs everywhere
+  in Radix); issue AC only requires script-src.


### PR DESCRIPTION
Closes #307

## What

1. **Nonce-based CSP** — the document CSP moves from a static nginx `add_header` to the Next.js middleware, which mints a fresh nonce per request: `script-src 'self' 'nonce-…' 'strict-dynamic'` (dev adds `'unsafe-eval'` for fast refresh). `'unsafe-inline'` is gone from script-src everywhere.
2. **Middleware rewrite** — next-auth v4's `withAuth` skips the signIn page (`/login`), `/api/auth/*` and `/_next` entirely, so a CSP set inside a wrapped middleware would never reach the login page. Replaced with a plain middleware: nonce CSP for all pages + the same auth gate via `getToken` (what `withAuth` uses internally), preserving the `/login?callbackUrl=…` redirect from #222.
3. **Layout** — the theme-flash inline script now carries the request nonce.
4. **nginx** — server-level CSP removed (two CSP headers enforce their intersection, which would block every nonce'd script); `/static/` block keeps a strict CSP with `script-src 'self'`. All other security headers (HSTS/XFO/XCTO/Referrer-Policy) unchanged.
5. **Build gates** — `eslint.ignoreDuringBuilds` and `typescript.ignoreBuildErrors` removed from `next.config.mjs`: every `next build` (CI, local, and the on-VPS rebuild in deploy-dev.yml) now fails on type/lint errors.
6. **npm dedupe** — the re-enabled type gate immediately exposed a phantom `next@16.2.10` at the workspace root that `next-auth` type-resolved against while the app runs 15.5.20; deduped to a single copy.

## Verification

- 340 jest tests green incl. 11 middleware tests (nonce present + per-request unique, no `unsafe-inline` in script-src, S3 media/connect kept, auth redirect parity, CSP on public `/login`).
- 18 deployment pytest green incl. real `nginx -t` in Docker.
- `next build` green with lint+types enforced; `next start` runtime check: CSP header on `/login`, matching nonce stamped into HTML script tags, fresh nonce per request, unauthenticated `/dashboard` → 307 `/login?callbackUrl=%2Fdashboard`.
- Browser check (agent-browser): login page renders and hydrates with zero CSP violations; theme-flash inline script executes under the nonce (dark class applied).

## Third-party review

opencode (GLM) pre-PR review: **APPROVE**, no Critical/Major findings.

## Known Limitations

- `style-src` keeps `'unsafe-inline'`: Radix/shadcn set inline `style=` attributes, which style nonces cannot cover. Issue AC only requires script-src.
- `img-src 'self' data: https:` kept as-is (parity with the old policy); could be tightened to an allowlist in a follow-up.
- A middleware-thrown 500 (e.g. platform failure) serves Next's static error page without a CSP header — inert, since that page has no user data and a nonce-less CSP would block its scripts regardless.