### PR TITLE
Delete S3 audio + local artifacts on episode delete; add GDPR account erasure (#308)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ podcaststudiohub/
 - `POST /api/auth/login` - Login user
 - `POST /api/auth/logout` - Logout user
 - `GET /api/auth/me` - Get current user
+- `DELETE /api/auth/me` - Permanently erase the account (GDPR; requires password re-entry)
 
 ### Projects
 - `GET /api/projects` - List user's projects

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -54,6 +54,13 @@ _rate_limit_resend = create_rate_limit_dependency(
     settings.RATE_LIMIT_RESEND_REQUESTS,
     settings.RATE_LIMIT_RESEND_WINDOW_MINUTES,
 )
+# Account erasure re-checks the password, so it gets the login limits: the
+# threat (online password guessing) is the same.
+_rate_limit_delete_account = create_rate_limit_dependency(
+    "delete-account",
+    settings.RATE_LIMIT_LOGIN_REQUESTS,
+    settings.RATE_LIMIT_LOGIN_WINDOW_MINUTES,
+)
 
 
 @router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
@@ -186,6 +193,7 @@ async def delete_current_user(
     payload: AccountDeleteRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    _: None = Depends(_rate_limit_delete_account),
 ):
     """
     Permanently erase the authenticated user's account (GDPR-style right to

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -26,6 +26,7 @@ from ..services.auth_service import (
     verify_verification_token,
 )
 from ..services.email_service import send_verification_email
+from ..services.offboarding_service import erase_user
 from ..models.user import User
 from ..middleware.auth import get_current_user
 from ..dependencies import create_rate_limit_dependency
@@ -176,6 +177,24 @@ async def get_current_user_info(
     Example: Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
     """
     return UserResponse.model_validate(current_user)
+
+
+@router.delete("/me", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_current_user(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Permanently erase the authenticated user's account (GDPR-style right to
+    erasure).
+
+    Deletes every Postgres row tied to the account (projects, episodes and
+    everything cascading from them, plus billing rows), all S3 audio
+    objects, and local file artifacts. Irreversible; the bearer token used
+    to call this is rejected on every subsequent request.
+    """
+    await erase_user(db, current_user)
+    return None
 
 
 @router.get("/verify-email", response_model=VerificationResponse)

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..database import get_db, set_tenant_context
 from ..schemas.auth import (
+    AccountDeleteRequest,
     ResendVerificationRequest,
     ResendVerificationResponse,
     TokenResponse,
@@ -23,6 +24,7 @@ from ..services.auth_service import (
     create_verification_token,
     get_user_by_email,
     mark_user_verified,
+    verify_password,
     verify_verification_token,
 )
 from ..services.email_service import send_verification_email
@@ -181,6 +183,7 @@ async def get_current_user_info(
 
 @router.delete("/me", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_current_user(
+    payload: AccountDeleteRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -188,11 +191,18 @@ async def delete_current_user(
     Permanently erase the authenticated user's account (GDPR-style right to
     erasure).
 
-    Deletes every Postgres row tied to the account (projects, episodes and
-    everything cascading from them, plus billing rows), all S3 audio
-    objects, and local file artifacts. Irreversible; the bearer token used
-    to call this is rejected on every subsequent request.
+    Requires the current password re-entered in the body (step-up auth for an
+    irreversible action). Deletes every Postgres row tied to the account
+    (projects, episodes and everything cascading from them, plus billing rows),
+    all S3 audio objects, and local file artifacts. Returns 409 while any of
+    the account's episodes is still generating. Irreversible; the bearer token
+    used to call this is rejected on every subsequent request.
     """
+    if not verify_password(payload.password, current_user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Password confirmation failed",
+        )
     await erase_user(db, current_user)
     return None
 

--- a/apps/api/src/schemas/auth.py
+++ b/apps/api/src/schemas/auth.py
@@ -110,6 +110,11 @@ class VerificationResponse(BaseModel):
     verified: bool
 
 
+class AccountDeleteRequest(BaseModel):
+    """Schema for confirming irreversible account erasure"""
+    password: str = Field(..., description="Current password, re-entered to confirm erasure")
+
+
 class ResendVerificationRequest(BaseModel):
     """Schema for resending a verification email"""
     email: EmailStr = Field(..., description="Email address to resend verification to")

--- a/apps/api/src/services/episode_service.py
+++ b/apps/api/src/services/episode_service.py
@@ -314,10 +314,54 @@ async def delete_episode(
 	Unlike projects, episodes use hard delete (no soft delete).
 	Cascade deletes related content sources.
 
+	Best-effort removes the episode's S3 audio object, its EpisodeComposition's
+	composed S3 audio object (if any), and local file artifacts (episode audio,
+	transcript, composed audio) before deleting the database row. Storage and
+	filesystem cleanup failures are logged but never block the DB delete.
+
 	Args:
 		db: Database session
 		episode: Episode instance to delete
 	"""
+	import logging
+	import os
+
+	from .storage_service import StorageService
+	from ..models.episode_composition import EpisodeComposition
+
+	logger = logging.getLogger(__name__)
+
+	composition_result = await db.execute(
+		select(EpisodeComposition).where(EpisodeComposition.episode_id == episode.id)
+	)
+	composition = composition_result.scalar_one_or_none()
+
+	s3_keys = [
+		key for key in (
+			episode.s3_key,
+			composition.composed_s3_key if composition else None,
+		) if key
+	]
+	for key in s3_keys:
+		try:
+			storage = StorageService()
+			await storage.delete_file(key)
+		except Exception:
+			logger.warning(f"Failed to delete S3 object {key} for episode {episode.id}")
+
+	local_paths = [
+		path for path in (
+			episode.file_path,
+			episode.transcript_path,
+			composition.composed_file_path if composition else None,
+		) if path
+	]
+	for path in local_paths:
+		try:
+			os.remove(path)
+		except OSError:
+			logger.warning(f"Failed to remove local file {path} for episode {episode.id}")
+
 	await db.delete(episode)
 	await db.commit()
 

--- a/apps/api/src/services/episode_service.py
+++ b/apps/api/src/services/episode_service.py
@@ -5,6 +5,9 @@ Provides CRUD operations for episodes with project validation, pagination,
 status filtering, and generation status management. RLS ensures tenant isolation.
 """
 
+import logging
+import os
+
 from datetime import datetime
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, cast, or_
@@ -15,7 +18,11 @@ from typing import Optional, List
 from fastapi import HTTPException, status
 
 from ..models import Episode, Project
+from ..models.episode_composition import EpisodeComposition
 from ..schemas.episode import EpisodeCreate, EpisodeUpdate, BatchEpisodeCreate
+from .storage_service import StorageService
+
+logger = logging.getLogger(__name__)
 
 # Valid sort fields and orders for episode listing
 VALID_SORT_FIELDS = {"episode_number", "created_at", "duration_seconds"}
@@ -323,14 +330,6 @@ async def delete_episode(
 		db: Database session
 		episode: Episode instance to delete
 	"""
-	import logging
-	import os
-
-	from .storage_service import StorageService
-	from ..models.episode_composition import EpisodeComposition
-
-	logger = logging.getLogger(__name__)
-
 	composition_result = await db.execute(
 		select(EpisodeComposition).where(EpisodeComposition.episode_id == episode.id)
 	)
@@ -342,12 +341,13 @@ async def delete_episode(
 			composition.composed_s3_key if composition else None,
 		) if key
 	]
-	for key in s3_keys:
-		try:
-			storage = StorageService()
-			await storage.delete_file(key)
-		except Exception:
-			logger.warning(f"Failed to delete S3 object {key} for episode {episode.id}")
+	if s3_keys:
+		storage = StorageService()
+		for key in s3_keys:
+			try:
+				await storage.delete_file(key)
+			except Exception:
+				logger.warning(f"Failed to delete S3 object {key} for episode {episode.id}")
 
 	local_paths = [
 		path for path in (

--- a/apps/api/src/services/offboarding_service.py
+++ b/apps/api/src/services/offboarding_service.py
@@ -1,0 +1,111 @@
+"""Tenant offboarding service — GDPR-style account erasure (issue #308)."""
+
+import logging
+import os
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.audio_snippet import AudioSnippet
+from ..models.billing_subscription import BillingSubscription
+from ..models.billing_usage import BillingUsage
+from ..models.content_source import ContentSource
+from ..models.episode import Episode
+from ..models.episode_composition import EpisodeComposition
+from ..models.project import Project
+from ..models.rss_feed import RSSFeed
+from ..models.user import User
+from .storage_service import StorageService
+
+logger = logging.getLogger(__name__)
+
+
+async def erase_user(db: AsyncSession, user: User) -> dict:
+	"""
+	Permanently erase a user's account: Postgres rows, S3 audio objects, and
+	local file artifacts (GDPR-style tenant offboarding / right to erasure).
+
+	Collects S3 keys and local paths from the user's episodes, episode
+	compositions, audio snippets, RSS feeds, and content sources, then
+	best-effort deletes each — failures are logged but never block erasure.
+	BillingSubscription/BillingUsage rows have no FK to users and are deleted
+	explicitly; every other tenant row cascades via `ON DELETE CASCADE` once
+	the user row itself is deleted.
+
+	Args:
+		db: Database session (tenant context must already be armed for this user)
+		user: User instance to erase
+
+	Returns:
+		Summary dict with counts of S3 objects and local files erased
+	"""
+	projects_result = await db.execute(select(Project.id).where(Project.user_id == user.id))
+	project_ids = [row[0] for row in projects_result.all()]
+
+	episodes_result = await db.execute(select(Episode).where(Episode.user_id == user.id))
+	episodes = episodes_result.scalars().all()
+	episode_ids = [episode.id for episode in episodes]
+
+	compositions = []
+	content_sources = []
+	if episode_ids:
+		compositions_result = await db.execute(
+			select(EpisodeComposition).where(EpisodeComposition.episode_id.in_(episode_ids))
+		)
+		compositions = compositions_result.scalars().all()
+
+		content_sources_result = await db.execute(
+			select(ContentSource).where(ContentSource.episode_id.in_(episode_ids))
+		)
+		content_sources = content_sources_result.scalars().all()
+
+	snippets_result = await db.execute(select(AudioSnippet).where(AudioSnippet.user_id == user.id))
+	snippets = snippets_result.scalars().all()
+
+	rss_feeds = []
+	if project_ids:
+		rss_feeds_result = await db.execute(select(RSSFeed).where(RSSFeed.project_id.in_(project_ids)))
+		rss_feeds = rss_feeds_result.scalars().all()
+
+	s3_keys = []
+	s3_keys.extend(episode.s3_key for episode in episodes if episode.s3_key)
+	s3_keys.extend(composition.composed_s3_key for composition in compositions if composition.composed_s3_key)
+	s3_keys.extend(snippet.s3_key for snippet in snippets if snippet.s3_key)
+	s3_keys.extend(rss_feed.s3_key for rss_feed in rss_feeds if rss_feed.s3_key)
+	for source in content_sources:
+		key = (source.source_data or {}).get("s3_key")
+		if key:
+			s3_keys.append(key)
+
+	local_paths = []
+	local_paths.extend(episode.file_path for episode in episodes if episode.file_path)
+	local_paths.extend(episode.transcript_path for episode in episodes if episode.transcript_path)
+	local_paths.extend(
+		composition.composed_file_path for composition in compositions if composition.composed_file_path
+	)
+	local_paths.extend(snippet.file_path for snippet in snippets if snippet.file_path)
+
+	for key in s3_keys:
+		try:
+			storage = StorageService()
+			await storage.delete_file(key)
+		except Exception:
+			logger.warning(f"Failed to delete S3 object {key} for user {user.id}")
+
+	for path in local_paths:
+		try:
+			os.remove(path)
+		except OSError:
+			logger.warning(f"Failed to remove local file {path} for user {user.id}")
+
+	# Billing rows have no FK to users, so DB cascade won't reach them.
+	await db.execute(delete(BillingSubscription).where(BillingSubscription.user_id == user.id))
+	await db.execute(delete(BillingUsage).where(BillingUsage.user_id == user.id))
+
+	await db.delete(user)
+	await db.commit()
+
+	return {
+		"s3_objects_deleted": len(s3_keys),
+		"local_files_deleted": len(local_paths),
+	}

--- a/apps/api/src/services/offboarding_service.py
+++ b/apps/api/src/services/offboarding_service.py
@@ -3,7 +3,8 @@
 import logging
 import os
 
-from sqlalchemy import delete, select
+from fastapi import HTTPException, status
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models.audio_snippet import AudioSnippet
@@ -18,6 +19,11 @@ from ..models.user import User
 from .storage_service import StorageService
 
 logger = logging.getLogger(__name__)
+
+# Generation-pipeline states during which erasure is refused: a Celery chain is
+# still running and would re-upload audio to S3 after we deleted it, recreating
+# the orphaned-object problem this service exists to fix (issue #308).
+ACTIVE_GENERATION_STATUSES = {"queued", "generating", "composing", "uploading", "distributing"}
 
 
 async def erase_user(db: AsyncSession, user: User) -> dict:
@@ -38,7 +44,27 @@ async def erase_user(db: AsyncSession, user: User) -> dict:
 
 	Returns:
 		Summary dict with counts of S3 objects and local files erased
+
+	Raises:
+		HTTPException: 409 if any of the user's episodes is still generating
 	"""
+	active_count = await db.scalar(
+		select(func.count())
+		.select_from(Episode)
+		.where(
+			Episode.user_id == user.id,
+			Episode.generation_status.in_(ACTIVE_GENERATION_STATUSES),
+		)
+	)
+	if active_count:
+		raise HTTPException(
+			status_code=status.HTTP_409_CONFLICT,
+			detail=(
+				f"{active_count} episode(s) are still generating; "
+				"wait for them to finish (or fail) before deleting the account"
+			),
+		)
+
 	projects_result = await db.execute(select(Project.id).where(Project.user_id == user.id))
 	project_ids = [row[0] for row in projects_result.all()]
 
@@ -85,28 +111,47 @@ async def erase_user(db: AsyncSession, user: User) -> dict:
 	)
 	local_paths.extend(snippet.file_path for snippet in snippets if snippet.file_path)
 
+	failed_keys = []
 	if s3_keys:
 		storage = StorageService()
 		for key in s3_keys:
 			try:
 				await storage.delete_file(key)
 			except Exception:
+				failed_keys.append(key)
 				logger.warning(f"Failed to delete S3 object {key} for user {user.id}")
 
+	failed_paths = []
 	for path in local_paths:
 		try:
 			os.remove(path)
 		except OSError:
+			failed_paths.append(path)
 			logger.warning(f"Failed to remove local file {path} for user {user.id}")
 
 	# Billing rows have no FK to users, so DB cascade won't reach them.
 	await db.execute(delete(BillingSubscription).where(BillingSubscription.user_id == user.id))
 	await db.execute(delete(BillingUsage).where(BillingUsage.user_id == user.id))
 
-	await db.delete(user)
+	# Core DELETE (not ORM db.delete) so the ORM doesn't load and walk the full
+	# relationship graph — Postgres ON DELETE CASCADE removes the child rows.
+	await db.execute(delete(User).where(User.id == user.id))
+
+	# Audit record of the erasure, emitted before commit — after commit the user
+	# row is gone and this log line is the only durable trace of what happened.
+	logger.info(
+		"account erasure: user=%s tenant=%s s3_deleted=%d s3_failed=%s "
+		"local_deleted=%d local_failed=%s",
+		user.id,
+		user.tenant_id,
+		len(s3_keys) - len(failed_keys),
+		failed_keys or "none",
+		len(local_paths) - len(failed_paths),
+		failed_paths or "none",
+	)
 	await db.commit()
 
 	return {
-		"s3_objects_deleted": len(s3_keys),
-		"local_files_deleted": len(local_paths),
+		"s3_objects_deleted": len(s3_keys) - len(failed_keys),
+		"local_files_deleted": len(local_paths) - len(failed_paths),
 	}

--- a/apps/api/src/services/offboarding_service.py
+++ b/apps/api/src/services/offboarding_service.py
@@ -8,8 +8,6 @@ from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models.audio_snippet import AudioSnippet
-from ..models.billing_subscription import BillingSubscription
-from ..models.billing_usage import BillingUsage
 from ..models.content_source import ContentSource
 from ..models.episode import Episode
 from ..models.episode_composition import EpisodeComposition
@@ -34,9 +32,8 @@ async def erase_user(db: AsyncSession, user: User) -> dict:
 	Collects S3 keys and local paths from the user's episodes, episode
 	compositions, audio snippets, RSS feeds, and content sources, then
 	best-effort deletes each — failures are logged but never block erasure.
-	BillingSubscription/BillingUsage rows have no FK to users and are deleted
-	explicitly; every other tenant row cascades via `ON DELETE CASCADE` once
-	the user row itself is deleted.
+	Every tenant row (billing rows included — see migration 010) cascades via
+	`ON DELETE CASCADE` once the user row itself is deleted.
 
 	Args:
 		db: Database session (tenant context must already be armed for this user)
@@ -129,12 +126,10 @@ async def erase_user(db: AsyncSession, user: User) -> dict:
 			failed_paths.append(path)
 			logger.warning(f"Failed to remove local file {path} for user {user.id}")
 
-	# Billing rows have no FK to users, so DB cascade won't reach them.
-	await db.execute(delete(BillingSubscription).where(BillingSubscription.user_id == user.id))
-	await db.execute(delete(BillingUsage).where(BillingUsage.user_id == user.id))
-
 	# Core DELETE (not ORM db.delete) so the ORM doesn't load and walk the full
 	# relationship graph — Postgres ON DELETE CASCADE removes the child rows.
+	# That includes billing_subscriptions/billing_usage: their ORM models omit
+	# the FK, but migration 010 created user_id FKs with ON DELETE CASCADE.
 	await db.execute(delete(User).where(User.id == user.id))
 
 	# Audit record of the erasure, emitted before commit — after commit the user

--- a/apps/api/src/services/offboarding_service.py
+++ b/apps/api/src/services/offboarding_service.py
@@ -85,12 +85,13 @@ async def erase_user(db: AsyncSession, user: User) -> dict:
 	)
 	local_paths.extend(snippet.file_path for snippet in snippets if snippet.file_path)
 
-	for key in s3_keys:
-		try:
-			storage = StorageService()
-			await storage.delete_file(key)
-		except Exception:
-			logger.warning(f"Failed to delete S3 object {key} for user {user.id}")
+	if s3_keys:
+		storage = StorageService()
+		for key in s3_keys:
+			try:
+				await storage.delete_file(key)
+			except Exception:
+				logger.warning(f"Failed to delete S3 object {key} for user {user.id}")
 
 	for path in local_paths:
 		try:

--- a/apps/api/tests/test_episodes.py
+++ b/apps/api/tests/test_episodes.py
@@ -358,6 +358,152 @@ async def test_delete_nonexistent_episode(client, project_and_auth):
 	assert response.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_delete_episode_with_s3_key_calls_storage_delete(
+	client, project_and_auth, set_system_fields
+):
+	"""Deleting an episode with an s3_key removes the S3 object (#308)."""
+	from unittest.mock import AsyncMock, patch
+
+	project_id, headers = project_and_auth
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "S3 Episode", "description": "Desc"}
+	})
+	episode_id = create_response.json()["id"]
+	await set_system_fields(episode_id, s3_key="podcasts/episode.mp3")
+
+	with patch("src.services.storage_service.StorageService") as MockStorage:
+		mock_instance = MockStorage.return_value
+		mock_instance.delete_file = AsyncMock()
+		response = await client.delete(f"/episodes/{episode_id}", headers=headers)
+
+	assert response.status_code == 204
+	mock_instance.delete_file.assert_called_once_with("podcasts/episode.mp3")
+
+
+@pytest.mark.asyncio
+async def test_delete_episode_without_s3_key_skips_storage_delete(
+	client, project_and_auth
+):
+	"""Deleting an episode with no s3_key makes no S3 call (#308)."""
+	from unittest.mock import AsyncMock, patch
+
+	project_id, headers = project_and_auth
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "No S3 Episode", "description": "Desc"}
+	})
+	episode_id = create_response.json()["id"]
+
+	with patch("src.services.storage_service.StorageService") as MockStorage:
+		mock_instance = MockStorage.return_value
+		mock_instance.delete_file = AsyncMock()
+		response = await client.delete(f"/episodes/{episode_id}", headers=headers)
+
+	assert response.status_code == 204
+	mock_instance.delete_file.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_episode_s3_failure_does_not_block_delete(
+	client, project_and_auth, set_system_fields
+):
+	"""An S3 delete failure is best-effort: the episode row is still removed (#308)."""
+	from unittest.mock import AsyncMock, patch
+
+	project_id, headers = project_and_auth
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "Flaky S3 Episode", "description": "Desc"}
+	})
+	episode_id = create_response.json()["id"]
+	await set_system_fields(episode_id, s3_key="podcasts/episode.mp3")
+
+	with patch("src.services.storage_service.StorageService") as MockStorage:
+		mock_instance = MockStorage.return_value
+		mock_instance.delete_file = AsyncMock(side_effect=Exception("S3 unavailable"))
+		response = await client.delete(f"/episodes/{episode_id}", headers=headers)
+
+	assert response.status_code == 204
+
+	get_response = await client.get(f"/episodes/{episode_id}", headers=headers)
+	assert get_response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_episode_removes_local_files(
+	client, project_and_auth, set_system_fields, tmp_path
+):
+	"""Deleting an episode removes its local audio and transcript files (#308)."""
+	import os
+
+	project_id, headers = project_and_auth
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "Local Files Episode", "description": "Desc"}
+	})
+	episode_id = create_response.json()["id"]
+
+	audio_path = tmp_path / "episode-local.mp3"
+	audio_path.write_bytes(b"AUDIO")
+	transcript_path = tmp_path / "episode-transcript.txt"
+	transcript_path.write_text("transcript")
+
+	await set_system_fields(
+		episode_id,
+		file_path=str(audio_path),
+		transcript_path=str(transcript_path),
+	)
+
+	response = await client.delete(f"/episodes/{episode_id}", headers=headers)
+	assert response.status_code == 204
+
+	assert not os.path.exists(audio_path)
+	assert not os.path.exists(transcript_path)
+
+
+@pytest.mark.asyncio
+async def test_delete_episode_also_deletes_composition_s3_key(
+	client, project_and_auth, test_db
+):
+	"""Deleting an episode also deletes its EpisodeComposition's S3 audio (#308)."""
+	from unittest.mock import AsyncMock, patch
+	from src.models.episode_composition import EpisodeComposition
+	from src.services.auth_service import verify_jwt_token
+
+	project_id, headers = project_and_auth
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "Composed Episode", "description": "Desc"}
+	})
+	episode_id = create_response.json()["id"]
+
+	token = headers["Authorization"].split(" ")[1]
+	claims = verify_jwt_token(token)
+
+	test_db.add(EpisodeComposition(
+		episode_id=episode_id,
+		tenant_id=claims["tenant_id"],
+		timeline=[],
+		composed_s3_key="compositions/final.mp3",
+	))
+	await test_db.flush()
+
+	with patch("src.services.storage_service.StorageService") as MockStorage:
+		mock_instance = MockStorage.return_value
+		mock_instance.delete_file = AsyncMock()
+		response = await client.delete(f"/episodes/{episode_id}", headers=headers)
+
+	assert response.status_code == 204
+	mock_instance.delete_file.assert_called_once_with("compositions/final.mp3")
+
+
 # ============================================================================
 # PROJECT RELATIONSHIP TESTS
 # ============================================================================

--- a/apps/api/tests/test_episodes.py
+++ b/apps/api/tests/test_episodes.py
@@ -374,7 +374,7 @@ async def test_delete_episode_with_s3_key_calls_storage_delete(
 	episode_id = create_response.json()["id"]
 	await set_system_fields(episode_id, s3_key="podcasts/episode.mp3")
 
-	with patch("src.services.storage_service.StorageService") as MockStorage:
+	with patch("src.services.episode_service.StorageService") as MockStorage:
 		mock_instance = MockStorage.return_value
 		mock_instance.delete_file = AsyncMock()
 		response = await client.delete(f"/episodes/{episode_id}", headers=headers)
@@ -398,7 +398,7 @@ async def test_delete_episode_without_s3_key_skips_storage_delete(
 	})
 	episode_id = create_response.json()["id"]
 
-	with patch("src.services.storage_service.StorageService") as MockStorage:
+	with patch("src.services.episode_service.StorageService") as MockStorage:
 		mock_instance = MockStorage.return_value
 		mock_instance.delete_file = AsyncMock()
 		response = await client.delete(f"/episodes/{episode_id}", headers=headers)
@@ -423,7 +423,7 @@ async def test_delete_episode_s3_failure_does_not_block_delete(
 	episode_id = create_response.json()["id"]
 	await set_system_fields(episode_id, s3_key="podcasts/episode.mp3")
 
-	with patch("src.services.storage_service.StorageService") as MockStorage:
+	with patch("src.services.episode_service.StorageService") as MockStorage:
 		mock_instance = MockStorage.return_value
 		mock_instance.delete_file = AsyncMock(side_effect=Exception("S3 unavailable"))
 		response = await client.delete(f"/episodes/{episode_id}", headers=headers)
@@ -495,7 +495,7 @@ async def test_delete_episode_also_deletes_composition_s3_key(
 	))
 	await test_db.flush()
 
-	with patch("src.services.storage_service.StorageService") as MockStorage:
+	with patch("src.services.episode_service.StorageService") as MockStorage:
 		mock_instance = MockStorage.return_value
 		mock_instance.delete_file = AsyncMock()
 		response = await client.delete(f"/episodes/{episode_id}", headers=headers)

--- a/apps/api/tests/test_offboarding.py
+++ b/apps/api/tests/test_offboarding.py
@@ -1,0 +1,250 @@
+"""
+Tests for tenant offboarding / GDPR erasure (issue #308).
+
+DELETE /auth/me permanently erases the authenticated user's account: every
+Postgres row tied to the user (directly or via cascade), all S3 audio
+objects, and local file artifacts.
+"""
+
+import pytest
+from datetime import date
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from sqlalchemy import select
+
+from src.models.user import User
+from src.models.billing_subscription import BillingSubscription
+from src.models.billing_usage import BillingUsage
+from src.models.project import Project
+from src.models.episode import Episode
+from src.models.episode_composition import EpisodeComposition
+from src.models.audio_snippet import AudioSnippet
+from src.models.rss_feed import RSSFeed
+from src.models.content_source import ContentSource
+from src.services.auth_service import verify_jwt_token
+
+
+@pytest.fixture
+async def seeded_user(client, test_db):
+	"""Register a user and seed one of every kind of tenant-owned row that
+	the offboarding routine must account for: a project, an episode (with
+	s3_key + local file/transcript paths), an episode composition (with
+	composed_s3_key + composed_file_path), an audio snippet (with s3_key), an
+	RSS feed (with s3_key), a content source (with a JSONB s3_key), and
+	billing subscription/usage rows (no FK to users).
+
+	Returns a dict of everything a test needs to make assertions.
+	"""
+	reg_response = await client.post("/auth/register", json={
+		"email": f"offboard_{uuid4()}@example.com",
+		"password": "SecurePass123!",
+		"full_name": "Offboard Me",
+	})
+	assert reg_response.status_code == 201
+	token = reg_response.json()["access_token"]
+	headers = {"Authorization": f"Bearer {token}"}
+	claims = verify_jwt_token(token)
+	user_id = claims["sub"]
+	tenant_id = claims["tenant_id"]
+
+	test_db.add(BillingSubscription(user_id=user_id, tenant_id=tenant_id, tier="enterprise"))
+	test_db.add(BillingUsage(
+		user_id=user_id,
+		tenant_id=tenant_id,
+		period_start=date(2026, 1, 1),
+		period_end=date(2026, 1, 31),
+	))
+	await test_db.flush()
+
+	proj_response = await client.post("/projects", headers=headers, json={
+		"name": "Offboarding Project",
+		"podcast_metadata": {
+			"show_title": "Test Show",
+			"author": "Test Author",
+			"description": "Test Description",
+		},
+	})
+	assert proj_response.status_code == 201
+	project_id = proj_response.json()["id"]
+
+	ep_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "Offboarding Episode", "description": "Desc"},
+	})
+	assert ep_response.status_code == 201
+	episode_id = ep_response.json()["id"]
+
+	from src.services.episode_service import get_episode_by_id, set_episode_system_fields
+	from uuid import UUID as _UUID
+
+	episode = await get_episode_by_id(test_db, _UUID(episode_id))
+	await set_episode_system_fields(test_db, episode, s3_key="episodes/audio.mp3")
+
+	test_db.add(EpisodeComposition(
+		episode_id=episode_id,
+		tenant_id=tenant_id,
+		timeline=[],
+		composed_s3_key="compositions/final.mp3",
+	))
+	test_db.add(AudioSnippet(
+		user_id=user_id,
+		project_id=project_id,
+		tenant_id=tenant_id,
+		name="Intro",
+		snippet_type="intro",
+		file_path="/tmp/intro.mp3",
+		s3_key="snippets/intro.mp3",
+	))
+	test_db.add(RSSFeed(
+		project_id=project_id,
+		tenant_id=tenant_id,
+		s3_key="feeds/project.xml",
+	))
+	test_db.add(ContentSource(
+		episode_id=episode_id,
+		tenant_id=tenant_id,
+		source_type="pdf",
+		source_data={"filename": "doc.pdf", "s3_key": "uploads/doc.pdf"},
+		extraction_status="pending",
+	))
+	await test_db.flush()
+
+	return {
+		"headers": headers,
+		"token": token,
+		"user_id": user_id,
+		"tenant_id": tenant_id,
+		"project_id": project_id,
+		"episode_id": episode_id,
+		"s3_keys": {
+			"episodes/audio.mp3",
+			"compositions/final.mp3",
+			"snippets/intro.mp3",
+			"feeds/project.xml",
+			"uploads/doc.pdf",
+		},
+	}
+
+
+@pytest.mark.asyncio
+async def test_delete_me_returns_204(seeded_user, client):
+	"""DELETE /auth/me erases the account and returns 204."""
+	with patch("src.services.offboarding_service.StorageService") as MockStorage:
+		mock_instance = MockStorage.return_value
+		mock_instance.delete_file = AsyncMock()
+		response = await client.delete("/auth/me", headers=seeded_user["headers"])
+
+	assert response.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_delete_me_deletes_one_s3_object_per_key(seeded_user, client):
+	"""Every collected S3 key gets exactly one delete_file call."""
+	with patch("src.services.offboarding_service.StorageService") as MockStorage:
+		mock_instance = MockStorage.return_value
+		mock_instance.delete_file = AsyncMock()
+		response = await client.delete("/auth/me", headers=seeded_user["headers"])
+
+	assert response.status_code == 204
+	called_keys = {call.args[0] for call in mock_instance.delete_file.call_args_list}
+	assert called_keys == seeded_user["s3_keys"]
+	assert mock_instance.delete_file.call_count == len(seeded_user["s3_keys"])
+
+
+@pytest.mark.asyncio
+async def test_delete_me_removes_user_and_cascaded_rows(seeded_user, client, test_db):
+	"""The user row and everything that cascades from it (project, episode,
+	composition, audio snippet, RSS feed, content source) are gone."""
+	with patch("src.services.offboarding_service.StorageService") as MockStorage:
+		mock_instance = MockStorage.return_value
+		mock_instance.delete_file = AsyncMock()
+		response = await client.delete("/auth/me", headers=seeded_user["headers"])
+	assert response.status_code == 204
+
+	from uuid import UUID as _UUID
+
+	user_result = await test_db.execute(
+		select(User).where(User.id == _UUID(seeded_user["user_id"]))
+	)
+	assert user_result.scalar_one_or_none() is None
+
+	project_result = await test_db.execute(
+		select(Project).where(Project.id == _UUID(seeded_user["project_id"]))
+	)
+	assert project_result.scalar_one_or_none() is None
+
+	episode_result = await test_db.execute(
+		select(Episode).where(Episode.id == _UUID(seeded_user["episode_id"]))
+	)
+	assert episode_result.scalar_one_or_none() is None
+
+	composition_result = await test_db.execute(
+		select(EpisodeComposition).where(
+			EpisodeComposition.episode_id == _UUID(seeded_user["episode_id"])
+		)
+	)
+	assert composition_result.scalar_one_or_none() is None
+
+	snippet_result = await test_db.execute(
+		select(AudioSnippet).where(AudioSnippet.user_id == _UUID(seeded_user["user_id"]))
+	)
+	assert snippet_result.scalar_one_or_none() is None
+
+	rss_result = await test_db.execute(
+		select(RSSFeed).where(RSSFeed.project_id == _UUID(seeded_user["project_id"]))
+	)
+	assert rss_result.scalar_one_or_none() is None
+
+	content_source_result = await test_db.execute(
+		select(ContentSource).where(
+			ContentSource.episode_id == _UUID(seeded_user["episode_id"])
+		)
+	)
+	assert content_source_result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_delete_me_removes_billing_rows(seeded_user, client, test_db):
+	"""BillingSubscription/BillingUsage rows have no FK to users, so the
+	offboarding routine must delete them explicitly."""
+	with patch("src.services.offboarding_service.StorageService") as MockStorage:
+		mock_instance = MockStorage.return_value
+		mock_instance.delete_file = AsyncMock()
+		response = await client.delete("/auth/me", headers=seeded_user["headers"])
+	assert response.status_code == 204
+
+	from uuid import UUID as _UUID
+
+	sub_result = await test_db.execute(
+		select(BillingSubscription).where(
+			BillingSubscription.user_id == _UUID(seeded_user["user_id"])
+		)
+	)
+	assert sub_result.scalar_one_or_none() is None
+
+	usage_result = await test_db.execute(
+		select(BillingUsage).where(BillingUsage.user_id == _UUID(seeded_user["user_id"]))
+	)
+	assert usage_result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_delete_me_invalidates_old_token(seeded_user, client):
+	"""After erasure, the user's old bearer token is rejected."""
+	with patch("src.services.offboarding_service.StorageService") as MockStorage:
+		mock_instance = MockStorage.return_value
+		mock_instance.delete_file = AsyncMock()
+		response = await client.delete("/auth/me", headers=seeded_user["headers"])
+	assert response.status_code == 204
+
+	me_response = await client.get("/auth/me", headers=seeded_user["headers"])
+	assert me_response.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_delete_me_requires_auth(client):
+	"""DELETE /auth/me without a token is rejected."""
+	response = await client.delete("/auth/me")
+	assert response.status_code == 401

--- a/apps/api/tests/test_offboarding.py
+++ b/apps/api/tests/test_offboarding.py
@@ -216,8 +216,9 @@ async def test_delete_me_removes_user_and_cascaded_rows(seeded_user, client, tes
 
 @pytest.mark.asyncio
 async def test_delete_me_removes_billing_rows(seeded_user, client, test_db):
-	"""BillingSubscription/BillingUsage rows have no FK to users, so the
-	offboarding routine must delete them explicitly."""
+	"""Billing rows are erased with the account. Their ORM models declare no FK,
+	but migration 010 gave them user_id FKs with ON DELETE CASCADE, so the DB
+	guarantees this outcome (mutation-testing the service can't break it)."""
 	from uuid import UUID as _UUID
 
 	# Guard against a vacuous test: the seeded rows must be visible up front.

--- a/apps/api/tests/test_offboarding.py
+++ b/apps/api/tests/test_offboarding.py
@@ -134,7 +134,10 @@ async def test_delete_me_returns_204(seeded_user, client):
 	with patch("src.services.offboarding_service.StorageService") as MockStorage:
 		mock_instance = MockStorage.return_value
 		mock_instance.delete_file = AsyncMock()
-		response = await client.delete("/auth/me", headers=seeded_user["headers"])
+		response = await client.request(
+			"DELETE", "/auth/me", headers=seeded_user["headers"],
+			json={"password": "SecurePass123!"},
+		)
 
 	assert response.status_code == 204
 
@@ -145,7 +148,10 @@ async def test_delete_me_deletes_one_s3_object_per_key(seeded_user, client):
 	with patch("src.services.offboarding_service.StorageService") as MockStorage:
 		mock_instance = MockStorage.return_value
 		mock_instance.delete_file = AsyncMock()
-		response = await client.delete("/auth/me", headers=seeded_user["headers"])
+		response = await client.request(
+			"DELETE", "/auth/me", headers=seeded_user["headers"],
+			json={"password": "SecurePass123!"},
+		)
 
 	assert response.status_code == 204
 	called_keys = {call.args[0] for call in mock_instance.delete_file.call_args_list}
@@ -160,7 +166,10 @@ async def test_delete_me_removes_user_and_cascaded_rows(seeded_user, client, tes
 	with patch("src.services.offboarding_service.StorageService") as MockStorage:
 		mock_instance = MockStorage.return_value
 		mock_instance.delete_file = AsyncMock()
-		response = await client.delete("/auth/me", headers=seeded_user["headers"])
+		response = await client.request(
+			"DELETE", "/auth/me", headers=seeded_user["headers"],
+			json={"password": "SecurePass123!"},
+		)
 	assert response.status_code == 204
 
 	from uuid import UUID as _UUID
@@ -209,25 +218,42 @@ async def test_delete_me_removes_user_and_cascaded_rows(seeded_user, client, tes
 async def test_delete_me_removes_billing_rows(seeded_user, client, test_db):
 	"""BillingSubscription/BillingUsage rows have no FK to users, so the
 	offboarding routine must delete them explicitly."""
+	from uuid import UUID as _UUID
+
+	# Guard against a vacuous test: the seeded rows must be visible up front.
+	# (There may be more than one usage row — the metering middleware creates
+	# them for every API call the fixture made.)
+	pre_sub = await test_db.execute(
+		select(BillingSubscription).where(
+			BillingSubscription.user_id == _UUID(seeded_user["user_id"])
+		)
+	)
+	assert pre_sub.scalars().all()
+	pre_usage = await test_db.execute(
+		select(BillingUsage).where(BillingUsage.user_id == _UUID(seeded_user["user_id"]))
+	)
+	assert pre_usage.scalars().all()
+
 	with patch("src.services.offboarding_service.StorageService") as MockStorage:
 		mock_instance = MockStorage.return_value
 		mock_instance.delete_file = AsyncMock()
-		response = await client.delete("/auth/me", headers=seeded_user["headers"])
+		response = await client.request(
+			"DELETE", "/auth/me", headers=seeded_user["headers"],
+			json={"password": "SecurePass123!"},
+		)
 	assert response.status_code == 204
-
-	from uuid import UUID as _UUID
 
 	sub_result = await test_db.execute(
 		select(BillingSubscription).where(
 			BillingSubscription.user_id == _UUID(seeded_user["user_id"])
 		)
 	)
-	assert sub_result.scalar_one_or_none() is None
+	assert sub_result.scalars().all() == []
 
 	usage_result = await test_db.execute(
 		select(BillingUsage).where(BillingUsage.user_id == _UUID(seeded_user["user_id"]))
 	)
-	assert usage_result.scalar_one_or_none() is None
+	assert usage_result.scalars().all() == []
 
 
 @pytest.mark.asyncio
@@ -236,7 +262,10 @@ async def test_delete_me_invalidates_old_token(seeded_user, client):
 	with patch("src.services.offboarding_service.StorageService") as MockStorage:
 		mock_instance = MockStorage.return_value
 		mock_instance.delete_file = AsyncMock()
-		response = await client.delete("/auth/me", headers=seeded_user["headers"])
+		response = await client.request(
+			"DELETE", "/auth/me", headers=seeded_user["headers"],
+			json={"password": "SecurePass123!"},
+		)
 	assert response.status_code == 204
 
 	me_response = await client.get("/auth/me", headers=seeded_user["headers"])
@@ -246,5 +275,73 @@ async def test_delete_me_invalidates_old_token(seeded_user, client):
 @pytest.mark.asyncio
 async def test_delete_me_requires_auth(client):
 	"""DELETE /auth/me without a token is rejected."""
-	response = await client.delete("/auth/me")
+	response = await client.request("DELETE", "/auth/me", json={"password": "SecurePass123!"})
 	assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_delete_me_wrong_password_rejected(seeded_user, client, test_db):
+	"""A wrong password confirmation is a 403 and nothing is erased."""
+	from uuid import UUID as _UUID
+
+	with patch("src.services.offboarding_service.StorageService") as MockStorage:
+		mock_instance = MockStorage.return_value
+		mock_instance.delete_file = AsyncMock()
+		response = await client.request(
+			"DELETE", "/auth/me", headers=seeded_user["headers"],
+			json={"password": "WrongPass456!"},
+		)
+
+	assert response.status_code == 403
+	mock_instance.delete_file.assert_not_called()
+	user_result = await test_db.execute(
+		select(User).where(User.id == _UUID(seeded_user["user_id"]))
+	)
+	assert user_result.scalar_one_or_none() is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_me_refused_while_episode_generating(seeded_user, client, test_db):
+	"""Erasure is refused (409) while an episode is mid-generation: the running
+	Celery chain would re-upload audio after we deleted it (orphan class #308)."""
+	from uuid import UUID as _UUID
+
+	from src.services.episode_service import get_episode_by_id, set_episode_system_fields
+
+	episode = await get_episode_by_id(test_db, _UUID(seeded_user["episode_id"]))
+	await set_episode_system_fields(test_db, episode, generation_status="generating")
+
+	with patch("src.services.offboarding_service.StorageService") as MockStorage:
+		mock_instance = MockStorage.return_value
+		mock_instance.delete_file = AsyncMock()
+		response = await client.request(
+			"DELETE", "/auth/me", headers=seeded_user["headers"],
+			json={"password": "SecurePass123!"},
+		)
+
+	assert response.status_code == 409
+	mock_instance.delete_file.assert_not_called()
+	user_result = await test_db.execute(
+		select(User).where(User.id == _UUID(seeded_user["user_id"]))
+	)
+	assert user_result.scalar_one_or_none() is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_me_s3_failure_does_not_block_erasure(seeded_user, client, test_db):
+	"""S3 cleanup is best-effort: delete_file raising never blocks the erasure."""
+	from uuid import UUID as _UUID
+
+	with patch("src.services.offboarding_service.StorageService") as MockStorage:
+		mock_instance = MockStorage.return_value
+		mock_instance.delete_file = AsyncMock(side_effect=Exception("S3 unavailable"))
+		response = await client.request(
+			"DELETE", "/auth/me", headers=seeded_user["headers"],
+			json={"password": "SecurePass123!"},
+		)
+
+	assert response.status_code == 204
+	user_result = await test_db.execute(
+		select(User).where(User.id == _UUID(seeded_user["user_id"]))
+	)
+	assert user_result.scalar_one_or_none() is None

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -312,7 +312,7 @@ dedicated IAM user (e.g. `fastapi-s3-uploader`). That user needs an identity-bas
 |---|---|
 | `s3:PutObject` | upload generated audio (incl. multipart for large/long-form files) |
 | `s3:GetObject` | download / `head_object` / presigned playback URLs |
-| `s3:DeleteObject` | remove audio when an episode is deleted |
+| `s3:DeleteObject` | remove audio when an episode or account is deleted |
 | `s3:AbortMultipartUpload` | clean up failed multipart uploads |
 
 `s3:ListBucket` is intentionally **not** granted (least privilege). `aws s3 ls` returns
@@ -353,6 +353,38 @@ one-time **administrative** action — run it from AWS CloudShell (admin identit
 ```bash
 deployment/scripts/enable-s3-versioning.sh podcaststudiohub-audio
 ```
+
+### Tenant offboarding / GDPR erasure — issue #308
+
+`DELETE /auth/me` (authenticated, self-service — the app has no admin/superuser role) permanently
+erases a user's account:
+
+- **Postgres rows**: the user row is deleted directly; every other tenant-owned row (projects,
+  episodes, episode compositions, audio snippets, RSS feeds, content sources, distribution targets,
+  templates, TTS configs, layouts, team memberships/invitations) cascades via `ON DELETE CASCADE`.
+  `billing_subscriptions` and `billing_usage` have no FK to `users`, so those rows are deleted
+  explicitly first.
+- **S3 objects**: deleted by the keys already stored on those rows (`episodes.s3_key`,
+  `episode_compositions.composed_s3_key`, `audio_snippets.s3_key`, `rss_feeds.s3_key`, and the
+  `s3_key` inside `content_sources.source_data`). This is why `s3:ListBucket` is never needed — see
+  above.
+- **Local file artifacts**: episode audio/transcript files, composed audio, and snippet audio are
+  removed from disk.
+
+Storage and filesystem cleanup are **best-effort**: a failed S3 or `os.remove` call is logged but
+never blocks the Postgres erasure, matching the same pattern single-episode delete uses (below).
+
+Single-episode `DELETE /episodes/{id}` follows the same best-effort pattern at smaller scope: it
+removes the episode's `s3_key`, its composition's `composed_s3_key`, and the episode's local
+audio/transcript files, but does not touch that episode's content-source uploads (those are only
+erased on full account deletion).
+
+**Known limitations** (disclosed, not yet addressed):
+
+- `Team` rows have no owner; erasure removes the user's own memberships/invitations but leaves team
+  shells behind.
+- Stripe-side customer data is untouched — only local billing rows are deleted. Cancelling the
+  Stripe subscription/customer is out of scope here.
 
 ## Database Backup & Restore (DR) — issue #293
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -361,9 +361,12 @@ erases a user's account:
 
 - **Postgres rows**: the user row is deleted directly; every other tenant-owned row (projects,
   episodes, episode compositions, audio snippets, RSS feeds, content sources, distribution targets,
-  templates, TTS configs, layouts, team memberships/invitations) cascades via `ON DELETE CASCADE`.
-  `billing_subscriptions` and `billing_usage` have no FK to `users`, so those rows are deleted
-  explicitly first.
+  templates, TTS configs, layouts, team memberships/invitations, and billing
+  subscription/usage rows — whose FKs exist in migration 010 even though the ORM models omit
+  them) cascades via `ON DELETE CASCADE`.
+- **Guards**: the request must re-enter the account password (step-up auth; 403 on mismatch), and
+  erasure is refused with 409 while any episode is mid-generation — the running Celery chain would
+  re-upload audio to S3 after cleanup, recreating the orphaned-object problem this issue fixed.
 - **S3 objects**: deleted by the keys already stored on those rows (`episodes.s3_key`,
   `episode_compositions.composed_s3_key`, `audio_snippets.s3_key`, `rss_feeds.s3_key`, and the
   `s3_key` inside `content_sources.source_data`). This is why `s3:ListBucket` is never needed — see

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -56,7 +56,11 @@
   - Add "Tenant offboarding / GDPR erasure" section (deployment/README.md): what
     `DELETE /auth/me` erases (Postgres rows + S3 objects + local artifacts), key-based
     deletion rationale (no ListBucket), limitations below.
-- [ ] 5. Quality gates: full pytest from apps/api (`uv run pytest tests/`), ruff, coverage ≥85;
+- [x] 5. Quality gates: full pytest 1689 passed / diff-cover 98% / ruff clean; deslop done;
+  internal review (1 Major rebutted: S3-before-commit ordering is deliberate — see #366);
+  cross-family opencode/GLM round 1 REQUEST_CHANGES → fixes (password step-up, 409
+  mid-generation guard, core user DELETE, audit log, rate limit) → round 2 APPROVE;
+  mutation checks: 4 killed, 1 infeasible (billing cascade DB-enforced, documented): full pytest from apps/api (`uv run pytest tests/`), ruff, coverage ≥85;
   deslop; internal review + cross-family (opencode/GLM) review; PR; demo; CI; merge.
 
 ## Acceptance criteria (from issue)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,60 +1,75 @@
-# #307 — COMPLETE (PR #362 squash-merged 2026-07-10, issue closed)
+# #308 — Episode delete orphans S3 audio; no tenant-offboarding / GDPR erasure path
 
-**Plan source**: self-authored (no plan comment on issue), verified against code 2026-07-09.
-**Branch**: `fix/307-csp-nonce-and-build-gates`
+**Plan source**: self-authored (no plan comment on issue), derived from code exploration 2026-07-09.
+**Branch**: `feature/issue-308-episode-delete-s3-erasure`
 
-## Why this shape
+## Design decisions (made autonomously — no architectural fork)
 
-nginx cannot mint per-request nonces (no native module on the VPS), so the CSP for
-HTML documents moves to Next.js middleware — the official Next 15 pattern
-(nonce + `'strict-dynamic'`, `'unsafe-eval'` in dev only). nginx keeps every other
-security header; its `/static/` block keeps a CSP with `script-src 'self'` (no
-unsafe-inline). Hash-based CSP is unworkable: Next's hydration payload changes
-every request.
-
-**Gotcha that forced a middleware rewrite**: next-auth v4 `withAuth` early-returns
-for the signIn page (`/login`), `/api/auth/*` and `/_next` — wrapped middleware
-never runs there, so the login page would get **no CSP**. Replace `withAuth` with a
-plain middleware: nonce-CSP for all matched pages + auth gate via `getToken`
-(what withAuth uses internally) with the same `/login?callbackUrl=` redirect.
+1. **Erasure entry point = self-service `DELETE /auth/me`** (204, `Depends(get_current_user)`).
+   The system has no admin/superuser role (`User` has only `is_active`/`is_verified`), so an
+   admin-only endpoint isn't possible; user-initiated deletion is the standard GDPR
+   right-to-erasure shape and matches existing hard-delete endpoints.
+2. **S3 deletion is key-based, not prefix-listing.** IAM intentionally does NOT grant
+   `s3:ListBucket` (deployment/README.md:318). Every S3 object has its key stored in a DB row
+   (`episodes.s3_key`, `episode_compositions.composed_s3_key`, `audio_snippets.s3_key`,
+   `rss_feeds.s3_key`, content-source `source_data['s3_key']`), so we collect keys from rows
+   before deleting them. No new StorageService list/bulk API needed — iterate `delete_file`
+   (S3 `delete_object` is already idempotent on missing keys).
+3. **S3/local cleanup is best-effort** (log warning, never block the DB delete) — copies the
+   existing `delete_audio_snippet` pattern (audio_snippet_service.py:286-318).
+4. **Wrap sync `delete_file` in `asyncio.to_thread`** at async call sites (matches how
+   `upload_file`/`download_file` are handled; existing `delete_file` call is bare — leave that).
+5. **Tests fake StorageService with unittest.mock patches** — the repo's established S3 test
+   convention (tests/unit/test_storage_service.py, test_episodes.py:1691).
 
 ## Steps (TDD)
 
-- [x] 1. Branch off main.
-- [x] 2. RED — extend `apps/web/__tests__/middleware.test.ts`:
-  - existing auth tests keep passing unchanged (redirect w/ callbackUrl; authed pass-through)
-  - CSP response header present on protected AND public (`/login`) routes
-  - `script-src` contains a base64 nonce + `'strict-dynamic'`, NOT `'unsafe-inline'`
-  - `style-src` keeps `'unsafe-inline'` (Radix/shadcn inline style attrs)
-  - media-src/connect-src keep both S3 hosts (episode audio streaming/download)
-  - nonce differs across requests; `x-nonce` request header forwarded
-- [x] 3. RED — update `deployment/tests/test_nginx_config.py`:
-  - server block no longer sets CSP (moved to app); other headers still asserted
-  - `/static/` CSP has no `'unsafe-inline'` in script-src
-  - drop/replace `test_csp_allows_s3_audio` (S3 allowance asserted in jest now)
-- [x] 4. GREEN — rewrite `apps/web/src/middleware.ts` (plain middleware, matcher
-  `/((?!api|_next/static|_next/image|favicon.ico).*)` — no prefetch `missing`
-  exclusions, preserving #222 auth-on-prefetch behavior).
-- [x] 5. GREEN — `apps/web/src/app/layout.tsx`: async, read `x-nonce` via
-  `headers()`, pass `nonce` to the theme-flash inline script.
-- [x] 6. GREEN — `deployment/nginx/podcastfy.conf`: remove server-level CSP
-  add_header (comment: owned by Next middleware); `/static/` CSP drops
-  unsafe-inline from script-src.
-- [x] 7. `apps/web/next.config.mjs`: delete `eslint.ignoreDuringBuilds` +
-  `typescript.ignoreBuildErrors` (lint + typecheck verified green locally; CI
-  gates already blocking; server-side rebuild in deploy-dev.yml now also gated).
-- [x] 8. Verify: jest w/ coverage (≥80 gate), deployment pytest, `next build`
-  (flags removed → build runs lint+types), lint, typecheck.
-- [x] 9. Deslop scan; quality gate incl. opencode (GLM) review pre-PR.
-- [x] 10. PR; demo: `next start` + curl -I → CSP header w/ nonce, no
-  unsafe-inline in script-src; browser loads login/dashboard with zero CSP
-  violations; build fails when a type error is injected (gate proof, reverted).
-- [x] 11. Post-PR opencode review comment; CI green; docs sync; merge.
+- [x] 1. Branch off main: `feature/issue-308-episode-delete-s3-erasure`.
+- [x] 2. **Episode delete cleanup** — `apps/api/src/services/episode_service.py:delete_episode`:
+  - RED: tests in `tests/test_episodes.py`: (a) delete of episode with `s3_key` calls
+    `StorageService.delete_file(s3_key)`; (b) no `s3_key` → no S3 call; (c) S3 delete raising
+    still deletes the DB row (204); (d) local `file_path`/`transcript_path` files removed
+    (tmp_path fixture); (e) composition `composed_s3_key` also deleted.
+  - GREEN: collect episode.s3_key + its EpisodeComposition.composed_s3_key; best-effort
+    delete S3 objects (`asyncio.to_thread(storage.delete_file, key)`, try/except → log
+    warning); best-effort `os.remove` of `file_path`, `transcript_path`,
+    `composed_file_path`; then `db.delete(episode)` + commit.
+- [x] 3. **Tenant offboarding** — new `apps/api/src/services/offboarding_service.py` +
+  `DELETE /auth/me` in `src/routers/auth.py`:
+  - RED: new `tests/test_offboarding.py`: register user via `/auth/register`, seed
+    project/episode (with s3_key, composition) /audio_snippet/rss_feed rows; patch
+    StorageService; `DELETE /auth/me` → 204; `delete_file` called once per collected key;
+    user + cascaded rows + billing rows gone; the old token now 401/403 on `/auth/me`.
+  - GREEN: `erase_user(db, user)`: collect S3 keys from episodes, compositions, snippets,
+    rss feeds, content-source `source_data['s3_key']`; collect local paths; best-effort
+    delete S3 + local files; explicitly delete `BillingSubscription`/`BillingUsage` by
+    `user_id` (no FK — DB cascade won't reach them); `db.delete(user)` (FK CASCADE removes
+    projects → episodes → content_sources/compositions, snippets, rss_feeds, distribution
+    targets, templates, tts configs, layouts, team memberships/invitations); commit; return
+    summary counts. Router endpoint is a thin wrapper.
+  - RLS note: runs as the requesting user with tenant context armed, so RLS permits deleting
+    own-tenant rows. If the `users` RLS policy blocks self-delete, stop and report (don't
+    improvise a bypass).
+- [x] 4. **Docs reconcile**:
+  - `deployment/README.md:315`: `s3:DeleteObject` rationale → "remove audio when an episode
+    or account is deleted" (now true).
+  - Add "Tenant offboarding / GDPR erasure" section (deployment/README.md): what
+    `DELETE /auth/me` erases (Postgres rows + S3 objects + local artifacts), key-based
+    deletion rationale (no ListBucket), limitations below.
+- [ ] 5. Quality gates: full pytest from apps/api (`uv run pytest tests/`), ruff, coverage ≥85;
+  deslop; internal review + cross-family (opencode/GLM) review; PR; demo; CI; merge.
 
-## Risks
+## Acceptance criteria (from issue)
 
-- Nonce CSP forces dynamic rendering of all pages — fine for an authed SaaS
-  behind PM2 (`next start`); Playwright E2E runs prod mode, so a broken CSP
-  fails E2E loudly.
-- style-src keeps unsafe-inline deliberately (inline `style=` attrs everywhere
-  in Radix); issue AC only requires script-src.
+- [x] `StorageService.delete_file(episode.s3_key)` called on episode delete (idempotent on
+  missing) and local file artifacts removed.
+- [x] Documented tenant-offboarding routine erasing Postgres rows + all S3 audio for a user.
+- [x] deployment/README.md reconciled with actual behaviour.
+
+## Known limitations (disclose in PR)
+
+- `Team` rows have no owner; erasure removes the user's memberships/invitations but leaves
+  team shells.
+- Stripe-side customer data is not touched (only local billing rows) — out of scope here.
+- Content-source uploads are deleted on account erasure but not on single-episode delete
+  (episode delete scope per AC = episode audio + local artifacts + composition audio).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,4 +1,4 @@
-# #308 — Episode delete orphans S3 audio; no tenant-offboarding / GDPR erasure path
+# #308 — SHIPPED via PR #367 (all gates passed: tests, diff-cover 98%, cross-family APPROVE, bot review clean, demo verified, CI green)
 
 **Plan source**: self-authored (no plan comment on issue), derived from code exploration 2026-07-09.
 **Branch**: `feature/issue-308-episode-delete-s3-erasure`


### PR DESCRIPTION
## Summary
Implements #308: episode delete previously removed only the DB row, orphaning the S3 object at `episode.s3_key` forever; there was also no tenant-offboarding / GDPR erasure path.

- `delete_episode` now best-effort deletes the episode's S3 object, its composition's composed S3 object, and local artifacts (`file_path`, `transcript_path`, `composed_file_path`) before the DB delete — S3/filesystem failures are logged and never block the delete (same pattern as `delete_audio_snippet`).
- New `DELETE /auth/me` (self-service — the app has no admin role) erases the account: user row via core DELETE (Postgres `ON DELETE CASCADE` removes all tenant rows, billing included — migration 010 FKs), all S3 objects by their stored keys (no `s3:ListBucket` needed by design), and local artifacts. Guards: password re-entry in the body (403 on mismatch), 409 while any episode is mid-generation, login-tier rate limit, structured audit log line before commit.
- `deployment/README.md` reconciled: `s3:DeleteObject` rationale now true, new offboarding section documents exactly what is erased and why.

## Acceptance Criteria
- [x] `StorageService.delete_file(episode.s3_key)` called on episode delete (idempotent on missing) + local artifacts removed
- [x] Documented tenant-offboarding routine erasing Postgres rows + all S3 audio for a user
- [x] README reconciled with actual behaviour

## Test Plan
- [x] TDD: red tests committed before each implementation step
- [x] Full suite: 1689 passed, 7 skipped (pre-existing env skips)
- [x] Diff coverage 98% on changed lines (gate 85)
- [x] ruff clean
- [x] Internal review (advisory) completed — 1 Major rebutted (see notes)
- [x] Cross-family review: opencode/GLM — round 1 REQUEST_CHANGES → fixes applied → round 2 **APPROVE**
- [x] Mutation sanity: 4 mutations killed by tests; 1 infeasible (billing-row erasure is DB-cascade-enforced; documented in the test docstring)

## Known Limitations / Intentionally Deferred
- **Storage-vs-commit race windows** → #366: S3 cleanup runs before the DB commit (deliberate: commit failure leaves rows whose keys make retry possible; the inverse order would orphan objects permanently since IAM has no `s3:ListBucket`). A deletion outbox + GC will close both this and the in-flight-generation TOCTOU.
- **Episode delete has no mid-generation 409 guard** (account erasure does) — deleting a stuck episode is currently the only way to abort generation; noted on #366.
- **Team shells**: teams have no owner column; erasure removes the user's memberships/invitations but leaves team rows.
- **Stripe-side data untouched** — only local billing rows are erased.
- **Content-source uploads** are erased on account deletion but not on single-episode delete (per AC scope).

## Implementation Notes
- Plan was self-authored (issue had no plan comment); persisted in `tasks/todo.md`.
- The plan's `asyncio.to_thread` instruction for `delete_file` was wrong (it's already `async def`) — implementation follows the existing awaited-call convention.
- Both explorers/reviewers initially believed billing tables have no FK to `users`; mutation testing exposed that migration 010 created `ON DELETE CASCADE` FKs the ORM models omit. Redundant explicit deletes were removed and docs corrected.

Closes #308