### PR TITLE
Rollback failed transaction before cleanup write in finalize task (#311)

### DIFF
--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -710,6 +710,16 @@ def finalize_episode_generation_task(
                     f"Finalization failed after {self.max_retries} retries "
                     f"for episode {episode_id}: {e}"
                 )
+                # The triggering error may have left the session in a failed-
+                # transaction state; reset it so the 'failed' status write
+                # below can actually persist (issue #311).
+                try:
+                    db.rollback()
+                except Exception as rollback_err:
+                    logger.error(
+                        f"Rollback before failure-status write failed for "
+                        f"episode {episode_id}: {rollback_err}"
+                    )
                 try:
                     episode = db.get(Episode, uuid_module.UUID(episode_id))
                     if episode:

--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -717,7 +717,7 @@ def finalize_episode_generation_task(
                     db.rollback()
                 except Exception as rollback_err:
                     logger.error(
-                        f"Rollback before failure-status write failed for "
+                        "Rollback before failure-status write failed for "
                         f"episode {episode_id}: {rollback_err}"
                     )
                 try:

--- a/apps/api/tests/unit/test_task_retry.py
+++ b/apps/api/tests/unit/test_task_retry.py
@@ -615,3 +615,22 @@ class TestFinalizeEpisodeGenerationTaskRetry:
 
 		assert result["status"] == "failed"
 		assert "error" in result
+
+	def test_cleanup_proceeds_when_rollback_itself_fails(self):
+		"""A rollback failure is logged but must not prevent the cleanup write
+		from being attempted (issue #311)."""
+		episode = MagicMock()
+		episode.generation_progress = {}
+
+		mock_db = MagicMock()
+		mock_db.get.side_effect = [RuntimeError("Database connection lost"), episode]
+		mock_db.rollback.side_effect = RuntimeError("rollback failed too")
+		mock_db.__enter__ = MagicMock(return_value=mock_db)
+		mock_db.__exit__ = MagicMock(return_value=False)
+
+		result = self._run_with_broken_session(mock_db)
+
+		assert mock_db.get.call_count == 2, "cleanup get() must still run"
+		assert episode.generation_status == "failed"
+		mock_db.commit.assert_called_once()
+		assert result["status"] == "failed"

--- a/apps/api/tests/unit/test_task_retry.py
+++ b/apps/api/tests/unit/test_task_retry.py
@@ -614,23 +614,28 @@ class TestFinalizeEpisodeGenerationTaskRetry:
 		result = self._run_with_broken_session(mock_db)
 
 		assert result["status"] == "failed"
-		assert "error" in result
+		assert "Database connection lost" in result["error"]
 
 	def test_cleanup_proceeds_when_rollback_itself_fails(self):
-		"""A rollback failure is logged but must not prevent the cleanup write
-		from being attempted (issue #311)."""
-		episode = MagicMock()
-		episode.generation_progress = {}
+		"""A rollback failure is logged but must not abort the handler: the
+		cleanup write is still attempted and the task returns a failed result
+		instead of raising (issue #311)."""
+		from sqlalchemy.exc import PendingRollbackError
 
 		mock_db = MagicMock()
-		mock_db.get.side_effect = [RuntimeError("Database connection lost"), episode]
+		# Faithful to SQLAlchemy semantics: rollback failed, so the transaction
+		# is still aborted and the cleanup get() raises too.
+		mock_db.get.side_effect = [
+			RuntimeError("Database connection lost"),
+			PendingRollbackError("transaction still aborted"),
+		]
 		mock_db.rollback.side_effect = RuntimeError("rollback failed too")
 		mock_db.__enter__ = MagicMock(return_value=mock_db)
 		mock_db.__exit__ = MagicMock(return_value=False)
 
 		result = self._run_with_broken_session(mock_db)
 
-		assert mock_db.get.call_count == 2, "cleanup get() must still run"
-		assert episode.generation_status == "failed"
-		mock_db.commit.assert_called_once()
+		assert mock_db.get.call_count == 2, "cleanup get() must still be attempted"
+		mock_db.commit.assert_not_called()
 		assert result["status"] == "failed"
+		assert "Database connection lost" in result["error"]

--- a/apps/api/tests/unit/test_task_retry.py
+++ b/apps/api/tests/unit/test_task_retry.py
@@ -540,3 +540,78 @@ class TestFinalizeEpisodeGenerationTaskRetry:
 
 		mock_retry.assert_called_once()
 		assert result["status"] == "failed"
+
+	def _run_with_broken_session(self, mock_db):
+		"""Run finalize with retries exhausted against the given mock session."""
+		import uuid
+		from src.tasks.podcast_generation import finalize_episode_generation_task
+
+		generation_result = {
+			"status": "success",
+			"audio_file_path": "/tmp/ep.mp3",
+			"transcript_path": "/tmp/ep_transcript.txt",
+			"duration_seconds": 120.0,
+			"file_size_bytes": 2_000_000,
+			"error": None,
+		}
+
+		with (
+			patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=mock_db),
+			patch("src.tasks.podcast_generation.settings") as mock_settings,
+			patch.object(finalize_episode_generation_task, "update_state"),
+			patch.object(
+				finalize_episode_generation_task,
+				"retry",
+				side_effect=_make_celery_retry_exception(finalize_episode_generation_task),
+			),
+		):
+			mock_settings.AWS_S3_BUCKET = None
+			finalize_episode_generation_task.request.update(retries=0)
+			return finalize_episode_generation_task.run(
+				episode_id=str(uuid.uuid4()),
+				generation_result=generation_result,
+			)
+
+	def test_cleanup_rolls_back_failed_transaction_before_marking_failed(self):
+		"""After retries are exhausted, the cleanup must rollback() the broken
+		session before reusing it, so the 'failed' status is durably persisted
+		(issue #311)."""
+		episode = MagicMock()
+		episode.generation_progress = {}
+
+		mock_db = MagicMock()
+		# First get() raises (triggers the outer except / broken tx); the
+		# cleanup get() after rollback succeeds.
+		mock_db.get.side_effect = [RuntimeError("Database connection lost"), episode]
+		mock_db.__enter__ = MagicMock(return_value=mock_db)
+		mock_db.__exit__ = MagicMock(return_value=False)
+
+		result = self._run_with_broken_session(mock_db)
+
+		names = [name for name, _, _ in mock_db.mock_calls]
+		first_get = names.index("get")
+		second_get = names.index("get", first_get + 1)
+		assert "rollback" in names, "cleanup must rollback the failed transaction"
+		assert first_get < names.index("rollback") < second_get, (
+			"rollback must happen before the cleanup get()"
+		)
+		assert episode.generation_status == "failed"
+		mock_db.commit.assert_called_once()
+		assert result["status"] == "failed"
+
+	def test_cleanup_degrades_gracefully_when_cleanup_commit_fails(self):
+		"""If even the post-rollback cleanup write fails, the task must log and
+		return a failed result dict instead of raising (issue #311)."""
+		episode = MagicMock()
+		episode.generation_progress = {}
+
+		mock_db = MagicMock()
+		mock_db.get.side_effect = [RuntimeError("Database connection lost"), episode]
+		mock_db.commit.side_effect = RuntimeError("connection still broken")
+		mock_db.__enter__ = MagicMock(return_value=mock_db)
+		mock_db.__exit__ = MagicMock(return_value=False)
+
+		result = self._run_with_broken_session(mock_db)
+
+		assert result["status"] == "failed"
+		assert "error" in result

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,24 +1,21 @@
-# Issue #310 — TZ-aware analytics params vs naive DB timestamps
+# Issue #311 — Rollback before cleanup write in finalize_episode_generation_task
 
-## Adapted plan (approved autonomously — no architectural fork)
+**Problem:** When the outer try in `finalize_episode_generation_task` fails on a DB error,
+the session is left in a failed-transaction state. The `MaxRetriesExceededError` handler
+(apps/api/src/tasks/podcast_generation.py:708-725) reuses that same session to mark the
+episode failed; `db.get(...)` raises `InvalidRequestError`, the inner except logs it, and
+the episode is stuck in an intermediate status.
 
-Most of the issue is already fixed: PR #348 introduced the naive `utcnow()` helper
-(`src/utils/datetime_utils.py`) and analytics/RSS/usage services already use it, so the
-deprecated `datetime.utcnow()` calls and the write-side timestamps are done.
-
-**Remaining bug:** `analytics_service.get_episode_analytics` uses caller-supplied
-`date_from`/`date_to` directly in the WHERE clause against naive
-`AnalyticsEvent.created_at`. A `Z`-suffixed query param arrives TZ-aware from FastAPI →
-asyncpg raises "cannot compare timestamp with/without time zone".
-(`get_project_analytics` only uses naive internal bounds — not affected.)
+**Decision (no fork):** `db.rollback()` on the existing session (CodeRabbit design choice 1;
+matches service-layer rollback precedent).
 
 ## Steps
 
-- [x] RED: `test_get_episode_analytics_tz_aware_date_range` failed with the exact
-      asyncpg DataError from the issue.
-- [x] GREEN: shared `to_naive_utc()` helper in `datetime_utils.py`; used in
-      `get_episode_analytics` and `episode_service` date filters.
-- [x] GLM pre-PR review: APPROVE. Took its two minor suggestions: shared helper
-      (also fixes pre-existing non-UTC-offset bug in episode_service) and
-      load-bearing +03:00 offset tests (analytics + episodes).
-- [x] Gates all passed — SHIPPED via PR #369 (1701 tests + coverage gate, GLM APPROVE pre+post-PR + CI review no-defects, live demo verified, CI green, squash-merged, issue #310 closed).
+- [ ] RED: add tests in `apps/api/tests/unit/test_task_retry.py`
+  - broken-tx cleanup: first `db.get` raises, retries exhausted → assert `rollback()` called
+    before cleanup `get`, episode marked `failed`, cleanup `commit()` invoked
+  - graceful degradation: cleanup commit also fails → returns `{"status": "failed", ...}` without raising
+- [ ] GREEN: defensive `db.rollback()` (own try/except, log-and-continue) at start of the
+  `except self.MaxRetriesExceededError:` block, before `db.get(...)`
+- [ ] Quality gate: pytest, ruff, opencode review (pre-PR)
+- [ ] PR, post-PR opencode review comment, demo (Showboat, API-only), CI green, merge


### PR DESCRIPTION
Fixes #311.

## Problem

When the outer try in `finalize_episode_generation_task` fails on a DB error, the session is left in a failed-transaction state. The `MaxRetriesExceededError` cleanup handler reused that same session to mark the episode failed; `db.get(...)` raised `InvalidRequestError`, the inner except only logged it, and the episode stayed stuck in an intermediate status with no recovery.

## Fix

Defensive `db.rollback()` (own try/except, log-and-continue) at the top of the `MaxRetriesExceededError` handler, before the cleanup `get`/`commit` — so the `failed` status is durably persisted. Matches the existing service-layer rollback precedent (issue's primary recommendation; CodeRabbit plan design choice 1). No other commit points or task flow touched.

## Tests (TDD)

Three regression tests in `tests/unit/test_task_retry.py` (RED first — the ordering assertion failed against the old code):

- `test_cleanup_rolls_back_failed_transaction_before_marking_failed` — first `db.get` raises, retries exhausted → asserts `rollback()` lands strictly between the failing get and the cleanup get, episode marked `failed`, cleanup `commit()` invoked.
- `test_cleanup_degrades_gracefully_when_cleanup_commit_fails` — cleanup commit also fails → returns `{"status": "failed", ...}` without raising.
- `test_cleanup_proceeds_when_rollback_itself_fails` — rollback raises → cleanup write still attempted (covers the new defensive branch; added from GLM review).

Full backend suite: **1703 passed, 7 skipped** with coverage gate; ruff clean.

## Third-party review

Pre-PR GLM (opencode) review: **APPROVE**. Its one actionable Minor (uncovered rollback-failure branch) is addressed by the third test. Its follow-up suggestion (sibling tasks sharing the anti-pattern) was swept and ruled out: the other five `MaxRetriesExceededError` handlers either touch no DB or use `_update_episode`, which opens a fresh `SyncSessionLocal`.

## Known Limitations

- Unit tests verify call ordering with mocks rather than reproducing SQLAlchemy's real `InvalidRequestError` failed-transaction state; an integration test forcing a real broken transaction would be a stronger regression proof (noted by GLM as non-blocking).
- If the connection is truly dead (rollback *and* cleanup write both fail), the episode still can't be updated — the task logs and returns a failed result cleanly, but status recovery would need an out-of-band sweep.
