### PR TITLE
Fix fabricated transcript_path and clean up engine audio/transcript artifacts (#309)

### DIFF
--- a/apps/api/alembic/versions/015_null_fabricated_transcript_paths.py
+++ b/apps/api/alembic/versions/015_null_fabricated_transcript_paths.py
@@ -1,0 +1,37 @@
+"""NULL out fabricated episode transcript_path values
+
+Revision ID: 015
+Revises: 014
+Create Date: 2026-07-10 00:00:00.000000
+
+The generation task used to derive transcript_path by string-substituting the
+audio path (audio.mp3 -> audio_transcript.txt), a file podcastfy never wrote —
+so every generated episode's transcript_path pointed at a non-existent file
+(#309). New code persists NULL; this backfills existing rows. Real transcripts
+written by the script-generation service are named "<episode_id>.xml" and are
+untouched by the LIKE pattern.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers
+revision: str = "015"
+down_revision: Union[str, None] = "014"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+	op.execute(
+		r"""
+		UPDATE episodes
+		SET transcript_path = NULL
+		WHERE transcript_path LIKE '%\_transcript.txt'
+		"""
+	)
+
+
+def downgrade() -> None:
+	# Data-only cleanup of values that were always dangling; nothing to restore.
+	pass

--- a/apps/api/src/tasks/callbacks.py
+++ b/apps/api/src/tasks/callbacks.py
@@ -14,6 +14,7 @@ from sqlalchemy import select
 
 from src.database import SyncSessionLocal
 from src.models.episode import Episode
+from src.tasks.s3_upload import _cleanup_temp_file
 from src.worker import celery_app
 
 logger = logging.getLogger(__name__)
@@ -143,27 +144,47 @@ def on_composition_complete(self: Task, result: Dict[str, Any], episode_id: str)
 		)
 		return
 
-	updated = _update_episode(
-		episode_id,
-		updates={
-			"file_path": result.get("output_path"),
+	composed_path = result.get("output_path")
+	old_file_path: Optional[str] = None
+	try:
+		with SyncSessionLocal() as db:
+			episode = _get_episode_for_update(db, episode_id)
+			if episode is None:
+				logger.error("Episode %s not found in database", episode_id)
+				return
+
+			# Capture the pre-composition path before overwriting it: the composed
+			# file supersedes the raw generated audio, so its per-run temp dir
+			# (audio + transcript) is now disposable (issue #309).
+			old_file_path = episode.file_path
+
+			episode.file_path = composed_path
 			# Persist the composed duration to the column so distribution publishes
 			# the composed length, not the pre-composition one (issue #211).
-			"duration_seconds": result.get("duration_seconds"),
-			"generation_status": "composing",
-		},
-		progress_updates={
-			"composition": "complete",
-			"duration_seconds": result.get("duration_seconds"),
-			"composed_at": _utcnow_iso(),
-		},
-	)
-	if updated:
-		logger.info(
-			"Episode %s composition complete: %.1fs",
-			episode_id,
-			result.get("duration_seconds", 0),
+			episode.duration_seconds = result.get("duration_seconds")
+			episode.generation_status = "composing"
+			current_progress = dict(episode.generation_progress or {})
+			current_progress.update({
+				"composition": "complete",
+				"duration_seconds": result.get("duration_seconds"),
+				"composed_at": _utcnow_iso(),
+			})
+			episode.generation_progress = current_progress
+			db.commit()
+	except Exception as exc:
+		logger.error(
+			"Failed to update episode %s: %s", episode_id, exc, exc_info=True
 		)
+		return
+
+	if old_file_path and old_file_path != composed_path:
+		_cleanup_temp_file(old_file_path)
+
+	logger.info(
+		"Episode %s composition complete: %.1fs",
+		episode_id,
+		result.get("duration_seconds", 0),
+	)
 
 
 @celery_app.task(bind=True, name="on_distribution_complete")

--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -4,6 +4,7 @@ Wraps the existing podcastfy CLI functionality
 """
 import os
 import shutil
+import tempfile
 import time
 import uuid as uuid_module
 import logging
@@ -18,7 +19,11 @@ from src.database import SyncSessionLocal
 from src.models.episode import Episode
 from src.tasks.callbacks import _update_episode, _utcnow_iso
 from src.tasks.idempotency import acquire_generation_lock, release_generation_lock
-from src.tasks.s3_upload import upload_to_s3_task
+from src.tasks.s3_upload import (
+    GENERATION_RUN_DIR_PREFIX,
+    _cleanup_temp_file,
+    upload_to_s3_task,
+)
 from src.tasks.retry_utils import calculate_backoff
 
 logger = logging.getLogger(__name__)
@@ -83,6 +88,10 @@ def _persist_local_audio(audio_file_path: str, episode_id: str) -> str:
     dest = os.path.join(storage_dir, f"episode-{episode_id}.mp3")
     if os.path.abspath(dest) == os.path.abspath(audio_file_path):
         return audio_file_path
+    if os.path.isfile(dest) and not os.path.isfile(audio_file_path):
+        # A finalize retry after the temp source was already cleaned up (issue
+        # #309): the persistent copy exists, so reuse it instead of failing.
+        return dest
     shutil.copy2(audio_file_path, dest)
     return dest
 
@@ -195,7 +204,7 @@ def generate_podcast_task(
         {
             "status": "success" | "failed",
             "audio_file_path": str,
-            "transcript_path": str,
+            "transcript_path": None,  # engine transcript is a temp artifact (#309)
             "duration_seconds": float,
             "file_size_bytes": int,
             "error": Optional[str]
@@ -204,6 +213,7 @@ def generate_podcast_task(
     task_id = self.request.id or "unknown"
     is_retry = (self.request.retries or 0) > 0
     lock_held = False
+    run_dir: Optional[str] = None
 
     try:
         # Idempotency guard (issue #295): short-circuit before any paid work so a
@@ -265,6 +275,19 @@ def generate_podcast_task(
             }
         )
 
+        # Route engine output (audio + transcript) into a per-run temp dir via
+        # podcastfy's supported text_to_speech.output_directories config (deep-
+        # merged into its defaults). Otherwise podcastfy writes to persistent
+        # data/audio + data/transcripts, which nothing ever cleans up (issue #309).
+        run_dir = tempfile.mkdtemp(prefix=GENERATION_RUN_DIR_PREFIX)
+        engine_conversation_config = dict(conversation_config or {})
+        engine_tts_config = dict(engine_conversation_config.get("text_to_speech") or {})
+        engine_tts_config["output_directories"] = {
+            "audio": run_dir,
+            "transcripts": run_dir,
+        }
+        engine_conversation_config["text_to_speech"] = engine_tts_config
+
         # Generate the podcast using existing CLI.
         # podcastfy 0.4.1 has no `file`/`youtube_urls` kwargs: YouTube URLs flow
         # through `urls`, and file/PDF sources are pre-extracted into `text`.
@@ -274,7 +297,7 @@ def generate_podcast_task(
             image_paths=image_paths,
             topic=topic,
             tts_model=tts_model,
-            conversation_config=conversation_config,
+            conversation_config=engine_conversation_config,
             longform=longform,
         )
 
@@ -321,7 +344,10 @@ def generate_podcast_task(
         generation_result = {
             "status": "success",
             "audio_file_path": audio_file_path,
-            "transcript_path": audio_file_path.replace('.mp3', '_transcript.txt'),
+            # podcastfy does not return the transcript path when generating
+            # audio; the transcript is a temp artifact deleted with the run dir
+            # after upload, so persist None rather than a fabricated path (#309).
+            "transcript_path": None,
             "duration_seconds": duration_seconds,
             "file_size_bytes": file_size_bytes,
             "error": None
@@ -435,6 +461,8 @@ def generate_podcast_task(
         # episode does not stay stuck at 'queued' (issue #294).
         msg = "Generation exceeded the soft time limit"
         logger.error("Podcast generation soft-timeout for episode %s", episode_id)
+        if run_dir:
+            shutil.rmtree(run_dir, ignore_errors=True)
         _update_episode(
             episode_id,
             updates={"generation_status": "failed"},
@@ -469,6 +497,10 @@ def generate_podcast_task(
             f"Podcast generation error for episode {episode_id}, "
             f"attempt {self.request.retries + 1}/{self.max_retries + 1}: {e}"
         )
+        # Each attempt creates its own run dir (a retry re-executes the whole
+        # task body), so this attempt's partial artifacts are dead weight (#309).
+        if run_dir:
+            shutil.rmtree(run_dir, ignore_errors=True)
         self.update_state(
             state='PROGRESS',
             meta={
@@ -633,9 +665,11 @@ def finalize_episode_generation_task(
                     return {"status": "failed", "error": error_msg}
             else:
                 # No S3: persist the artifact off ephemeral /tmp so the episode
-                # stays downloadable from local disk (issue #292).
+                # stays downloadable from local disk (issue #292), then drop the
+                # per-run temp dir now that a persistent copy exists (issue #309).
                 persistent_path = _persist_local_audio(audio_file_path, episode_id)
                 episode.file_path = persistent_path
+                _cleanup_temp_file(audio_file_path)
                 logger.info(
                     f"AWS_S3_BUCKET not configured; persisted episode {episode_id} "
                     f"audio to {persistent_path}"

--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -785,7 +785,12 @@ def build_generation_workflow(
 
 	# Stage: audio composition (optional)
 	if enable_composition:
-		composed_output = output_path or f"/tmp/composed_{episode_id}.mp3"
+		# Derive from gettempdir(), not a literal /tmp: the cleanup guard in
+		# _cleanup_temp_file is scoped to gettempdir(), so a TMPDIR override
+		# would otherwise leave every composed file outside its reach (#309).
+		composed_output = output_path or os.path.join(
+			tempfile.gettempdir(), f"composed_{episode_id}.mp3"
+		)
 		composition_sig = merge_audio_snippets_task.si(
 			episode_id=episode_id,
 			timeline=composition_timeline or [],

--- a/apps/api/src/tasks/s3_upload.py
+++ b/apps/api/src/tasks/s3_upload.py
@@ -2,6 +2,7 @@
 Celery tasks for S3 file uploads
 """
 import os
+import shutil
 import tempfile
 import logging
 from celery import Task
@@ -16,19 +17,37 @@ from src.tasks.retry_utils import calculate_backoff
 
 logger = logging.getLogger(__name__)
 
+# Per-run directory prefix used by generate_podcast_task to route podcastfy's
+# audio + transcript output under the system temp dir (issue #309). Cleanup
+# recognizes this prefix and removes the whole run dir, not just the uploaded
+# file, so the transcript beside it cannot leak.
+GENERATION_RUN_DIR_PREFIX = "podcastfy-run-"
+
 
 def _cleanup_temp_file(file_path: str) -> None:
     """Best-effort delete of a temp upload artifact once it is no longer needed.
 
     Only removes files under the system temp dir so it can never delete a
-    persistent file (e.g. under ``data/``); never raises. Call this only when the
-    local copy is disposable: after a successful upload, or after retries are
-    exhausted (no further retry will read it) — never on the retry path.
+    persistent file (e.g. under ``data/``); never raises. When the file lives in
+    a ``podcastfy-run-*`` per-run dir, the whole dir is removed (audio +
+    transcript, issue #309). Call this only when the local copy is disposable:
+    after a successful upload, or after retries are exhausted (no further retry
+    will read it) — never on the retry path.
     """
     try:
         temp_root = os.path.realpath(tempfile.gettempdir())
         real = os.path.realpath(file_path)
-        if os.path.commonpath([temp_root, real]) == temp_root and os.path.isfile(real):
+        if os.path.commonpath([temp_root, real]) != temp_root:
+            return
+        parent = os.path.dirname(real)
+        if (
+            parent != temp_root
+            and os.path.basename(parent).startswith(GENERATION_RUN_DIR_PREFIX)
+            and os.path.isdir(parent)
+        ):
+            shutil.rmtree(parent)
+            logger.info("Removed generation run dir: %s", parent)
+        elif os.path.isfile(real):
             os.remove(real)
             logger.info("Removed temp upload artifact: %s", real)
     except Exception as exc:  # cleanup must never fail the task

--- a/apps/api/tests/test_s3_upload.py
+++ b/apps/api/tests/test_s3_upload.py
@@ -254,6 +254,45 @@ class TestFinalizeEpisodeGenerationTask:
         assert os.path.isfile(episode.file_path)
         assert episode.file_path != str(src_audio)
 
+    def test_no_s3_path_cleans_up_run_dir_after_persisting(self, tmp_path):
+        """Issue #309: with no S3 bucket, once the audio is copied into persistent
+        storage the per-run temp dir (audio + transcript) must be removed."""
+        import shutil
+
+        episode_id = str(uuid.uuid4())
+        episode = _make_mock_episode(episode_id)
+
+        run_dir = tempfile.mkdtemp(prefix="podcastfy-run-")
+        src_audio = os.path.join(run_dir, "podcast_abc.mp3")
+        transcript = os.path.join(run_dir, "transcript_abc.txt")
+        storage_dir = tmp_path / "audio"
+        try:
+            with open(src_audio, "wb") as f:
+                f.write(b"FAKE_MP3")
+            with open(transcript, "w") as f:
+                f.write("transcript")
+            generation_result = self._make_generation_result(
+                audio_file_path=src_audio, transcript_path=None
+            )
+            mock_db = self._make_db_context_manager(episode)
+
+            with (
+                patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=mock_db),
+                patch("src.tasks.podcast_generation.settings") as mock_settings,
+            ):
+                mock_settings.AWS_S3_BUCKET = None
+                mock_settings.LOCAL_AUDIO_STORAGE_PATH = str(storage_dir)
+                result = self._invoke_finalize(episode_id, generation_result, mock_db)
+
+            assert result["status"] == "success"
+            assert episode.generation_status == "complete"
+            assert os.path.isfile(episode.file_path)
+            assert not os.path.exists(run_dir), (
+                "run dir should be removed once the persistent copy exists"
+            )
+        finally:
+            shutil.rmtree(run_dir, ignore_errors=True)
+
     def test_populates_s3_url_on_successful_upload(self):
         """Episode.s3_url and s3_key are populated after successful S3 upload."""
         episode_id = str(uuid.uuid4())
@@ -669,6 +708,71 @@ class TestTempFileCleanup:
 
         assert result["status"] == "success"
         assert persistent.exists(), "non-temp file must be preserved"
+
+    def test_run_dir_removed_after_successful_upload(self):
+        """Issue #309: uploading a file that lives in a podcastfy per-run dir must
+        remove the whole dir — audio AND the transcript beside it."""
+        import shutil
+        from src.tasks.s3_upload import GENERATION_RUN_DIR_PREFIX
+
+        run_dir = tempfile.mkdtemp(prefix=GENERATION_RUN_DIR_PREFIX)
+        audio = os.path.join(run_dir, "podcast_abc.mp3")
+        transcript = os.path.join(run_dir, "transcript_abc.txt")
+        try:
+            with open(audio, "wb") as f:
+                f.write(b"fake audio bytes")
+            with open(transcript, "w") as f:
+                f.write("fake transcript")
+
+            with (
+                patch("src.tasks.s3_upload.settings") as mock_settings,
+                patch("src.tasks.s3_upload.boto3") as mock_boto,
+            ):
+                mock_settings.AWS_REGION = "us-east-1"
+                mock_boto.client.return_value = MagicMock()
+
+                result = self._invoke_upload(
+                    file_path=audio,
+                    s3_key="test/key.mp3",
+                    bucket_name="my-bucket",
+                )
+
+            assert result["status"] == "success"
+            assert not os.path.exists(run_dir), (
+                "the per-run dir (audio + transcript) should be removed after upload"
+            )
+        finally:
+            shutil.rmtree(run_dir, ignore_errors=True)
+
+    def test_run_dir_outside_temp_root_is_preserved(self, tmp_path):
+        """Guard: a podcastfy-run-* directory OUTSIDE the system temp root must
+        never be deleted (nor its files)."""
+        fake_temp_root = tmp_path / "systmp"
+        fake_temp_root.mkdir()
+        run_dir = tmp_path / "podcastfy-run-persistent"
+        run_dir.mkdir()
+        audio = run_dir / "podcast.mp3"
+        audio.write_bytes(b"keep me")
+        transcript = run_dir / "transcript.txt"
+        transcript.write_text("keep me")
+
+        with (
+            patch("src.tasks.s3_upload.settings") as mock_settings,
+            patch("src.tasks.s3_upload.boto3") as mock_boto,
+            patch("src.tasks.s3_upload.os.path.getsize", return_value=7),
+            patch("src.tasks.s3_upload.tempfile.gettempdir", return_value=str(fake_temp_root)),
+        ):
+            mock_settings.AWS_REGION = "us-east-1"
+            mock_boto.client.return_value = MagicMock()
+
+            result = self._invoke_upload(
+                file_path=str(audio),
+                s3_key="test/key.mp3",
+                bucket_name="my-bucket",
+            )
+
+        assert result["status"] == "success"
+        assert audio.exists() and transcript.exists(), "non-temp run dir must be preserved"
 
     def test_temp_file_kept_while_retrying(self):
         """Retry path: a transient error that triggers a retry must NOT delete

--- a/apps/api/tests/unit/test_celery_callbacks.py
+++ b/apps/api/tests/unit/test_celery_callbacks.py
@@ -173,6 +173,47 @@ class TestOnCompositionComplete:
 		assert progress.get("duration_seconds") == 182.5
 		mock_session.commit.assert_called_once()
 
+	def test_removes_raw_generation_artifacts_after_composition(self):
+		"""Issue #309: once the composed file supersedes the raw generated audio,
+		the raw per-run dir (audio + transcript) must be removed — the composed
+		file itself is later cleaned by upload_to_s3_task."""
+		import os
+		import shutil
+		import tempfile
+
+		episode_id = str(uuid.uuid4())
+		episode = _mock_episode(episode_id)
+
+		run_dir = tempfile.mkdtemp(prefix="podcastfy-run-")
+		raw_audio = os.path.join(run_dir, "podcast_raw.mp3")
+		transcript = os.path.join(run_dir, "transcript_raw.txt")
+		try:
+			with open(raw_audio, "wb") as f:
+				f.write(b"raw audio")
+			with open(transcript, "w") as f:
+				f.write("transcript")
+			episode.file_path = raw_audio
+			mock_ctx, mock_session = _make_sync_session(episode)
+
+			result = {
+				"status": "success",
+				"output_path": "/tmp/composed.mp3",
+				"duration_seconds": 10.0,
+			}
+
+			from src.tasks.callbacks import on_composition_complete
+
+			with patch("src.tasks.callbacks.SyncSessionLocal", return_value=mock_ctx):
+				_invoke_task(on_composition_complete, result=result, episode_id=episode_id)
+
+			assert episode.file_path == "/tmp/composed.mp3"
+			mock_session.commit.assert_called_once()
+			assert not os.path.exists(run_dir), (
+				"raw generation run dir should be removed once composition succeeded"
+			)
+		finally:
+			shutil.rmtree(run_dir, ignore_errors=True)
+
 	def test_skips_update_when_composition_failed(self):
 		"""No database update happens when result status is not 'success'."""
 		episode_id = str(uuid.uuid4())

--- a/apps/api/tests/unit/test_podcast_generation_task.py
+++ b/apps/api/tests/unit/test_podcast_generation_task.py
@@ -12,7 +12,10 @@ YouTube URLs arrive via ``urls``; file/PDF sources arrive pre-extracted via
 """
 
 import inspect
+import os
+import shutil
 import sys
+import tempfile
 import types
 from typing import Any
 from unittest.mock import MagicMock, create_autospec, patch
@@ -229,6 +232,88 @@ def test_task_returns_failed_result_on_exception():
 	assert result["status"] == "failed"
 	assert "Podcastfy crashed" in result["error"]
 	assert result["audio_file_path"] is None
+
+
+# ============================================================================
+# ISSUE #309 — transcript_path must not be fabricated; engine output must be
+# routed into a per-run temp dir so post-upload cleanup can remove it.
+# ============================================================================
+
+def _engine_output_dirs(mock_gen) -> dict:
+	"""Extract the output_directories the task injected into conversation_config."""
+	cc = mock_gen.call_args.kwargs.get("conversation_config")
+	assert cc is not None, "task must pass conversation_config to generate_podcast"
+	return cc["text_to_speech"]["output_directories"]
+
+
+def test_success_result_transcript_path_is_none():
+	"""podcastfy never returns a transcript path when generating audio, so the
+	task must persist None — not a string-substituted path to a file that does
+	not exist (issue #309)."""
+	result, mock_gen = _run_task(episode_id=str(uuid4()), urls=["https://example.com"])
+	assert result["status"] == "success"
+	assert result["transcript_path"] is None
+	shutil.rmtree(_engine_output_dirs(mock_gen)["audio"], ignore_errors=True)
+
+
+def test_task_routes_engine_output_to_per_run_temp_dir():
+	"""Both audio and transcript output dirs must be the same per-run directory
+	under the system temp root, named with the cleanup-recognized prefix."""
+	_, mock_gen = _run_task(episode_id=str(uuid4()), urls=["https://example.com"])
+	dirs = _engine_output_dirs(mock_gen)
+
+	assert dirs["audio"] == dirs["transcripts"]
+	run_dir = os.path.realpath(dirs["audio"])
+	temp_root = os.path.realpath(tempfile.gettempdir())
+	assert os.path.commonpath([temp_root, run_dir]) == temp_root
+	assert os.path.basename(run_dir).startswith("podcastfy-run-")
+	assert os.path.isdir(run_dir), "run dir must exist before the engine writes to it"
+	shutil.rmtree(run_dir, ignore_errors=True)
+
+
+def test_task_preserves_user_conversation_config():
+	"""Injecting output_directories must not clobber user-provided conversation
+	config keys (top-level or inside text_to_speech), nor mutate the caller's dict."""
+	user_cc = {"word_count": 500, "text_to_speech": {"ending_message": "bye"}}
+	_, mock_gen = _run_task(
+		episode_id=str(uuid4()),
+		urls=["https://example.com"],
+		conversation_config=user_cc,
+	)
+	cc = mock_gen.call_args.kwargs["conversation_config"]
+	assert cc["word_count"] == 500
+	assert cc["text_to_speech"]["ending_message"] == "bye"
+	assert "output_directories" in cc["text_to_speech"]
+	# The caller's dict must not be mutated in place.
+	assert "output_directories" not in user_cc["text_to_speech"]
+	shutil.rmtree(cc["text_to_speech"]["output_directories"]["audio"], ignore_errors=True)
+
+
+def test_terminal_failure_cleans_up_run_dir():
+	"""When generation fails terminally, the attempt's run dir must be removed
+	so failed attempts don't leak temp artifacts either."""
+	run_dir = tempfile.mkdtemp(prefix="podcastfy-run-")
+	try:
+		mock_client, mock_modules = _mock_podcastfy_modules()
+		mock_client.generate_podcast = create_autospec(
+			real_generate_podcast, side_effect=RuntimeError("boom")
+		)
+		with patch.object(generate_podcast_task, 'update_state'), \
+			 patch.dict(sys.modules, mock_modules), \
+			 patch('src.tasks.podcast_generation.tempfile.mkdtemp', return_value=run_dir), \
+			 patch.object(
+				generate_podcast_task,
+				"retry",
+				side_effect=generate_podcast_task.MaxRetriesExceededError(),
+			 ):
+			result = generate_podcast_task.run(
+				episode_id=str(uuid4()),
+				urls=["https://example.com"],
+			)
+		assert result["status"] == "failed"
+		assert not os.path.exists(run_dir)
+	finally:
+		shutil.rmtree(run_dir, ignore_errors=True)
 
 
 class TestBuildPodcastS3Key:

--- a/apps/api/tests/unit/test_podcast_generation_task.py
+++ b/apps/api/tests/unit/test_podcast_generation_task.py
@@ -316,6 +316,30 @@ def test_terminal_failure_cleans_up_run_dir():
 		shutil.rmtree(run_dir, ignore_errors=True)
 
 
+def test_soft_timeout_cleans_up_run_dir():
+	"""SoftTimeLimitExceeded is a separate terminal branch (it bypasses the
+	generic except) — it must also remove the attempt's run dir."""
+	from celery.exceptions import SoftTimeLimitExceeded
+
+	run_dir = tempfile.mkdtemp(prefix="podcastfy-run-")
+	try:
+		mock_client, mock_modules = _mock_podcastfy_modules()
+		mock_client.generate_podcast = create_autospec(
+			real_generate_podcast, side_effect=SoftTimeLimitExceeded()
+		)
+		with patch.object(generate_podcast_task, 'update_state'), \
+			 patch.dict(sys.modules, mock_modules), \
+			 patch('src.tasks.podcast_generation.tempfile.mkdtemp', return_value=run_dir):
+			result = generate_podcast_task.run(
+				episode_id=str(uuid4()),
+				urls=["https://example.com"],
+			)
+		assert result["status"] == "failed"
+		assert not os.path.exists(run_dir)
+	finally:
+		shutil.rmtree(run_dir, ignore_errors=True)
+
+
 class TestBuildPodcastS3Key:
 	"""Canonical S3 key helper (issue #215)."""
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,79 +1,31 @@
-# #308 — SHIPPED via PR #367 (all gates passed: tests, diff-cover 98%, cross-family APPROVE, bot review clean, demo verified, CI green)
+# Issue #309 — Wrong transcript_path persisted; engine artifacts never cleaned up
 
-**Plan source**: self-authored (no plan comment on issue), derived from code exploration 2026-07-09.
-**Branch**: `feature/issue-308-episode-delete-s3-erasure`
+Plan source: CodeRabbit comment on issue, adapted to current code (post-#367).
+Autonomous decisions (no architectural fork):
+- `transcript_path=None` (not captured-real-path): the run dir is deleted after upload, so a captured path would dangle exactly like the fabricated one.
+- Output routing via `conversation_config["text_to_speech"]["output_directories"]` — verified podcastfy 0.4.1 deep-merges this (`NestedConfig.configure` recurses), so other TTS defaults are preserved. No new kwarg to `generate_podcast()`.
+- Composition chain: raw run-dir artifacts cleaned in `on_composition_complete` (the only place that still knows the pre-composition `file_path` before overwriting it); the uploaded composed file is already cleaned by `upload_to_s3_task`.
+- Failure paths: best-effort `rmtree` of the current attempt's run dir on soft-timeout/retry/exhaustion so failed attempts don't leak either.
+- No-S3 dev path: clean the run dir after `_persist_local_audio` copies the audio out.
 
-## Design decisions (made autonomously — no architectural fork)
+## Steps
 
-1. **Erasure entry point = self-service `DELETE /auth/me`** (204, `Depends(get_current_user)`).
-   The system has no admin/superuser role (`User` has only `is_active`/`is_verified`), so an
-   admin-only endpoint isn't possible; user-initiated deletion is the standard GDPR
-   right-to-erasure shape and matches existing hard-delete endpoints.
-2. **S3 deletion is key-based, not prefix-listing.** IAM intentionally does NOT grant
-   `s3:ListBucket` (deployment/README.md:318). Every S3 object has its key stored in a DB row
-   (`episodes.s3_key`, `episode_compositions.composed_s3_key`, `audio_snippets.s3_key`,
-   `rss_feeds.s3_key`, content-source `source_data['s3_key']`), so we collect keys from rows
-   before deleting them. No new StorageService list/bulk API needed — iterate `delete_file`
-   (S3 `delete_object` is already idempotent on missing keys).
-3. **S3/local cleanup is best-effort** (log warning, never block the DB delete) — copies the
-   existing `delete_audio_snippet` pattern (audio_snippet_service.py:286-318).
-4. **Wrap sync `delete_file` in `asyncio.to_thread`** at async call sites (matches how
-   `upload_file`/`download_file` are handled; existing `delete_file` call is bare — leave that).
-5. **Tests fake StorageService with unittest.mock patches** — the repo's established S3 test
-   convention (tests/unit/test_storage_service.py, test_episodes.py:1691).
+- [ ] 1. Tests first (RED):
+  - `tests/unit/test_podcast_generation_task.py`: success result has `transcript_path is None`; `generate_podcast()` receives `conversation_config` with `text_to_speech.output_directories.{audio,transcripts}` under `tempfile.gettempdir()`; user-supplied `conversation_config` keys preserved; keep `output_dir`-not-passed guard.
+  - `tests/test_s3_upload.py` (TestTempFileCleanup): uploading a file inside a `podcastfy-run-*` dir removes the whole dir (audio + transcript); a run-dir-named dir outside temp root is untouched; plain temp files behave as before.
+  - `tests/unit/test_celery_callbacks.py`: `on_composition_complete` removes the old run-dir artifacts before persisting the composed `file_path`.
+- [ ] 2. `src/tasks/s3_upload.py`: add `GENERATION_RUN_DIR_PREFIX = "podcastfy-run-"`; extend `_cleanup_temp_file` to rmtree the containing run dir (prefix match, under temp root) instead of just the file.
+- [ ] 3. `src/tasks/podcast_generation.py`: create `run_dir = tempfile.mkdtemp(prefix=GENERATION_RUN_DIR_PREFIX)` before calling the engine; inject output_directories into a copied `conversation_config`; set `transcript_path=None`; rmtree run dir on failure paths; clean run dir after `_persist_local_audio` in the no-S3 branch (guard `_persist_local_audio` for retry-safety: return dest if dest exists and source is gone).
+- [ ] 4. `src/tasks/callbacks.py`: `on_composition_complete` — read old `file_path`, `_cleanup_temp_file(old_path)` best-effort, then update as today.
+- [ ] 5. Full api test suite + ruff; quality gates; PR.
 
-## Steps (TDD)
+## Acceptance criteria
 
-- [x] 1. Branch off main: `feature/issue-308-episode-delete-s3-erasure`.
-- [x] 2. **Episode delete cleanup** — `apps/api/src/services/episode_service.py:delete_episode`:
-  - RED: tests in `tests/test_episodes.py`: (a) delete of episode with `s3_key` calls
-    `StorageService.delete_file(s3_key)`; (b) no `s3_key` → no S3 call; (c) S3 delete raising
-    still deletes the DB row (204); (d) local `file_path`/`transcript_path` files removed
-    (tmp_path fixture); (e) composition `composed_s3_key` also deleted.
-  - GREEN: collect episode.s3_key + its EpisodeComposition.composed_s3_key; best-effort
-    delete S3 objects (`asyncio.to_thread(storage.delete_file, key)`, try/except → log
-    warning); best-effort `os.remove` of `file_path`, `transcript_path`,
-    `composed_file_path`; then `db.delete(episode)` + commit.
-- [x] 3. **Tenant offboarding** — new `apps/api/src/services/offboarding_service.py` +
-  `DELETE /auth/me` in `src/routers/auth.py`:
-  - RED: new `tests/test_offboarding.py`: register user via `/auth/register`, seed
-    project/episode (with s3_key, composition) /audio_snippet/rss_feed rows; patch
-    StorageService; `DELETE /auth/me` → 204; `delete_file` called once per collected key;
-    user + cascaded rows + billing rows gone; the old token now 401/403 on `/auth/me`.
-  - GREEN: `erase_user(db, user)`: collect S3 keys from episodes, compositions, snippets,
-    rss feeds, content-source `source_data['s3_key']`; collect local paths; best-effort
-    delete S3 + local files; explicitly delete `BillingSubscription`/`BillingUsage` by
-    `user_id` (no FK — DB cascade won't reach them); `db.delete(user)` (FK CASCADE removes
-    projects → episodes → content_sources/compositions, snippets, rss_feeds, distribution
-    targets, templates, tts configs, layouts, team memberships/invitations); commit; return
-    summary counts. Router endpoint is a thin wrapper.
-  - RLS note: runs as the requesting user with tenant context armed, so RLS permits deleting
-    own-tenant rows. If the `users` RLS policy blocks self-delete, stop and report (don't
-    improvise a bypass).
-- [x] 4. **Docs reconcile**:
-  - `deployment/README.md:315`: `s3:DeleteObject` rationale → "remove audio when an episode
-    or account is deleted" (now true).
-  - Add "Tenant offboarding / GDPR erasure" section (deployment/README.md): what
-    `DELETE /auth/me` erases (Postgres rows + S3 objects + local artifacts), key-based
-    deletion rationale (no ListBucket), limitations below.
-- [x] 5. Quality gates: full pytest 1689 passed / diff-cover 98% / ruff clean; deslop done;
-  internal review (1 Major rebutted: S3-before-commit ordering is deliberate — see #366);
-  cross-family opencode/GLM round 1 REQUEST_CHANGES → fixes (password step-up, 409
-  mid-generation guard, core user DELETE, audit log, rate limit) → round 2 APPROVE;
-  mutation checks: 4 killed, 1 infeasible (billing cascade DB-enforced, documented): full pytest from apps/api (`uv run pytest tests/`), ruff, coverage ≥85;
-  deslop; internal review + cross-family (opencode/GLM) review; PR; demo; CI; merge.
+- [ ] `Episode.transcript_path` never points at a non-existent fabricated path (set to None).
+- [ ] Engine audio/transcript artifacts are written to a per-run temp dir and deleted after successful S3 upload (both finalize and workflow-chain paths).
+- [ ] Persistent (non-temp) paths can never be deleted by cleanup.
 
-## Acceptance criteria (from issue)
+## Known limitations (for PR body)
 
-- [x] `StorageService.delete_file(episode.s3_key)` called on episode delete (idempotent on
-  missing) and local file artifacts removed.
-- [x] Documented tenant-offboarding routine erasing Postgres rows + all S3 audio for a user.
-- [x] deployment/README.md reconciled with actual behaviour.
-
-## Known limitations (disclose in PR)
-
-- `Team` rows have no owner; erasure removes the user's memberships/invitations but leaves
-  team shells.
-- Stripe-side customer data is not touched (only local billing rows) — out of scope here.
-- Content-source uploads are deleted on account erasure but not on single-episode delete
-  (episode delete scope per AC = episode audio + local artifacts + composition audio).
+- On workflow *failure*, the run dir of the failed attempt inside the chain may remain until OS temp cleanup (bounded; regeneration uses a fresh dir).
+- Episode transcript content is not retained anywhere after this change (it never was retrievable — the stored path was fabricated).


### PR DESCRIPTION
## Summary
Implements #309: the generation task persisted a string-substituted `transcript_path` pointing at a file podcastfy never writes, and the engine's audio/transcript artifacts in `data/audio` / `data/transcripts` were never cleaned up, leaking disk on the worker per episode.

- **`transcript_path=None`**: podcastfy 0.4.1 never returns the transcript path when generating audio; the fabricated `.replace('.mp3','_transcript.txt')` value is gone. Migration `015` NULLs existing fabricated rows (real script-generation transcripts are `<episode_id>.xml` and untouched).
- **Per-run temp routing**: engine output (audio + transcript) is routed into a `podcastfy-run-*` dir under the system temp root via podcastfy's supported `text_to_speech.output_directories` conversation-config key (deep-merged — user-provided conversation config is preserved; verified against installed 0.4.1 source).
- **Cleanup after upload**: `_cleanup_temp_file` now removes the whole run dir (audio + transcript) when the uploaded file lives in one — still hard-guarded to `tempfile.gettempdir()` via realpath+commonpath, so persistent paths can never be deleted. Covers the inline finalize path and the workflow chain; with composition enabled, `on_composition_complete` cleans the superseded raw run dir (the composed upload was already cleaned).
- **Failure paths**: soft-timeout and retry/exhaustion remove the attempt's run dir; the no-S3 dev path cleans the run dir after copying audio to persistent storage (with a retry-safe reuse guard).
- **TMPDIR hardening**: composed output path now derives from `tempfile.gettempdir()` instead of literal `/tmp` so the cleanup guard covers it under a TMPDIR override.

## Acceptance Criteria
- [x] `transcript_path` is `None` (not string-replaced) — never points at a non-existent file; existing rows backfilled by migration 015
- [x] Engine audio/transcript artifacts routed to a per-run temp dir the cleanup covers and deleted after successful S3 upload (both upload paths)
- [x] Cleanup can never delete persistent (non-temp) files (realpath + commonpath guard, tested incl. run-dir-named dirs outside temp root)

## Test Plan
- [x] Unit tests written first (TDD; 7 RED-verified tests + 1 mutation-verified soft-timeout test)
- [x] Full API suite: 1698 passed, 7 skipped; total coverage 93.87%
- [x] Diff coverage 87% on changed lines (≥85 gate)
- [x] Linting clean (ruff)
- [x] Internal code review (advisory) completed — no blocking findings
- [x] Cross-family review pass: opencode (GLM) — **APPROVE**
- [x] Test mutation sanity check completed

## Known Limitations / Intentionally Deferred
- **Broker-dispatch failure keeps the run dir** (deliberate): if the workflow chain cannot be dispatched after a successful generation, the artifacts are kept so an operator can still salvage the paid generation; the #294 reaper handles the stuck episode and the leak is temp-dir-bounded. (GLM review suggestion, skipped with this rationale.)
- **Episode transcripts are not retained** after upload — they never were retrievable (the stored path was fabricated); retaining transcripts (e.g. uploading them to S3) would be a new feature.
- Chain failure mid-workflow (e.g. composition fails) can leave that attempt's run dir until OS temp cleanup — bounded, and regeneration uses a fresh dir.

## Implementation Notes
- Output routing uses podcastfy's conversation-config `output_directories` (no unsupported `output_dir` kwarg); the existing signature drift-guard tests still bind against the real 0.4.1 signature.
- `on_composition_complete` was restructured to a single locked session (matching `on_distribution_complete`) so it can capture the pre-composition `file_path` before overwriting it.

Closes #309