### PR TITLE
Fix TZ-aware date params vs naive DB timestamps in analytics/episodes (#310)

### DIFF
--- a/apps/api/src/services/analytics_service.py
+++ b/apps/api/src/services/analytics_service.py
@@ -8,7 +8,7 @@ from uuid import UUID
 from sqlalchemy import Boolean, Float, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..utils.datetime_utils import utcnow
+from ..utils.datetime_utils import to_naive_utc, utcnow
 
 from ..models.analytics_event import (
 	AnalyticsEvent,
@@ -65,10 +65,9 @@ async def get_episode_analytics(
 	date_to: Optional[datetime] = None,
 ) -> Dict[str, Any]:
 	"""Aggregate analytics events for an episode within a date range."""
-	if date_from is None:
-		date_from = utcnow() - timedelta(days=30)
-	if date_to is None:
-		date_to = utcnow()
+	# created_at is offset-naive UTC, so normalize caller-supplied bounds to naive UTC
+	date_from = utcnow() - timedelta(days=30) if date_from is None else to_naive_utc(date_from)
+	date_to = utcnow() if date_to is None else to_naive_utc(date_to)
 
 	window = (
 		(AnalyticsEvent.episode_id == episode_id)

--- a/apps/api/src/services/episode_service.py
+++ b/apps/api/src/services/episode_service.py
@@ -20,6 +20,7 @@ from fastapi import HTTPException, status
 from ..models import Episode, Project
 from ..models.episode_composition import EpisodeComposition
 from ..schemas.episode import EpisodeCreate, EpisodeUpdate, BatchEpisodeCreate
+from ..utils.datetime_utils import to_naive_utc
 from .storage_service import StorageService
 
 logger = logging.getLogger(__name__)
@@ -170,14 +171,12 @@ async def get_episodes(
 			)
 		)
 
-	# Date range filter — created_at is offset-naive, so strip tzinfo from inputs
+	# Date range filter — created_at is offset-naive UTC, so normalize inputs
 	if date_from is not None:
-		date_from_naive = date_from.replace(tzinfo=None) if date_from.tzinfo else date_from
-		query = query.where(Episode.created_at >= date_from_naive)
+		query = query.where(Episode.created_at >= to_naive_utc(date_from))
 
 	if date_to is not None:
-		date_to_naive = date_to.replace(tzinfo=None) if date_to.tzinfo else date_to
-		query = query.where(Episode.created_at <= date_to_naive)
+		query = query.where(Episode.created_at <= to_naive_utc(date_to))
 
 	# Tag filter — each tag must be present in episode_metadata.tags array (AND logic)
 	# Uses PostgreSQL JSONB @> operator: episode_metadata->'tags' @> '["tag"]'::jsonb

--- a/apps/api/src/utils/datetime_utils.py
+++ b/apps/api/src/utils/datetime_utils.py
@@ -10,3 +10,10 @@ from datetime import datetime, timezone
 def utcnow() -> datetime:
 	"""Current UTC time as a naive datetime — what datetime.utcnow() returned."""
 	return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def to_naive_utc(dt: datetime) -> datetime:
+	"""Normalize a possibly-aware datetime to naive UTC for naive-column comparison."""
+	if dt.tzinfo:
+		return dt.astimezone(timezone.utc).replace(tzinfo=None)
+	return dt

--- a/apps/api/tests/test_analytics.py
+++ b/apps/api/tests/test_analytics.py
@@ -3,6 +3,7 @@ Integration tests for analytics endpoints (GAP-049).
 """
 
 import pytest
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 
@@ -223,6 +224,53 @@ async def test_get_episode_analytics_counts_correctly(client):
 	data = response.json()
 	assert data["metrics"]["total_downloads"] == 2
 	assert data["metrics"]["total_plays"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_episode_analytics_tz_aware_date_range(client):
+	"""Z-suffixed (TZ-aware) date params must not raise against naive created_at (#310)."""
+	headers = await register_and_login(client)
+	project_id = await create_project(client, headers)
+	episode_id = await create_episode(client, headers, project_id)
+
+	await client.post("/analytics/events", json={
+		"event_type": "download",
+		"episode_id": episode_id,
+	}, headers=headers)
+
+	date_from = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+	date_to = (datetime.now(timezone.utc) + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+	response = await client.get(
+		f"/analytics/episodes/{episode_id}?date_from={date_from}&date_to={date_to}",
+		headers=headers,
+	)
+	assert response.status_code == 200, response.text
+	assert response.json()["metrics"]["total_downloads"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_episode_analytics_non_utc_offset_converted(client):
+	"""Non-UTC offsets must be converted to UTC, not just tz-stripped (#310)."""
+	headers = await register_and_login(client)
+	project_id = await create_project(client, headers)
+	episode_id = await create_episode(client, headers, project_id)
+
+	await client.post("/analytics/events", json={
+		"event_type": "download",
+		"episode_id": episode_id,
+	}, headers=headers)
+
+	# 30 min ago UTC, expressed in +03:00 — naive stripping would yield a
+	# wall time ~2.5h in the future and wrongly exclude the event just tracked.
+	plus3 = timezone(timedelta(hours=3))
+	date_from = (datetime.now(timezone.utc) - timedelta(minutes=30)).astimezone(plus3)
+	response = await client.get(
+		f"/analytics/episodes/{episode_id}",
+		params={"date_from": date_from.isoformat()},
+		headers=headers,
+	)
+	assert response.status_code == 200, response.text
+	assert response.json()["metrics"]["total_downloads"] == 1
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_episodes.py
+++ b/apps/api/tests/test_episodes.py
@@ -6,7 +6,7 @@ status filtering, and tenant isolation for episodes.
 """
 
 import pytest
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 from src.models.billing_subscription import BillingSubscription
@@ -127,6 +127,30 @@ async def test_list_episodes(client, project_and_auth):
 	data = response.json()
 	assert data["total"] >= 3
 	assert len(data["episodes"]) >= 3
+
+
+@pytest.mark.asyncio
+async def test_list_episodes_tz_aware_date_filter(client, project_and_auth):
+	"""TZ-aware date_from/date_to are converted to UTC before filtering (#310)."""
+	project_id, headers = project_and_auth
+	response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_metadata": {"title": "TZ Episode", "description": "TZ"},
+	})
+	assert response.status_code == 201
+
+	# 30 min ago UTC, expressed in +03:00 — naive stripping would yield a
+	# wall time ~2.5h in the future and wrongly exclude the episode.
+	plus3 = timezone(timedelta(hours=3))
+	date_from = (datetime.now(timezone.utc) - timedelta(minutes=30)).astimezone(plus3)
+	date_to = (datetime.now(timezone.utc) + timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
+	response = await client.get(
+		"/episodes",
+		params={"project_id": project_id, "date_from": date_from.isoformat(), "date_to": date_to},
+		headers=headers,
+	)
+	assert response.status_code == 200, response.text
+	assert response.json()["total"] == 1
 
 
 @pytest.mark.asyncio

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,31 +1,24 @@
-# #309 — SHIPPED via PR #368 (all gates passed: 1698 tests, diff-cover 87%, GLM APPROVE pre+post-PR, demo verified, CI green, issue closed)
+# Issue #310 — TZ-aware analytics params vs naive DB timestamps
 
-Plan source: CodeRabbit comment on issue, adapted to current code (post-#367).
-Autonomous decisions (no architectural fork):
-- `transcript_path=None` (not captured-real-path): the run dir is deleted after upload, so a captured path would dangle exactly like the fabricated one.
-- Output routing via `conversation_config["text_to_speech"]["output_directories"]` — verified podcastfy 0.4.1 deep-merges this (`NestedConfig.configure` recurses), so other TTS defaults are preserved. No new kwarg to `generate_podcast()`.
-- Composition chain: raw run-dir artifacts cleaned in `on_composition_complete` (the only place that still knows the pre-composition `file_path` before overwriting it); the uploaded composed file is already cleaned by `upload_to_s3_task`.
-- Failure paths: best-effort `rmtree` of the current attempt's run dir on soft-timeout/retry/exhaustion so failed attempts don't leak either.
-- No-S3 dev path: clean the run dir after `_persist_local_audio` copies the audio out.
+## Adapted plan (approved autonomously — no architectural fork)
+
+Most of the issue is already fixed: PR #348 introduced the naive `utcnow()` helper
+(`src/utils/datetime_utils.py`) and analytics/RSS/usage services already use it, so the
+deprecated `datetime.utcnow()` calls and the write-side timestamps are done.
+
+**Remaining bug:** `analytics_service.get_episode_analytics` uses caller-supplied
+`date_from`/`date_to` directly in the WHERE clause against naive
+`AnalyticsEvent.created_at`. A `Z`-suffixed query param arrives TZ-aware from FastAPI →
+asyncpg raises "cannot compare timestamp with/without time zone".
+(`get_project_analytics` only uses naive internal bounds — not affected.)
 
 ## Steps
 
-- [ ] 1. Tests first (RED):
-  - `tests/unit/test_podcast_generation_task.py`: success result has `transcript_path is None`; `generate_podcast()` receives `conversation_config` with `text_to_speech.output_directories.{audio,transcripts}` under `tempfile.gettempdir()`; user-supplied `conversation_config` keys preserved; keep `output_dir`-not-passed guard.
-  - `tests/test_s3_upload.py` (TestTempFileCleanup): uploading a file inside a `podcastfy-run-*` dir removes the whole dir (audio + transcript); a run-dir-named dir outside temp root is untouched; plain temp files behave as before.
-  - `tests/unit/test_celery_callbacks.py`: `on_composition_complete` removes the old run-dir artifacts before persisting the composed `file_path`.
-- [ ] 2. `src/tasks/s3_upload.py`: add `GENERATION_RUN_DIR_PREFIX = "podcastfy-run-"`; extend `_cleanup_temp_file` to rmtree the containing run dir (prefix match, under temp root) instead of just the file.
-- [ ] 3. `src/tasks/podcast_generation.py`: create `run_dir = tempfile.mkdtemp(prefix=GENERATION_RUN_DIR_PREFIX)` before calling the engine; inject output_directories into a copied `conversation_config`; set `transcript_path=None`; rmtree run dir on failure paths; clean run dir after `_persist_local_audio` in the no-S3 branch (guard `_persist_local_audio` for retry-safety: return dest if dest exists and source is gone).
-- [ ] 4. `src/tasks/callbacks.py`: `on_composition_complete` — read old `file_path`, `_cleanup_temp_file(old_path)` best-effort, then update as today.
-- [ ] 5. Full api test suite + ruff; quality gates; PR.
-
-## Acceptance criteria
-
-- [ ] `Episode.transcript_path` never points at a non-existent fabricated path (set to None).
-- [ ] Engine audio/transcript artifacts are written to a per-run temp dir and deleted after successful S3 upload (both finalize and workflow-chain paths).
-- [ ] Persistent (non-temp) paths can never be deleted by cleanup.
-
-## Known limitations (for PR body)
-
-- On workflow *failure*, the run dir of the failed attempt inside the chain may remain until OS temp cleanup (bounded; regeneration uses a fresh dir).
-- Episode transcript content is not retained anywhere after this change (it never was retrievable — the stored path was fabricated).
+- [x] RED: `test_get_episode_analytics_tz_aware_date_range` failed with the exact
+      asyncpg DataError from the issue.
+- [x] GREEN: shared `to_naive_utc()` helper in `datetime_utils.py`; used in
+      `get_episode_analytics` and `episode_service` date filters.
+- [x] GLM pre-PR review: APPROVE. Took its two minor suggestions: shared helper
+      (also fixes pre-existing non-UTC-offset bug in episode_service) and
+      load-bearing +03:00 offset tests (analytics + episodes).
+- [ ] Gates: full pytest, PR, post-PR review, demo, CI, merge.


### PR DESCRIPTION
Closes #310

## Problem
FastAPI parses Z-suffixed ISO date query params (`?date_from=2024-01-01T00:00:00Z`) as TZ-aware datetimes. `GET /analytics/episodes/{id}` passed them straight into WHERE clauses against offset-naive `analytics_events.created_at`, raising asyncpg `DataError` (500).

## Scope note
The deprecated-`datetime.utcnow()` half of #310 was already fixed by the naive `utcnow()` helper introduced in #348 — analytics/RSS/usage services all use it now. This PR fixes the remaining live bug: TZ-aware filter params.

## Changes
- New shared `to_naive_utc()` in `src/utils/datetime_utils.py` — converts to UTC **before** stripping tzinfo, so non-UTC offsets (e.g. `+03:00`) are handled correctly, not just `Z`.
- `analytics_service.get_episode_analytics`: normalize caller-supplied `date_from`/`date_to` (RED test reproduced the exact asyncpg error before the fix).
- `episode_service` date filters: adopted the same helper — the old inline pattern stripped tzinfo without converting, silently shifting non-UTC-offset bounds (pre-existing bug, flagged in pre-PR review).

## Tests
- `test_get_episode_analytics_tz_aware_date_range` — Z-suffixed range returns 200 + correct counts (acceptance criterion).
- `test_get_episode_analytics_non_utc_offset_converted` and `test_list_episodes_tz_aware_date_filter` — `+03:00` bounds designed so a regression to plain tz-strip flips the result.
- Full API suite: 1701 passed, 7 skipped, coverage gate green.

## Third-party review
Pre-PR opencode/GLM review: **APPROVE**, no Critical/Major. Both minor suggestions (shared helper, non-UTC-offset test) were adopted.

## Known limitations
- `get_project_analytics` takes only a `days` int (no date params) — unaffected, unchanged.
- Stored timestamps remain naive UTC by design (storage contract; see `datetime_utils.py` docstring).