### PR TITLE
Make platform distribution idempotent across redeliveries (#312)

### DIFF
--- a/apps/api/alembic/versions/016_expand_episode_status_check.py
+++ b/apps/api/alembic/versions/016_expand_episode_status_check.py
@@ -43,6 +43,16 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+	# Any environment that ran the workflow now holds rows with
+	# composing/uploading/distributing/distribution_failed; re-adding the
+	# narrow CHECK validates them and fails the downgrade, so normalize first.
+	op.execute(
+		"UPDATE episodes SET generation_status = CASE "
+		"WHEN generation_status = 'distribution_failed' THEN 'failed' "
+		"ELSE 'complete' END "
+		"WHERE generation_status IN "
+		"('composing', 'uploading', 'distributing', 'distribution_failed')"
+	)
 	op.drop_constraint("episodes_status_check", "episodes", type_="check")
 	op.create_check_constraint(
 		"episodes_status_check",

--- a/apps/api/alembic/versions/016_expand_episode_status_check.py
+++ b/apps/api/alembic/versions/016_expand_episode_status_check.py
@@ -1,0 +1,51 @@
+"""Expand episodes_status_check to the full generation_status vocabulary
+
+Revision ID: 016
+Revises: 015
+Create Date: 2026-07-10 00:00:00.000000
+
+Migration 001 allowed only draft/queued/extracting/generating/synthesizing/
+complete/failed, but the workflow also writes 'composing', 'uploading',
+'distributing' (distribution callbacks and the in-task success recording from
+issue #312), and 'distribution_failed' (on_workflow_complete, issue #300).
+Those UPDATEs raised CheckViolation, which the callbacks swallow — so
+per-platform distribution results were silently never recorded. This expands
+the constraint to every status the code writes.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers
+revision: str = "016"
+down_revision: Union[str, None] = "015"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+OLD_STATUSES = (
+	"'draft', 'queued', 'extracting', 'generating', 'synthesizing', "
+	"'complete', 'failed'"
+)
+NEW_STATUSES = (
+	"'draft', 'queued', 'extracting', 'generating', 'synthesizing', "
+	"'composing', 'uploading', 'distributing', 'distribution_failed', "
+	"'complete', 'failed'"
+)
+
+
+def upgrade() -> None:
+	op.drop_constraint("episodes_status_check", "episodes", type_="check")
+	op.create_check_constraint(
+		"episodes_status_check",
+		"episodes",
+		f"generation_status IN ({NEW_STATUSES})",
+	)
+
+
+def downgrade() -> None:
+	op.drop_constraint("episodes_status_check", "episodes", type_="check")
+	op.create_check_constraint(
+		"episodes_status_check",
+		"episodes",
+		f"generation_status IN ({OLD_STATUSES})",
+	)

--- a/apps/api/src/services/apple_podcasts_service.py
+++ b/apps/api/src/services/apple_podcasts_service.py
@@ -58,6 +58,7 @@ class ApplePodcastsService:
 		show_id: str,
 		api_key: str,
 		metadata: Dict[str, Any],
+		idempotency_key: Optional[str] = None,
 	) -> Dict[str, Any]:
 		"""
 		Publish a podcast episode to Apple Podcasts Connect.
@@ -74,6 +75,8 @@ class ApplePodcastsService:
 				- audio_url (str): Publicly accessible audio file URL
 				- publish_date (str): ISO-8601 datetime string
 				- explicit (bool): Whether episode contains explicit content
+			idempotency_key: Stable token sent as an ``Idempotency-Key`` header
+				so a retried publish deduplicates server-side (issue #312)
 
 		Returns:
 			Dict with keys:
@@ -96,6 +99,8 @@ class ApplePodcastsService:
 			"Authorization": f"Bearer {api_key}",
 			"Content-Type": "application/json",
 		}
+		if idempotency_key:
+			headers["Idempotency-Key"] = idempotency_key
 
 		publish_date = metadata.get(
 			"publish_date",

--- a/apps/api/src/services/spotify_service.py
+++ b/apps/api/src/services/spotify_service.py
@@ -8,7 +8,7 @@ Raises typed exceptions to enable selective retry logic:
 """
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import httpx
 
@@ -56,6 +56,7 @@ class SpotifyService:
 		show_id: str,
 		access_token: str,
 		metadata: Dict[str, Any],
+		idempotency_key: Optional[str] = None,
 	) -> Dict[str, Any]:
 		"""
 		Publish a podcast episode to Spotify for Podcasters.
@@ -73,6 +74,8 @@ class SpotifyService:
 				- duration_seconds (float): Episode duration
 				- publish_date (str): ISO-8601 date string (e.g. "2024-01-15")
 				- explicit (bool): Whether episode contains explicit content
+			idempotency_key: Stable token sent as an ``Idempotency-Key`` header
+				so a retried publish deduplicates server-side (issue #312)
 
 		Returns:
 			Dict with keys:
@@ -94,6 +97,8 @@ class SpotifyService:
 			"Authorization": f"Bearer {access_token}",
 			"Content-Type": "application/json",
 		}
+		if idempotency_key:
+			headers["Idempotency-Key"] = idempotency_key
 
 		payload: Dict[str, Any] = {
 			"name": metadata.get("title", ""),

--- a/apps/api/src/tasks/callbacks.py
+++ b/apps/api/src/tasks/callbacks.py
@@ -187,6 +187,51 @@ def on_composition_complete(self: Task, result: Dict[str, Any], episode_id: str)
 	)
 
 
+def record_platform_distribution(
+	episode_id: str, platform: str, result: Dict[str, Any]
+) -> bool:
+	"""
+	Merge a platform's distribution outcome into Episode.generation_progress
+	under a row lock and commit.
+
+	Shared by the on_distribution_complete callback and the distribution task's
+	in-task success recording (issue #312) so both writes produce an identical
+	entry shape — the second write is an idempotent re-merge of the first.
+
+	Returns:
+		True if the episode was found and updated, False otherwise.
+	"""
+	failed = result.get("status") != "success"
+	with SyncSessionLocal() as db:
+		episode = _get_episode_for_update(db, episode_id)
+		if episode is None:
+			logger.error("Episode %s not found in database", episode_id)
+			return False
+
+		current_progress = dict(episode.generation_progress or {})
+		distribution = dict(current_progress.get("distribution", {}))
+		if failed:
+			distribution[platform] = {
+				"status": "failed",
+				"error": result.get("error"),
+				"failed_at": _utcnow_iso(),
+			}
+		else:
+			distribution[platform] = {
+				"status": "complete",
+				"platform_episode_id": result.get("platform_episode_id"),
+				"platform_url": result.get("platform_url"),
+				"distributed_at": _utcnow_iso(),
+			}
+		current_progress["distribution"] = distribution
+		episode.generation_progress = current_progress
+		if not failed:
+			episode.generation_status = "distributing"
+
+		db.commit()
+	return True
+
+
 @celery_app.task(bind=True, name="on_distribution_complete")
 def on_distribution_complete(
 	self: Task, result: Dict[str, Any], episode_id: str, platform: str
@@ -217,33 +262,8 @@ def on_distribution_complete(
 		)
 
 	try:
-		with SyncSessionLocal() as db:
-			episode = _get_episode_for_update(db, episode_id)
-			if episode is None:
-				logger.error("Episode %s not found in database", episode_id)
-				return
-
-			current_progress = dict(episode.generation_progress or {})
-			distribution = dict(current_progress.get("distribution", {}))
-			if failed:
-				distribution[platform] = {
-					"status": "failed",
-					"error": result.get("error"),
-					"failed_at": _utcnow_iso(),
-				}
-			else:
-				distribution[platform] = {
-					"status": "complete",
-					"platform_episode_id": result.get("platform_episode_id"),
-					"platform_url": result.get("platform_url"),
-					"distributed_at": _utcnow_iso(),
-				}
-			current_progress["distribution"] = distribution
-			episode.generation_progress = current_progress
-			if not failed:
-				episode.generation_status = "distributing"
-
-			db.commit()
+		if not record_platform_distribution(episode_id, platform, result):
+			return
 
 		if not failed:
 			logger.info(

--- a/apps/api/src/tasks/platform_distribution.py
+++ b/apps/api/src/tasks/platform_distribution.py
@@ -221,7 +221,9 @@ def distribute_to_platform_task(
         # The on_distribution_complete link callback re-merges the same entry
         # as idempotent redundancy. A recording failure must NOT raise:
         # retrying the task would repeat the platform side effect that just
-        # succeeded.
+        # succeeded. If recording fails AND the worker dies before ack, the
+        # pre-check cannot catch the redelivery — the Idempotency-Key sent
+        # with the publish is the remaining (receiver-side) dedup layer.
         if result.get("status") == "success":
             try:
                 from src.tasks.callbacks import record_platform_distribution

--- a/apps/api/src/tasks/platform_distribution.py
+++ b/apps/api/src/tasks/platform_distribution.py
@@ -60,6 +60,16 @@ def _decrypt_platform_config(config: Dict[str, Any], platform: str) -> Dict[str,
     return decrypted
 
 
+def _idempotency_key(episode_id: str, platform: str) -> str:
+    """
+    Canonical idempotency token for one episode/platform publish (issue #312).
+
+    Stable across Celery redeliveries (acks_late + retries), so the platform
+    API or webhook receiver can deduplicate a repeated publish.
+    """
+    return f"{episode_id}:{platform}"
+
+
 def _merge_episode_metadata(episode: Any, passed_metadata: Dict[str, Any]) -> Dict[str, Any]:
     """
     Build distribution metadata from an Episode row, overlaying any passed-in values.
@@ -134,15 +144,38 @@ def distribute_to_platform_task(
         # passed-in values win.
         from src.models.episode import Episode
         from uuid import UUID as _UUID
+        prior_result = None
         with SyncSessionLocal() as db:
-            episode = db.get(Episode, _UUID(episode_id))
+            # Row lock so the completion check below observes committed state and
+            # cannot race a concurrent callback's read-modify-write (issue #312).
+            episode = db.get(Episode, _UUID(episode_id), with_for_update=True)
             if episode is not None:
-                episode_metadata = _merge_episode_metadata(episode, episode_metadata)
+                progress = getattr(episode, "generation_progress", None) or {}
+                entry = (progress.get("distribution") or {}).get(platform) or {}
+                if entry.get("status") == "complete":
+                    # Redelivery after a recorded success — do not republish.
+                    prior_result = {
+                        "status": "success",
+                        "platform": platform,
+                        "platform_episode_id": entry.get("platform_episode_id"),
+                        "platform_url": entry.get("platform_url"),
+                        "error": None,
+                    }
+                else:
+                    episode_metadata = _merge_episode_metadata(episode, episode_metadata)
             else:
                 logger.warning(
                     "Episode %s not found while building distribution metadata",
                     episode_id,
                 )
+
+        if prior_result is not None:
+            logger.info(
+                "Episode %s already distributed to %s; skipping republish on redelivery.",
+                episode_id,
+                platform,
+            )
+            return prior_result
 
         # Never publish an episode whose audio was not actually uploaded. s3_url is
         # written by on_upload_complete only on a successful upload, so its absence
@@ -182,6 +215,26 @@ def distribute_to_platform_task(
             result = _distribute_via_webhook(episode_id, platform_config, episode_metadata, self)
         else:
             raise ValueError(f"Unsupported platform: {platform}")
+
+        # Record success durably before returning so a redelivery after this
+        # point hits the pre-check above instead of republishing (issue #312).
+        # The on_distribution_complete link callback re-merges the same entry
+        # as idempotent redundancy. A recording failure must NOT raise:
+        # retrying the task would repeat the platform side effect that just
+        # succeeded.
+        if result.get("status") == "success":
+            try:
+                from src.tasks.callbacks import record_platform_distribution
+                record_platform_distribution(episode_id, platform, result)
+            except Exception as exc:
+                logger.error(
+                    "Failed to record %s distribution success for episode %s "
+                    "in-task (callback will retry the record): %s",
+                    platform,
+                    episode_id,
+                    exc,
+                    exc_info=True,
+                )
 
         self.update_state(
             state='SUCCESS',
@@ -305,6 +358,7 @@ def _distribute_to_spotify(episode_id: str, config: Dict, metadata: Dict, task: 
         show_id=show_id,
         access_token=access_token,
         metadata=metadata,
+        idempotency_key=_idempotency_key(episode_id, "spotify"),
     )
 
     logger.info(
@@ -361,6 +415,7 @@ def _distribute_to_apple(episode_id: str, config: Dict, metadata: Dict, task: Ta
         show_id=show_id,
         api_key=api_key,
         metadata=metadata,
+        idempotency_key=_idempotency_key(episode_id, "apple_podcasts"),
     )
 
     logger.info(
@@ -409,13 +464,16 @@ def _distribute_via_webhook(episode_id: str, config: Dict, metadata: Dict, task:
     except SSRFValidationError as exc:
         raise ValueError(f"Webhook URL is not allowed: {exc}") from exc
 
-    headers = config.get('headers', {})
+    idempotency_key = _idempotency_key(episode_id, "webhook")
+    headers = dict(config.get('headers', {}))
+    headers["Idempotency-Key"] = idempotency_key
     method = config.get('method', 'POST')
 
     payload = {
         "episode_id": episode_id,
         "metadata": metadata,
-        "event": "episode_published"
+        "event": "episode_published",
+        "idempotency_key": idempotency_key,
     }
 
     # Send webhook with episode data (redirects disabled to prevent SSRF bounce).

--- a/apps/api/tests/test_episode_status_constraint.py
+++ b/apps/api/tests/test_episode_status_constraint.py
@@ -1,0 +1,52 @@
+"""
+Regression test for issue #312 (found while demoing the idempotency fix).
+
+Migration 001's episodes_status_check allowed only a subset of the
+generation_status values the workflow actually writes. Statuses like
+'distributing' (on_distribution_complete / record_platform_distribution),
+'composing', 'uploading', and 'distribution_failed' (on_workflow_complete)
+raised CheckViolation on commit — which the callbacks swallow, so per-platform
+distribution results were silently never recorded. Migration 016 expands the
+constraint; this test reads the live constraint definition so it can never
+drift behind the code again.
+
+The check is asserted against pg_constraint (SELECT-only) rather than by
+committing rows: full-suite runs currently poison psycopg's Jsonb adaptation
+for sync ORM inserts (see issue filed from #312 work), and an IN-list CHECK
+needs no row-level exercise beyond its definition.
+"""
+from sqlalchemy import text
+
+from src.database import SyncSessionLocal
+
+# Every value assigned to Episode.generation_status anywhere in src/.
+CODE_WRITTEN_STATUSES = [
+    "draft",
+    "queued",
+    "extracting",
+    "generating",
+    "synthesizing",
+    "composing",
+    "uploading",
+    "distributing",
+    "distribution_failed",
+    "complete",
+    "failed",
+]
+
+
+def test_status_check_constraint_allows_all_code_written_statuses():
+    with SyncSessionLocal() as db:
+        condef = db.execute(
+            text(
+                "SELECT pg_get_constraintdef(oid) FROM pg_constraint "
+                "WHERE conname = 'episodes_status_check' "
+                "AND conrelid = 'episodes'::regclass"
+            )
+        ).scalar_one()
+
+    for status in CODE_WRITTEN_STATUSES:
+        assert f"'{status}'" in condef, (
+            f"generation_status '{status}' is written by src/ but rejected by "
+            f"episodes_status_check: {condef}"
+        )

--- a/apps/api/tests/unit/test_distribution_idempotency.py
+++ b/apps/api/tests/unit/test_distribution_idempotency.py
@@ -191,6 +191,30 @@ class TestHelpersForwardIdempotencyKey:
 		assert kwargs["headers"]["Idempotency-Key"] == f"{EPISODE_ID}:webhook"
 		assert kwargs["json"]["idempotency_key"] == f"{EPISODE_ID}:webhook"
 
+	def test_webhook_get_method_carries_key(self):
+		from src.tasks.platform_distribution import _distribute_via_webhook
+
+		session = MagicMock()
+		session.__enter__ = MagicMock(return_value=session)
+		session.__exit__ = MagicMock(return_value=False)
+		response = MagicMock()
+		response.raise_for_status.return_value = None
+		session.get.return_value = response
+
+		with patch(
+			"src.utils.ssrf.validate_public_url", return_value=("1.2.3.4", 443)
+		), patch("src.utils.pinned_fetch.pinned_session", return_value=session):
+			_distribute_via_webhook(
+				EPISODE_ID,
+				{"url": "https://hooks.example.com/x", "method": "GET"},
+				{"title": "T"},
+				MagicMock(),
+			)
+
+		kwargs = session.get.call_args.kwargs
+		assert kwargs["headers"]["Idempotency-Key"] == f"{EPISODE_ID}:webhook"
+		assert kwargs["params"]["idempotency_key"] == f"{EPISODE_ID}:webhook"
+
 
 # ===========================================================================
 # Task-level: pre-publish skip of already-complete platforms
@@ -391,6 +415,37 @@ class TestRecordPlatformDistribution:
 		assert entry["platform_url"] == "https://open.spotify.com/episode/sp_1"
 		assert "distributed_at" in entry
 		session.commit.assert_called_once()
+
+	def test_double_call_is_idempotent_re_merge(self):
+		"""Second write (in-task then callback) re-merges an equivalent entry."""
+		from src.tasks.callbacks import record_platform_distribution
+
+		episode = SimpleNamespace(
+			generation_progress={}, generation_status="distributing"
+		)
+		session = MagicMock()
+		session.__enter__ = MagicMock(return_value=session)
+		session.__exit__ = MagicMock(return_value=False)
+		session.execute.return_value.scalar_one_or_none.return_value = episode
+
+		result = {
+			"status": "success",
+			"platform": "spotify",
+			"platform_episode_id": "sp_1",
+			"platform_url": "https://open.spotify.com/episode/sp_1",
+			"error": None,
+		}
+		with patch("src.tasks.callbacks.SyncSessionLocal", return_value=session):
+			assert record_platform_distribution(EPISODE_ID, "spotify", result) is True
+			first = dict(episode.generation_progress["distribution"]["spotify"])
+			assert record_platform_distribution(EPISODE_ID, "spotify", result) is True
+			second = episode.generation_progress["distribution"]["spotify"]
+
+		# Identical shape and identifiers; only the timestamp may refresh.
+		assert {k: v for k, v in first.items() if k != "distributed_at"} == {
+			k: v for k, v in second.items() if k != "distributed_at"
+		}
+		assert second["status"] == "complete"
 
 	def test_missing_episode_returns_false(self):
 		from src.tasks.callbacks import record_platform_distribution

--- a/apps/api/tests/unit/test_distribution_idempotency.py
+++ b/apps/api/tests/unit/test_distribution_idempotency.py
@@ -1,0 +1,410 @@
+"""
+Unit tests for distribution idempotency (issue #312).
+
+A Celery redelivery of distribute_to_platform_task (acks_late, max_retries=5)
+must not republish an episode: platform publishes carry a stable
+``{episode_id}:{platform}`` Idempotency-Key, platforms already recorded
+complete are skipped, and success is recorded transactionally in-task.
+
+All HTTP and DB interactions are mocked.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+EPISODE_ID = "00000000-0000-0000-0000-000000000001"
+
+
+def _make_httpx_response(status_code: int, json_body: dict | None = None) -> httpx.Response:
+	import json as _json
+
+	return httpx.Response(
+		status_code=status_code,
+		content=_json.dumps(json_body or {}).encode(),
+		request=httpx.Request("POST", "https://example.com"),
+	)
+
+
+def _mock_httpx_client(response: httpx.Response) -> MagicMock:
+	client = MagicMock()
+	client.__enter__ = MagicMock(return_value=client)
+	client.__exit__ = MagicMock(return_value=False)
+	client.post.return_value = response
+	return client
+
+
+def _episode(**overrides):
+	data = {
+		"episode_metadata": {"title": "T", "description": "D"},
+		"duration_seconds": 10.0,
+		"s3_url": "https://bucket.s3.amazonaws.com/e.mp3",
+		"generation_progress": {},
+	}
+	data.update(overrides)
+	return SimpleNamespace(**data)
+
+
+def _mock_session(episode) -> MagicMock:
+	session = MagicMock()
+	session.get.return_value = episode
+	session.__enter__ = MagicMock(return_value=session)
+	session.__exit__ = MagicMock(return_value=False)
+	return session
+
+
+# ===========================================================================
+# Service-level: Idempotency-Key header
+# ===========================================================================
+
+
+class TestSpotifyIdempotencyHeader:
+	def test_key_sets_idempotency_header(self):
+		from src.services.spotify_service import SpotifyService
+
+		body = {"id": "sp_1", "external_urls": {"spotify": "https://open.spotify.com/episode/sp_1"}}
+		client = _mock_httpx_client(_make_httpx_response(200, body))
+		with patch("httpx.Client", return_value=client):
+			SpotifyService().publish_episode(
+				show_id="show1",
+				access_token="tok",
+				metadata={"title": "T"},
+				idempotency_key=f"{EPISODE_ID}:spotify",
+			)
+
+		headers = client.post.call_args.kwargs["headers"]
+		assert headers["Idempotency-Key"] == f"{EPISODE_ID}:spotify"
+
+	def test_no_key_no_header(self):
+		from src.services.spotify_service import SpotifyService
+
+		body = {"id": "sp_1", "external_urls": {"spotify": "https://open.spotify.com/episode/sp_1"}}
+		client = _mock_httpx_client(_make_httpx_response(200, body))
+		with patch("httpx.Client", return_value=client):
+			SpotifyService().publish_episode(
+				show_id="show1", access_token="tok", metadata={"title": "T"}
+			)
+
+		headers = client.post.call_args.kwargs["headers"]
+		assert "Idempotency-Key" not in headers
+
+
+class TestAppleIdempotencyHeader:
+	def test_key_sets_idempotency_header(self):
+		from src.services.apple_podcasts_service import ApplePodcastsService
+
+		body = {"data": {"id": "ap_1", "attributes": {}}}
+		client = _mock_httpx_client(_make_httpx_response(201, body))
+		with patch("httpx.Client", return_value=client):
+			ApplePodcastsService().publish_episode(
+				show_id="show1",
+				api_key="key",
+				metadata={"title": "T"},
+				idempotency_key=f"{EPISODE_ID}:apple_podcasts",
+			)
+
+		headers = client.post.call_args.kwargs["headers"]
+		assert headers["Idempotency-Key"] == f"{EPISODE_ID}:apple_podcasts"
+
+	def test_no_key_no_header(self):
+		from src.services.apple_podcasts_service import ApplePodcastsService
+
+		body = {"data": {"id": "ap_1", "attributes": {}}}
+		client = _mock_httpx_client(_make_httpx_response(201, body))
+		with patch("httpx.Client", return_value=client):
+			ApplePodcastsService().publish_episode(
+				show_id="show1", api_key="key", metadata={"title": "T"}
+			)
+
+		headers = client.post.call_args.kwargs["headers"]
+		assert "Idempotency-Key" not in headers
+
+
+# ===========================================================================
+# Helper-level: key derivation and forwarding
+# ===========================================================================
+
+
+class TestHelpersForwardIdempotencyKey:
+	def test_spotify_helper_forwards_key(self):
+		from src.tasks.platform_distribution import _distribute_to_spotify
+
+		service = MagicMock()
+		service.publish_episode.return_value = {
+			"episode_id": "sp_1",
+			"platform_url": "https://open.spotify.com/episode/sp_1",
+		}
+		with patch("src.services.spotify_service.SpotifyService", return_value=service):
+			_distribute_to_spotify(
+				EPISODE_ID,
+				{"show_id": "show1", "oauth_tokens": {"access_token": "tok"}},
+				{"title": "T"},
+				MagicMock(),
+			)
+
+		kwargs = service.publish_episode.call_args.kwargs
+		assert kwargs["idempotency_key"] == f"{EPISODE_ID}:spotify"
+
+	def test_apple_helper_forwards_key(self):
+		from src.tasks.platform_distribution import _distribute_to_apple
+
+		service = MagicMock()
+		service.publish_episode.return_value = {
+			"episode_id": "ap_1",
+			"platform_url": None,
+		}
+		with patch(
+			"src.services.apple_podcasts_service.ApplePodcastsService",
+			return_value=service,
+		):
+			_distribute_to_apple(
+				EPISODE_ID,
+				{"show_id": "show1", "credentials": {"api_key": "key"}},
+				{"title": "T"},
+				MagicMock(),
+			)
+
+		kwargs = service.publish_episode.call_args.kwargs
+		assert kwargs["idempotency_key"] == f"{EPISODE_ID}:apple_podcasts"
+
+	def test_webhook_includes_key_in_header_and_payload(self):
+		from src.tasks.platform_distribution import _distribute_via_webhook
+
+		session = MagicMock()
+		session.__enter__ = MagicMock(return_value=session)
+		session.__exit__ = MagicMock(return_value=False)
+		response = MagicMock()
+		response.raise_for_status.return_value = None
+		session.post.return_value = response
+
+		with patch(
+			"src.utils.ssrf.validate_public_url", return_value=("1.2.3.4", 443)
+		), patch("src.utils.pinned_fetch.pinned_session", return_value=session):
+			_distribute_via_webhook(
+				EPISODE_ID,
+				{"url": "https://hooks.example.com/x", "method": "POST"},
+				{"title": "T"},
+				MagicMock(),
+			)
+
+		kwargs = session.post.call_args.kwargs
+		assert kwargs["headers"]["Idempotency-Key"] == f"{EPISODE_ID}:webhook"
+		assert kwargs["json"]["idempotency_key"] == f"{EPISODE_ID}:webhook"
+
+
+# ===========================================================================
+# Task-level: pre-publish skip of already-complete platforms
+# ===========================================================================
+
+
+class TestPrePublishSkip:
+	def test_completed_platform_short_circuits(self):
+		from src.tasks.platform_distribution import distribute_to_platform_task
+
+		episode = _episode(
+			generation_progress={
+				"distribution": {
+					"spotify": {
+						"status": "complete",
+						"platform_episode_id": "sp_prior",
+						"platform_url": "https://open.spotify.com/episode/sp_prior",
+						"distributed_at": "2026-07-01T00:00:00+00:00",
+					}
+				}
+			}
+		)
+		session = _mock_session(episode)
+		spotify = MagicMock()
+
+		with patch(
+			"src.tasks.platform_distribution.SyncSessionLocal", return_value=session
+		), patch(
+			"src.tasks.platform_distribution._decrypt_platform_config",
+			side_effect=lambda cfg, plat: cfg,
+		), patch(
+			"src.tasks.platform_distribution._distribute_to_spotify", spotify
+		):
+			distribute_to_platform_task.request.update(id="t-skip")
+			with patch.object(distribute_to_platform_task, "update_state", MagicMock()):
+				result = distribute_to_platform_task.run(
+					episode_id=EPISODE_ID,
+					platform="spotify",
+					platform_config={"show_id": "show1", "oauth_tokens": {}},
+					episode_metadata={},
+				)
+
+		spotify.assert_not_called()
+		assert result["status"] == "success"
+		assert result["platform_episode_id"] == "sp_prior"
+		assert result["platform_url"] == "https://open.spotify.com/episode/sp_prior"
+
+	def test_incomplete_platform_still_publishes(self):
+		from src.tasks.platform_distribution import distribute_to_platform_task
+
+		episode = _episode(
+			generation_progress={"distribution": {"spotify": {"status": "failed"}}}
+		)
+		session = _mock_session(episode)
+		success = {
+			"status": "success",
+			"platform": "spotify",
+			"platform_episode_id": "sp_new",
+			"platform_url": "https://open.spotify.com/episode/sp_new",
+			"error": None,
+		}
+		spotify = MagicMock(return_value=success)
+
+		with patch(
+			"src.tasks.platform_distribution.SyncSessionLocal", return_value=session
+		), patch(
+			"src.tasks.platform_distribution._decrypt_platform_config",
+			side_effect=lambda cfg, plat: cfg,
+		), patch(
+			"src.tasks.platform_distribution._distribute_to_spotify", spotify
+		), patch(
+			"src.tasks.callbacks.record_platform_distribution", MagicMock()
+		):
+			distribute_to_platform_task.request.update(id="t-pub")
+			with patch.object(distribute_to_platform_task, "update_state", MagicMock()):
+				result = distribute_to_platform_task.run(
+					episode_id=EPISODE_ID,
+					platform="spotify",
+					platform_config={"show_id": "show1", "oauth_tokens": {}},
+					episode_metadata={},
+				)
+
+		spotify.assert_called_once()
+		assert result["platform_episode_id"] == "sp_new"
+
+
+# ===========================================================================
+# Task-level: transactional success recording
+# ===========================================================================
+
+
+class TestInTaskSuccessRecording:
+	def test_success_recorded_in_task(self):
+		from src.tasks.platform_distribution import distribute_to_platform_task
+
+		episode = _episode()
+		session = _mock_session(episode)
+		success = {
+			"status": "success",
+			"platform": "spotify",
+			"platform_episode_id": "sp_1",
+			"platform_url": "https://open.spotify.com/episode/sp_1",
+			"error": None,
+		}
+		record = MagicMock()
+
+		with patch(
+			"src.tasks.platform_distribution.SyncSessionLocal", return_value=session
+		), patch(
+			"src.tasks.platform_distribution._decrypt_platform_config",
+			side_effect=lambda cfg, plat: cfg,
+		), patch(
+			"src.tasks.platform_distribution._distribute_to_spotify",
+			MagicMock(return_value=success),
+		), patch(
+			"src.tasks.callbacks.record_platform_distribution", record
+		):
+			distribute_to_platform_task.request.update(id="t-rec")
+			with patch.object(distribute_to_platform_task, "update_state", MagicMock()):
+				result = distribute_to_platform_task.run(
+					episode_id=EPISODE_ID,
+					platform="spotify",
+					platform_config={"show_id": "show1", "oauth_tokens": {}},
+					episode_metadata={},
+				)
+
+		record.assert_called_once_with(EPISODE_ID, "spotify", success)
+		assert result == success
+
+	def test_record_failure_does_not_fail_task(self):
+		"""A DB error while recording must not retry (and thus republish)."""
+		from src.tasks.platform_distribution import distribute_to_platform_task
+
+		episode = _episode()
+		session = _mock_session(episode)
+		success = {
+			"status": "success",
+			"platform": "spotify",
+			"platform_episode_id": "sp_1",
+			"platform_url": "https://open.spotify.com/episode/sp_1",
+			"error": None,
+		}
+
+		with patch(
+			"src.tasks.platform_distribution.SyncSessionLocal", return_value=session
+		), patch(
+			"src.tasks.platform_distribution._decrypt_platform_config",
+			side_effect=lambda cfg, plat: cfg,
+		), patch(
+			"src.tasks.platform_distribution._distribute_to_spotify",
+			MagicMock(return_value=success),
+		), patch(
+			"src.tasks.callbacks.record_platform_distribution",
+			MagicMock(side_effect=RuntimeError("db down")),
+		):
+			distribute_to_platform_task.request.update(id="t-recfail")
+			with patch.object(distribute_to_platform_task, "update_state", MagicMock()):
+				result = distribute_to_platform_task.run(
+					episode_id=EPISODE_ID,
+					platform="spotify",
+					platform_config={"show_id": "show1", "oauth_tokens": {}},
+					episode_metadata={},
+				)
+
+		assert result["status"] == "success"
+
+
+# ===========================================================================
+# record_platform_distribution (shared with on_distribution_complete)
+# ===========================================================================
+
+
+class TestRecordPlatformDistribution:
+	def test_merges_complete_entry_and_commits(self):
+		from src.tasks.callbacks import record_platform_distribution
+
+		episode = SimpleNamespace(
+			generation_progress={}, generation_status="distributing"
+		)
+		session = MagicMock()
+		session.__enter__ = MagicMock(return_value=session)
+		session.__exit__ = MagicMock(return_value=False)
+		session.execute.return_value.scalar_one_or_none.return_value = episode
+
+		result = {
+			"status": "success",
+			"platform": "spotify",
+			"platform_episode_id": "sp_1",
+			"platform_url": "https://open.spotify.com/episode/sp_1",
+			"error": None,
+		}
+		with patch("src.tasks.callbacks.SyncSessionLocal", return_value=session):
+			assert record_platform_distribution(EPISODE_ID, "spotify", result) is True
+
+		entry = episode.generation_progress["distribution"]["spotify"]
+		assert entry["status"] == "complete"
+		assert entry["platform_episode_id"] == "sp_1"
+		assert entry["platform_url"] == "https://open.spotify.com/episode/sp_1"
+		assert "distributed_at" in entry
+		session.commit.assert_called_once()
+
+	def test_missing_episode_returns_false(self):
+		from src.tasks.callbacks import record_platform_distribution
+
+		session = MagicMock()
+		session.__enter__ = MagicMock(return_value=session)
+		session.__exit__ = MagicMock(return_value=False)
+		session.execute.return_value.scalar_one_or_none.return_value = None
+
+		with patch("src.tasks.callbacks.SyncSessionLocal", return_value=session):
+			assert (
+				record_platform_distribution(
+					EPISODE_ID, "spotify", {"status": "success"}
+				)
+				is False
+			)
+		session.commit.assert_not_called()

--- a/apps/web/src/app/(auth)/episodes/[id]/page.tsx
+++ b/apps/web/src/app/(auth)/episodes/[id]/page.tsx
@@ -58,14 +58,25 @@ interface TTSConfig {
 // uses a sentinel that maps back to null when applied (#299).
 const TTS_DEFAULT_SENTINEL = "__default__"
 
-const ACTIVE_STATUSES = ["queued", "extracting", "generating", "synthesizing", "uploading"]
+const ACTIVE_STATUSES = [
+  "queued",
+  "extracting",
+  "generating",
+  "synthesizing",
+  "composing",
+  "uploading",
+  "distributing",
+]
 
 const STATUS_MESSAGES: Record<string, string> = {
   queued: "Queued for generation...",
   extracting: "Extracting content from sources...",
   generating: "Generating podcast transcript...",
   synthesizing: "Synthesizing audio...",
+  composing: "Composing final audio...",
   uploading: "Uploading audio...",
+  distributing: "Distributing to platforms...",
+  distribution_failed: "Distribution failed",
   complete: "Generation complete",
   failed: "Generation failed",
 }
@@ -455,7 +466,10 @@ export default function EpisodePage() {
       extracting: "text-accent-foreground",
       generating: "text-accent-foreground",
       synthesizing: "text-accent-foreground",
+      composing: "text-accent-foreground",
       uploading: "text-accent-foreground",
+      distributing: "text-accent-foreground",
+      distribution_failed: "text-destructive",
       complete: "text-foreground",
       failed: "text-destructive",
     }

--- a/apps/web/src/app/(auth)/projects/[id]/page.tsx
+++ b/apps/web/src/app/(auth)/projects/[id]/page.tsx
@@ -249,6 +249,10 @@ export default function ProjectPage() {
       extracting: "bg-accent text-accent-foreground",
       generating: "bg-accent text-accent-foreground",
       synthesizing: "bg-accent text-accent-foreground",
+      composing: "bg-accent text-accent-foreground",
+      uploading: "bg-accent text-accent-foreground",
+      distributing: "bg-accent text-accent-foreground",
+      distribution_failed: "bg-destructive/20 text-destructive",
       complete: "bg-muted text-foreground",
       failed: "bg-destructive/20 text-destructive",
     }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,22 +1,29 @@
-# Issue #311 — Rollback before cleanup write in finalize_episode_generation_task
+# Issue #312 — Distribution idempotency (P3.9)
 
-**Problem:** When the outer try in `finalize_episode_generation_task` fails on a DB error,
-the session is left in a failed-transaction state. The `MaxRetriesExceededError` handler
-(apps/api/src/tasks/podcast_generation.py:708-725) reuses that same session to mark the
-episode failed; `db.get(...)` raises `InvalidRequestError`, the inner except logs it, and
-the episode is stuck in an intermediate status.
+**Problem**: `distribute_to_platform_task` (max_retries=5, acks_late) has no idempotency guard —
+a redelivery after a successful publish re-publishes to Spotify/Apple or re-POSTs the webhook.
 
-**Decision (no fork):** `db.rollback()` on the existing session (CodeRabbit design choice 1;
-matches service-layer rollback precedent).
+**Plan source**: CodeRabbit comment (verified against current code 2026-07-10; matches exactly).
+**Design choice**: record success in-task via existing `generation_progress["distribution"]` +
+`SELECT FOR UPDATE` pattern (no new table). Callback stays as idempotent redundancy.
 
 ## Steps
 
-- [x] RED: ordering test failed on unfixed code (`['__enter__','get','get','commit','__exit__']` — no rollback)
-- [x] GREEN: defensive `db.rollback()` at start of the `MaxRetriesExceededError` handler
-- [x] GLM pre-PR review: APPROVE; took its Minor (cover rollback-failure branch → 3rd test)
-- [x] GLM post-PR review: APPROVE; took its Minor (rework 3rd test to faithful SQLAlchemy
-      semantics — cleanup get raises `PendingRollbackError` after failed rollback) + 2 nits
-- [x] SHIPPED via PR #370 — 1703 passed + coverage gate, CI review bots "no defects" (both
-      commits), real-Postgres demo posted to PR, CI green, squash-merged, issue #311 closed.
-      Sibling-handler sweep: anti-pattern unique to finalize (others use fresh-session
-      `_update_episode` or no DB).
+- [ ] 1. Tests first (RED): unit tests in `apps/api/tests/unit/`
+  - services: `publish_episode(idempotency_key=...)` sets `Idempotency-Key` header; absent → no header
+  - webhook: key in header AND payload
+  - task: platform already `complete` in generation_progress → short-circuit, no publish/POST, returns stored result
+  - task: after successful publish, success merged into `generation_progress["distribution"][platform]` in-task (locked session)
+- [ ] 2. `spotify_service.py` / `apple_podcasts_service.py`: optional `idempotency_key` param → `Idempotency-Key` header
+- [ ] 3. `platform_distribution.py`:
+  - derive `key = f"{episode_id}:{platform}"` in task; thread through `_distribute_to_spotify/_apple/_via_webhook`
+  - webhook: key as header + `idempotency_key` payload field (keep SSRF pinning/`allow_redirects=False`)
+  - pre-check: read episode `with_for_update` in existing session; skip if `distribution[platform].status == "complete"`
+  - after success result: locked merge of completion entry (same shape as `on_distribution_complete`); share the merge helper with callbacks.py to avoid drift
+- [ ] 4. Full test suite + lint (ruff/mypy) green
+- [ ] 5. Deslop scan, third-party review (opencode/GLM pre-PR), PR, demo, CI gate, merge
+
+## Acceptance criteria (from issue)
+- Pre-publish check skips platforms already recorded complete (locked read)
+- Stable `{episode_id}:{platform}` idempotency key passed to platform API + webhook payload/header
+- Success recorded transactionally


### PR DESCRIPTION
Fixes #312.

## Problem
`distribute_to_platform_task` (max_retries=5, acks_late) publishes to Spotify/Apple and POSTs the webhook with no idempotency token and no pre-check of prior success. A redelivery (worker crash after the side effect, or exception after publish) republishes the episode / re-POSTs the webhook.

## Changes
- **Stable idempotency key**: `{episode_id}:{platform}` (canonical helper `_idempotency_key`) sent as an `Idempotency-Key` header on Spotify/Apple `publish_episode` and on the webhook request — plus an `idempotency_key` field in the webhook JSON payload. SSRF pinning and `allow_redirects=False` untouched.
- **Pre-publish completion check**: the task's existing episode read is now `with_for_update=True`; if `generation_progress["distribution"][platform].status == "complete"`, the task returns the previously recorded result without calling the platform or webhook.
- **Transactional success recording in-task**: the locked merge in `on_distribution_complete` is extracted into `record_platform_distribution()` (callbacks.py); the task calls it immediately after a successful publish, narrowing the crash window. The link callback remains and re-merges the identical entry as idempotent redundancy. A recording failure logs and does not raise — retrying would repeat the side effect just performed.

## Plan deviation (minor)
The CodeRabbit plan threaded the key through the `_distribute_*` helper signatures; instead each helper derives it from the shared `_idempotency_key()` helper — same canonical key everywhere, shorter diff, no signature churn.

## Testing
- 13 new unit tests (`tests/unit/test_distribution_idempotency.py`): header injection/absence for both services, webhook header+payload, pre-publish skip, still-publishes-when-not-complete, in-task recording, recording-failure tolerance, shared merge function.
- Full backend suite: 1717 passed, 7 skipped; coverage 94.04% (gate 85%). ruff clean.

## Third-party review
Pre-PR review by opencode (GLM): verdict sound, no Critical/Major defects (traced redelivery, crash-window, and concurrent-callback races).

## Known Limitations
- Spotify/Apple/webhook receivers must honor `Idempotency-Key` for full dedup; the locked pre-check + in-task recording close the redelivery window on our side regardless.
- A crash in the window between the platform side effect and the in-task commit still relies on the receiver honoring the key (inherent without receiver-side dedup).

## Additional fixes found during demo verification
- **Migration 016** (`016_expand_episode_status_check.py`): migration 001's `episodes_status_check` rejected `composing`/`uploading`/`distributing`/`distribution_failed` — statuses the workflow writes. The callbacks swallowed the CheckViolation, so per-platform distribution results were **silently never recorded in production**, which would also have defeated this PR's pre-check. Found by demoing against the real schema; regression test `test_episode_status_constraint.py` asserts the live constraint covers every code-written status.
- **Web**: labels/colors/active-polling for the now-actually-persisted statuses (`composing`, `uploading`, `distributing`, `distribution_failed`) on the episode and project pages.
- **Filed #372**: pre-existing test-isolation bug (mocked-podcastfy workflow tests poison psycopg Jsonb adaptation for later sync ORM inserts) discovered while writing the regression test.