### PR TITLE
Durable storage-erasure outbox + GC worker for delete flows (#366)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -310,10 +310,15 @@ jobs:
             fi
 
             echo "Starting Celery worker..."
+            # -B runs beat embedded in this single worker process: no separate
+            # deployment starts a standalone beat process, so without it
+            # nothing schedules reap_stuck_episodes or drain_storage_deletion_outbox
+            # (issue #366). Only safe with exactly one worker process — running
+            # -B on more than one would double-schedule every beat task.
             pm2 start uv \
               --name podcaststudiohub-celery \
               --cwd $SERVER_PATH/api \
-              -- run celery -A src.worker:celery_app worker --loglevel=info
+              -- run celery -A src.worker:celery_app worker -B --loglevel=info
 
             pm2 save
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ podcaststudiohub/
 ├── apps/
 │   ├── api/              # FastAPI backend (Python, uv)
 │   │   ├── src/          # Application code (api, routers, services, tasks, models, schemas, middleware, utils)
-│   │   ├── alembic/      # DB migrations (versions/ up to 014_…)
+│   │   ├── alembic/      # DB migrations (versions/ up to 017_…)
 │   │   ├── tests/        # pytest + pytest-bdd
 │   │   └── pyproject.toml
 │   └── web/              # Next.js 15 frontend (TypeScript, App Router)

--- a/apps/api/alembic/versions/017_add_storage_deletion_outbox.py
+++ b/apps/api/alembic/versions/017_add_storage_deletion_outbox.py
@@ -1,0 +1,59 @@
+"""Add storage_deletion_outbox table for durable storage erasure (issue #366)
+
+Revision ID: 017
+Revises: 016
+Create Date: 2026-07-10 00:00:00.000000
+
+delete_episode and erase_user used to best-effort delete S3/local storage
+before committing the DB row delete. Two orphan windows followed: a commit
+failure after storage deletion left rows pointing at deleted audio, and a
+Celery task finishing after the row was gone re-uploaded audio nobody could
+ever find again (no s3:ListBucket). This table is a durable outbox: delete
+flows insert a row per key/path in the same transaction as the row delete,
+so a failed commit leaves storage untouched, and a periodic GC worker
+(drain_storage_deletion_outbox) retries deletion until it succeeds.
+
+Deliberately has NO Row-Level Security: it is never API-exposed, and the GC
+worker must drain rows across every tenant in one pass.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers
+revision: str = "017"
+down_revision: Union[str, None] = "016"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+	op.create_table(
+		"storage_deletion_outbox",
+		sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+		sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=True),
+		sa.Column("s3_key", sa.Text(), nullable=True),
+		sa.Column("file_path", sa.Text(), nullable=True),
+		sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+		sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+		sa.Column("last_attempt_at", sa.DateTime(), nullable=True),
+		sa.CheckConstraint(
+			"s3_key IS NOT NULL OR file_path IS NOT NULL",
+			name="storage_deletion_outbox_key_or_path_check",
+		),
+	)
+
+	op.create_index(
+		"ix_storage_deletion_outbox_created_at",
+		"storage_deletion_outbox",
+		["created_at"],
+	)
+
+	# Non-superuser app role must be able to read/write this table (issue #308).
+	op.execute("GRANT ALL ON storage_deletion_outbox TO podcastfy_app")
+
+
+def downgrade() -> None:
+	op.drop_table("storage_deletion_outbox")

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -86,6 +86,7 @@ class Settings(BaseSettings):
     CELERY_BROKER_VISIBILITY_TIMEOUT: int = 2400  # 40m — keep in-flight msgs from redelivering
     EPISODE_REAP_THRESHOLD_SECONDS: int = 2700    # 45m — reaper fails genuinely-stuck episodes
     REAP_STUCK_EPISODES_INTERVAL_SECONDS: int = 300  # reaper cadence
+    STORAGE_GC_INTERVAL_SECONDS: int = 300  # storage-deletion-outbox drain cadence (issue #366)
 
     # Spotify OAuth
     SPOTIFY_CLIENT_ID: Optional[str] = None

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -17,6 +17,7 @@ from .team_invitation import TeamInvitation
 from .billing_subscription import BillingSubscription, SubscriptionTier, SubscriptionStatus
 from .billing_usage import BillingUsage
 from .analytics_event import AnalyticsEvent
+from .storage_deletion_outbox import StorageDeletionOutbox
 
 __all__ = [
     "User",
@@ -38,4 +39,5 @@ __all__ = [
     "SubscriptionStatus",
     "BillingUsage",
     "AnalyticsEvent",
+    "StorageDeletionOutbox",
 ]

--- a/apps/api/src/models/storage_deletion_outbox.py
+++ b/apps/api/src/models/storage_deletion_outbox.py
@@ -1,0 +1,48 @@
+"""StorageDeletionOutbox model — durable storage-erasure queue (issue #366).
+
+Delete flows (delete_episode, erase_user) insert a row here in the same
+transaction as the row delete, instead of best-effort deleting from S3/local
+storage before commit. A periodic GC worker (drain_storage_deletion_outbox)
+retries deletion until it succeeds and removes the row.
+
+Deliberately has NO Row-Level Security (see migration 017): it is never
+API-exposed, and the GC worker must drain rows across every tenant. tenant_id
+is kept as a plain nullable UUID (no FK) so a row can outlive the user row it
+was queued for.
+"""
+from sqlalchemy import CheckConstraint, Column, DateTime, Index, Integer, Text
+from sqlalchemy.dialects.postgresql import UUID
+import uuid
+
+from ..database import Base
+from ..utils.datetime_utils import utcnow
+
+
+class StorageDeletionOutbox(Base):
+    """Queued storage deletion: one S3 key or local file path per row."""
+
+    __tablename__ = "storage_deletion_outbox"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_id = Column(UUID(as_uuid=True), nullable=True)
+
+    s3_key = Column(Text, nullable=True)
+    file_path = Column(Text, nullable=True)
+
+    attempts = Column(Integer, nullable=False, default=0)
+    created_at = Column(DateTime, default=utcnow, nullable=False)
+    last_attempt_at = Column(DateTime, nullable=True)
+
+    __table_args__ = (
+        Index("ix_storage_deletion_outbox_created_at", "created_at"),
+        CheckConstraint(
+            "s3_key IS NOT NULL OR file_path IS NOT NULL",
+            name="storage_deletion_outbox_key_or_path_check",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<StorageDeletionOutbox(id={self.id}, s3_key={self.s3_key}, "
+            f"file_path={self.file_path}, attempts={self.attempts})>"
+        )

--- a/apps/api/src/services/episode_service.py
+++ b/apps/api/src/services/episode_service.py
@@ -17,6 +17,7 @@ from typing import Optional, List
 from fastapi import HTTPException, status
 
 from ..models import Episode, Project
+from ..models.content_source import ContentSource
 from ..models.episode_composition import EpisodeComposition
 from ..models.storage_deletion_outbox import StorageDeletionOutbox
 from ..schemas.episode import EpisodeCreate, EpisodeUpdate, BatchEpisodeCreate
@@ -347,10 +348,24 @@ async def delete_episode(
 	)
 	composition = composition_result.scalar_one_or_none()
 
+	# Content sources cascade-delete with the episode; their uploaded source
+	# objects (PDFs/images) are referenced only via source_data["s3_key"], so
+	# they must be queued too. Unlocked read: the key is written at upload
+	# time by API requests, never by late Celery tasks (same reasoning as
+	# erase_user's content-source collection).
+	sources_result = await db.execute(
+		select(ContentSource.source_data).where(ContentSource.episode_id == episode.id)
+	)
+	source_keys = [
+		key for (source_data,) in sources_result.all()
+		if (key := (source_data or {}).get("s3_key"))
+	]
+
 	s3_keys = [
 		key for key in (
 			episode.s3_key,
 			composition.composed_s3_key if composition else None,
+			*source_keys,
 		) if key
 	]
 	for key in s3_keys:

--- a/apps/api/src/services/episode_service.py
+++ b/apps/api/src/services/episode_service.py
@@ -334,8 +334,16 @@ async def delete_episode(
 		db: Database session
 		episode: Episode instance to delete
 	"""
+	# Re-read the episode (and composition) under lock before collecting keys:
+	# a Celery task can persist s3_key between the caller's fetch and this
+	# delete. The lock serializes against the callbacks' SELECT ... FOR UPDATE
+	# and finalize's UPDATE, so either the fresh key is collected here, or the
+	# task sees the row gone and absorbs the orphan itself (issue #366).
+	await db.refresh(episode, with_for_update=True)
 	composition_result = await db.execute(
-		select(EpisodeComposition).where(EpisodeComposition.episode_id == episode.id)
+		select(EpisodeComposition)
+		.where(EpisodeComposition.episode_id == episode.id)
+		.with_for_update()
 	)
 	composition = composition_result.scalar_one_or_none()
 

--- a/apps/api/src/services/episode_service.py
+++ b/apps/api/src/services/episode_service.py
@@ -6,7 +6,6 @@ status filtering, and generation status management. RLS ensures tenant isolation
 """
 
 import logging
-import os
 
 from datetime import datetime
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -19,9 +18,10 @@ from fastapi import HTTPException, status
 
 from ..models import Episode, Project
 from ..models.episode_composition import EpisodeComposition
+from ..models.storage_deletion_outbox import StorageDeletionOutbox
 from ..schemas.episode import EpisodeCreate, EpisodeUpdate, BatchEpisodeCreate
+from ..tasks.maintenance import drain_storage_deletion_outbox
 from ..utils.datetime_utils import to_naive_utc
-from .storage_service import StorageService
 
 logger = logging.getLogger(__name__)
 
@@ -320,10 +320,15 @@ async def delete_episode(
 	Unlike projects, episodes use hard delete (no soft delete).
 	Cascade deletes related content sources.
 
-	Best-effort removes the episode's S3 audio object, its EpisodeComposition's
-	composed S3 audio object (if any), and local file artifacts (episode audio,
-	transcript, composed audio) before deleting the database row. Storage and
-	filesystem cleanup failures are logged but never block the DB delete.
+	Queues the episode's S3 audio object, its EpisodeComposition's composed S3
+	audio object (if any), and local file artifacts (episode audio, transcript,
+	composed audio) onto the durable storage_deletion_outbox in the same
+	transaction as the row delete, instead of deleting from storage inline
+	(issue #366). A commit failure here therefore leaves storage untouched —
+	nothing is deleted from S3/disk until the row delete itself is durable. The
+	GC worker (drain_storage_deletion_outbox) performs the actual deletion,
+	retrying until it succeeds; a best-effort post-commit trigger below makes
+	that happen promptly instead of waiting for the next beat tick.
 
 	Args:
 		db: Database session
@@ -340,13 +345,8 @@ async def delete_episode(
 			composition.composed_s3_key if composition else None,
 		) if key
 	]
-	if s3_keys:
-		storage = StorageService()
-		for key in s3_keys:
-			try:
-				await storage.delete_file(key)
-			except Exception:
-				logger.warning(f"Failed to delete S3 object {key} for episode {episode.id}")
+	for key in s3_keys:
+		db.add(StorageDeletionOutbox(tenant_id=episode.tenant_id, s3_key=key))
 
 	local_paths = [
 		path for path in (
@@ -356,13 +356,16 @@ async def delete_episode(
 		) if path
 	]
 	for path in local_paths:
-		try:
-			os.remove(path)
-		except OSError:
-			logger.warning(f"Failed to remove local file {path} for episode {episode.id}")
+		db.add(StorageDeletionOutbox(tenant_id=episode.tenant_id, file_path=path))
 
 	await db.delete(episode)
 	await db.commit()
+
+	if s3_keys or local_paths:
+		try:
+			drain_storage_deletion_outbox.delay()
+		except Exception:
+			logger.warning(f"Failed to trigger storage deletion drain for episode {episode.id}")
 
 
 async def batch_create_episodes(

--- a/apps/api/src/services/offboarding_service.py
+++ b/apps/api/src/services/offboarding_service.py
@@ -1,7 +1,6 @@
 """Tenant offboarding service — GDPR-style account erasure (issue #308)."""
 
 import logging
-import os
 
 from fastapi import HTTPException, status
 from sqlalchemy import delete, func, select
@@ -13,8 +12,9 @@ from ..models.episode import Episode
 from ..models.episode_composition import EpisodeComposition
 from ..models.project import Project
 from ..models.rss_feed import RSSFeed
+from ..models.storage_deletion_outbox import StorageDeletionOutbox
 from ..models.user import User
-from .storage_service import StorageService
+from ..tasks.maintenance import drain_storage_deletion_outbox
 
 logger = logging.getLogger(__name__)
 
@@ -30,17 +30,22 @@ async def erase_user(db: AsyncSession, user: User) -> dict:
 	local file artifacts (GDPR-style tenant offboarding / right to erasure).
 
 	Collects S3 keys and local paths from the user's episodes, episode
-	compositions, audio snippets, RSS feeds, and content sources, then
-	best-effort deletes each — failures are logged but never block erasure.
-	Every tenant row (billing rows included — see migration 010) cascades via
-	`ON DELETE CASCADE` once the user row itself is deleted.
+	compositions, audio snippets, RSS feeds, and content sources, then queues
+	each onto the durable storage_deletion_outbox in the same transaction as
+	the user row delete (issue #366) instead of deleting from storage inline —
+	a commit failure therefore leaves storage untouched. The GC worker
+	(drain_storage_deletion_outbox) performs the actual deletion, retrying
+	until it succeeds; a best-effort post-commit trigger below makes that
+	happen promptly instead of waiting for the next beat tick. Every tenant row
+	(billing rows included — see migration 010) cascades via `ON DELETE
+	CASCADE` once the user row itself is deleted.
 
 	Args:
 		db: Database session (tenant context must already be armed for this user)
 		user: User instance to erase
 
 	Returns:
-		Summary dict with counts of S3 objects and local files erased
+		Summary dict with counts of S3 objects and local files queued for deletion
 
 	Raises:
 		HTTPException: 409 if any of the user's episodes is still generating
@@ -108,23 +113,10 @@ async def erase_user(db: AsyncSession, user: User) -> dict:
 	)
 	local_paths.extend(snippet.file_path for snippet in snippets if snippet.file_path)
 
-	failed_keys = []
-	if s3_keys:
-		storage = StorageService()
-		for key in s3_keys:
-			try:
-				await storage.delete_file(key)
-			except Exception:
-				failed_keys.append(key)
-				logger.warning(f"Failed to delete S3 object {key} for user {user.id}")
-
-	failed_paths = []
+	for key in s3_keys:
+		db.add(StorageDeletionOutbox(tenant_id=user.tenant_id, s3_key=key))
 	for path in local_paths:
-		try:
-			os.remove(path)
-		except OSError:
-			failed_paths.append(path)
-			logger.warning(f"Failed to remove local file {path} for user {user.id}")
+		db.add(StorageDeletionOutbox(tenant_id=user.tenant_id, file_path=path))
 
 	# Core DELETE (not ORM db.delete) so the ORM doesn't load and walk the full
 	# relationship graph — Postgres ON DELETE CASCADE removes the child rows.
@@ -135,18 +127,21 @@ async def erase_user(db: AsyncSession, user: User) -> dict:
 	# Audit record of the erasure, emitted before commit — after commit the user
 	# row is gone and this log line is the only durable trace of what happened.
 	logger.info(
-		"account erasure: user=%s tenant=%s s3_deleted=%d s3_failed=%s "
-		"local_deleted=%d local_failed=%s",
+		"account erasure: user=%s tenant=%s s3_queued=%d local_queued=%d",
 		user.id,
 		user.tenant_id,
-		len(s3_keys) - len(failed_keys),
-		failed_keys or "none",
-		len(local_paths) - len(failed_paths),
-		failed_paths or "none",
+		len(s3_keys),
+		len(local_paths),
 	)
 	await db.commit()
 
+	if s3_keys or local_paths:
+		try:
+			drain_storage_deletion_outbox.delay()
+		except Exception:
+			logger.warning(f"Failed to trigger storage deletion drain for user {user.id}")
+
 	return {
-		"s3_objects_deleted": len(s3_keys) - len(failed_keys),
-		"local_files_deleted": len(local_paths) - len(failed_paths),
+		"s3_objects_queued": len(s3_keys),
+		"local_files_queued": len(local_paths),
 	}

--- a/apps/api/src/services/offboarding_service.py
+++ b/apps/api/src/services/offboarding_service.py
@@ -70,7 +70,15 @@ async def erase_user(db: AsyncSession, user: User) -> dict:
 	projects_result = await db.execute(select(Project.id).where(Project.user_id == user.id))
 	project_ids = [row[0] for row in projects_result.all()]
 
-	episodes_result = await db.execute(select(Episode).where(Episode.user_id == user.id))
+	# Episodes and compositions are read FOR UPDATE: a Celery task can persist
+	# s3_key between an unlocked read and the commit below. The lock serializes
+	# against the callbacks' SELECT ... FOR UPDATE and finalize's UPDATE, so
+	# either the fresh key is collected here, or the task sees the rows gone
+	# and absorbs the orphan itself (issue #366). Snippets/RSS/content sources
+	# are only written by API requests, not late tasks — no lock needed.
+	episodes_result = await db.execute(
+		select(Episode).where(Episode.user_id == user.id).with_for_update()
+	)
 	episodes = episodes_result.scalars().all()
 	episode_ids = [episode.id for episode in episodes]
 
@@ -78,7 +86,9 @@ async def erase_user(db: AsyncSession, user: User) -> dict:
 	content_sources = []
 	if episode_ids:
 		compositions_result = await db.execute(
-			select(EpisodeComposition).where(EpisodeComposition.episode_id.in_(episode_ids))
+			select(EpisodeComposition)
+			.where(EpisodeComposition.episode_id.in_(episode_ids))
+			.with_for_update()
 		)
 		compositions = compositions_result.scalars().all()
 

--- a/apps/api/src/tasks/callbacks.py
+++ b/apps/api/src/tasks/callbacks.py
@@ -14,10 +14,39 @@ from sqlalchemy import select
 
 from src.database import SyncSessionLocal
 from src.models.episode import Episode
+from src.models.storage_deletion_outbox import StorageDeletionOutbox
 from src.tasks.s3_upload import _cleanup_temp_file
 from src.worker import celery_app
 
 logger = logging.getLogger(__name__)
+
+
+def _queue_orphaned_storage(
+	s3_key: Optional[str] = None,
+	file_path: Optional[str] = None,
+	tenant_id: Optional[uuid_module.UUID] = None,
+) -> None:
+	"""Queue a still-existing storage artifact for deletion when its episode
+	row is gone (issue #366).
+
+	Closes the TOCTOU window where a Celery task persists an S3 object or
+	local file *after* the episode row it belongs to (and any keys a delete
+	flow collected) has already been deleted. Without this the artifact would
+	be orphaned forever — IAM has no s3:ListBucket, so orphans are unfindable.
+	Opens its own session: the caller's session may already be in a failed
+	transaction state.
+	"""
+	if not s3_key and not file_path:
+		return
+	try:
+		with SyncSessionLocal() as db:
+			db.add(StorageDeletionOutbox(tenant_id=tenant_id, s3_key=s3_key, file_path=file_path))
+			db.commit()
+	except Exception as exc:
+		logger.error(
+			"Failed to queue orphaned storage (s3_key=%s, file_path=%s) for deletion: %s",
+			s3_key, file_path, exc, exc_info=True,
+		)
 
 
 def _utcnow_iso() -> str:
@@ -104,24 +133,38 @@ def on_upload_complete(self: Task, result: Dict[str, Any], episode_id: str) -> N
 		)
 		return
 
-	updated = _update_episode(
-		episode_id,
-		# Do NOT set generation_status here: upload has already completed, so
-		# "uploading" would briefly regress the status. The workflow chain's
-		# next task (or on_workflow_complete) owns status progression (issue #220).
-		updates={
-			"s3_url": result.get("s3_url"),
-			"s3_key": result.get("s3_key"),
-		},
-		progress_updates={
-			"upload": "complete",
-			"uploaded_at": _utcnow_iso(),
-		},
-	)
-	if updated:
-		logger.info(
-			"Episode %s updated with S3 URL: %s", episode_id, result.get("s3_url")
+	s3_key = result.get("s3_key")
+	try:
+		with SyncSessionLocal() as db:
+			episode = _get_episode_for_update(db, episode_id)
+			if episode is None:
+				# The episode was deleted after this upload started (issue #366):
+				# the object just landed in S3 with nothing left to reference it.
+				logger.error("Episode %s not found in database", episode_id)
+				_queue_orphaned_storage(s3_key=s3_key)
+				return
+
+			# Do NOT set generation_status here: upload has already completed, so
+			# "uploading" would briefly regress the status. The workflow chain's
+			# next task (or on_workflow_complete) owns status progression (issue #220).
+			episode.s3_url = result.get("s3_url")
+			episode.s3_key = s3_key
+			current_progress = dict(episode.generation_progress or {})
+			current_progress.update({
+				"upload": "complete",
+				"uploaded_at": _utcnow_iso(),
+			})
+			episode.generation_progress = current_progress
+			db.commit()
+	except Exception as exc:
+		logger.error(
+			"Failed to update episode %s: %s", episode_id, exc, exc_info=True
 		)
+		return
+
+	logger.info(
+		"Episode %s updated with S3 URL: %s", episode_id, result.get("s3_url")
+	)
 
 
 @celery_app.task(bind=True, name="on_composition_complete")

--- a/apps/api/src/tasks/callbacks.py
+++ b/apps/api/src/tasks/callbacks.py
@@ -5,6 +5,7 @@ These tasks are triggered by Celery's link/link_error mechanism and update the
 Episode record in the database with the results of each workflow stage.
 """
 import logging
+import time
 import uuid as uuid_module
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
@@ -15,17 +16,20 @@ from sqlalchemy import select
 from src.database import SyncSessionLocal
 from src.models.episode import Episode
 from src.models.storage_deletion_outbox import StorageDeletionOutbox
+from src.tasks.retry_utils import calculate_backoff
 from src.tasks.s3_upload import _cleanup_temp_file
 from src.worker import celery_app
 
 logger = logging.getLogger(__name__)
+
+_QUEUE_ORPHAN_ATTEMPTS = 3
 
 
 def _queue_orphaned_storage(
 	s3_key: Optional[str] = None,
 	file_path: Optional[str] = None,
 	tenant_id: Optional[uuid_module.UUID] = None,
-) -> None:
+) -> bool:
 	"""Queue a still-existing storage artifact for deletion when its episode
 	row is gone (issue #366).
 
@@ -35,18 +39,33 @@ def _queue_orphaned_storage(
 	be orphaned forever — IAM has no s3:ListBucket, so orphans are unfindable.
 	Opens its own session: the caller's session may already be in a failed
 	transaction state.
+
+	The insert is retried inline (a Celery-level retry can't help: once the
+	episode row is gone the retried task can no longer derive the key). If
+	every attempt fails, the key/path is logged at CRITICAL — that log line
+	is deliberately the last-resort durable trace for manual cleanup.
 	"""
 	if not s3_key and not file_path:
-		return
-	try:
-		with SyncSessionLocal() as db:
-			db.add(StorageDeletionOutbox(tenant_id=tenant_id, s3_key=s3_key, file_path=file_path))
-			db.commit()
-	except Exception as exc:
-		logger.error(
-			"Failed to queue orphaned storage (s3_key=%s, file_path=%s) for deletion: %s",
-			s3_key, file_path, exc, exc_info=True,
-		)
+		return True
+	for attempt in range(_QUEUE_ORPHAN_ATTEMPTS):
+		try:
+			with SyncSessionLocal() as db:
+				db.add(StorageDeletionOutbox(tenant_id=tenant_id, s3_key=s3_key, file_path=file_path))
+				db.commit()
+			return True
+		except Exception as exc:
+			logger.warning(
+				"Outbox insert for orphaned storage failed (attempt %d/%d, s3_key=%s, file_path=%s): %s",
+				attempt + 1, _QUEUE_ORPHAN_ATTEMPTS, s3_key, file_path, exc, exc_info=True,
+			)
+			if attempt < _QUEUE_ORPHAN_ATTEMPTS - 1:
+				time.sleep(calculate_backoff(attempt, base=1))
+	logger.critical(
+		"PERMANENT ORPHAN RISK: could not queue orphaned storage after %d attempts "
+		"(s3_key=%s, file_path=%s) — manual deletion needed",
+		_QUEUE_ORPHAN_ATTEMPTS, s3_key, file_path,
+	)
+	return False
 
 
 def _utcnow_iso() -> str:

--- a/apps/api/src/tasks/maintenance.py
+++ b/apps/api/src/tasks/maintenance.py
@@ -112,25 +112,34 @@ def drain_storage_deletion_outbox(self: Task) -> int:
     drain; no ``self.retry`` is used here since the beat schedule and the
     delete flows' prompt trigger both already re-run this task.
 
-    Loops while a full batch was processed so a backlog drains in one
-    invocation. Returns the total number of rows successfully drained.
+    Rows are fetched lowest-``attempts`` first so a head of long-failing rows
+    never starves newer, deletable work behind it; ``created_at`` breaks ties
+    for FIFO within a retry generation. Each row is attempted at most once per
+    invocation (``seen`` wrap-around detection), which both bounds the loop
+    when everything is failing (e.g. an S3 outage) and lets one invocation
+    drain an arbitrary backlog. Returns the number of rows drained.
     """
     storage: StorageService | None = None
     drained = 0
+    seen: set = set()
 
     while True:
         with SyncSessionLocal() as db:
-            rows = db.execute(
+            batch = db.execute(
                 select(StorageDeletionOutbox)
-                .order_by(StorageDeletionOutbox.created_at)
+                .order_by(
+                    StorageDeletionOutbox.attempts,
+                    StorageDeletionOutbox.created_at,
+                )
                 .with_for_update(skip_locked=True)
                 .limit(STORAGE_GC_BATCH_SIZE)
             ).scalars().all()
 
+            rows = [row for row in batch if row.id not in seen]
             if not rows:
                 break
+            seen.update(row.id for row in rows)
 
-            batch_drained = 0
             for row in rows:
                 ok = True
 
@@ -160,18 +169,14 @@ def drain_storage_deletion_outbox(self: Task) -> int:
 
                 if ok:
                     db.delete(row)
-                    batch_drained += 1
+                    drained += 1
                 else:
                     row.attempts += 1
                     row.last_attempt_at = utcnow()
 
             db.commit()
-            drained += batch_drained
 
-            # A full batch with zero progress means every row is failing right
-            # now (e.g. S3 outage) — stop instead of hammering storage until
-            # the task time limit kills us; the beat tick retries later.
-            if len(rows) < STORAGE_GC_BATCH_SIZE or batch_drained == 0:
+            if len(batch) < STORAGE_GC_BATCH_SIZE:
                 break
 
     if drained:

--- a/apps/api/src/tasks/maintenance.py
+++ b/apps/api/src/tasks/maintenance.py
@@ -6,8 +6,16 @@ run slips past every in-task guard (worker crash, broker loss, OOM kill) the
 episode can sit in a non-terminal ``generation_status`` forever and the UI shows
 a perpetual 'queued'. This beat task fails any episode whose run started longer
 ago than ``EPISODE_REAP_THRESHOLD_SECONDS``.
+
+``drain_storage_deletion_outbox`` is the GC worker for issue #366: delete flows
+(delete_episode, erase_user) insert a row per S3 key / local file path into the
+durable ``storage_deletion_outbox`` table instead of deleting from storage
+inline, so a failed commit never leaves storage deleted out from under a row
+that's still there. This task retries the actual deletion until it succeeds.
 """
+import asyncio
 import logging
+import os
 from datetime import datetime, timedelta, timezone
 
 from celery import Task
@@ -16,10 +24,17 @@ from sqlalchemy import and_, or_, select
 from src.config import settings
 from src.database import SyncSessionLocal
 from src.models.episode import Episode
+from src.models.storage_deletion_outbox import StorageDeletionOutbox
+from src.services.storage_service import StorageService
 from src.tasks.callbacks import _update_episode, _utcnow_iso
+from src.utils.datetime_utils import utcnow
 from src.worker import celery_app
 
 logger = logging.getLogger(__name__)
+
+# Rows fetched per drain iteration. The task loops while a full batch was
+# processed, so a backlog larger than this drains in one invocation.
+STORAGE_GC_BATCH_SIZE = 100
 
 # Statuses that represent an in-flight run. 'draft' is excluded (not started),
 # as are the terminal 'complete'/'failed'.
@@ -81,3 +96,79 @@ def reap_stuck_episodes(self: Task) -> int:
     if reaped:
         logger.warning("Reaped %d stuck episode(s) past %ds threshold", reaped, threshold)
     return reaped
+
+
+@celery_app.task(bind=True, name="drain_storage_deletion_outbox")
+def drain_storage_deletion_outbox(self: Task) -> int:
+    """Retry queued storage deletions until they succeed (issue #366).
+
+    Batch-fetches rows with ``FOR UPDATE SKIP LOCKED`` so an overlapping
+    invocation (beat tick racing a delete flow's post-commit trigger) skips
+    rows already claimed instead of double-processing them. Deletion is
+    idempotent both ways (a missing local file, or a repeated S3
+    ``delete_object``, both count as success — issue #366 AC5), so a row is
+    only removed once every key/path it names is gone. A failure increments
+    ``attempts``/``last_attempt_at`` and leaves the row queued for the next
+    drain; no ``self.retry`` is used here since the beat schedule and the
+    delete flows' prompt trigger both already re-run this task.
+
+    Loops while a full batch was processed so a backlog drains in one
+    invocation. Returns the total number of rows successfully drained.
+    """
+    storage: StorageService | None = None
+    drained = 0
+
+    while True:
+        with SyncSessionLocal() as db:
+            rows = db.execute(
+                select(StorageDeletionOutbox)
+                .order_by(StorageDeletionOutbox.created_at)
+                .with_for_update(skip_locked=True)
+                .limit(STORAGE_GC_BATCH_SIZE)
+            ).scalars().all()
+
+            if not rows:
+                break
+
+            for row in rows:
+                ok = True
+
+                if row.s3_key:
+                    if storage is None:
+                        storage = StorageService()
+                    try:
+                        asyncio.run(storage.delete_file(row.s3_key))
+                    except Exception as exc:
+                        ok = False
+                        logger.warning(
+                            "Failed to delete S3 object %s (attempt %d): %s",
+                            row.s3_key, row.attempts + 1, exc,
+                        )
+
+                if ok and row.file_path:
+                    try:
+                        os.remove(row.file_path)
+                    except FileNotFoundError:
+                        pass
+                    except OSError as exc:
+                        ok = False
+                        logger.warning(
+                            "Failed to remove local file %s (attempt %d): %s",
+                            row.file_path, row.attempts + 1, exc,
+                        )
+
+                if ok:
+                    db.delete(row)
+                    drained += 1
+                else:
+                    row.attempts += 1
+                    row.last_attempt_at = utcnow()
+
+            db.commit()
+
+            if len(rows) < STORAGE_GC_BATCH_SIZE:
+                break
+
+    if drained:
+        logger.info("Drained %d storage deletion(s) from the outbox", drained)
+    return drained

--- a/apps/api/src/tasks/maintenance.py
+++ b/apps/api/src/tasks/maintenance.py
@@ -130,6 +130,7 @@ def drain_storage_deletion_outbox(self: Task) -> int:
             if not rows:
                 break
 
+            batch_drained = 0
             for row in rows:
                 ok = True
 
@@ -159,14 +160,18 @@ def drain_storage_deletion_outbox(self: Task) -> int:
 
                 if ok:
                     db.delete(row)
-                    drained += 1
+                    batch_drained += 1
                 else:
                     row.attempts += 1
                     row.last_attempt_at = utcnow()
 
             db.commit()
+            drained += batch_drained
 
-            if len(rows) < STORAGE_GC_BATCH_SIZE:
+            # A full batch with zero progress means every row is failing right
+            # now (e.g. S3 outage) — stop instead of hammering storage until
+            # the task time limit kills us; the beat tick retries later.
+            if len(rows) < STORAGE_GC_BATCH_SIZE or batch_drained == 0:
                 break
 
     if drained:

--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -616,10 +616,11 @@ def finalize_episode_generation_task(
 
             s3_url = None
             s3_key = None
-            # Tracks the durable local artifact when no S3 bucket is configured,
-            # so it can be queued for deletion (issue #366) without depending on
-            # the possibly-expired `episode` ORM object after a rollback below.
+            # Captured now so the absorb branch below can use them without
+            # depending on the `episode` ORM object, which is expired (and its
+            # row gone) after the rollback there (issue #366).
             finalized_local_path = None
+            episode_tenant_id = episode.tenant_id
 
             # S3 upload (skip gracefully if bucket not configured)
             if settings.AWS_S3_BUCKET:
@@ -718,7 +719,11 @@ def finalize_episode_generation_task(
                 )
                 # s3_key and finalized_local_path are mutually exclusive by
                 # construction (only one of the two branches above runs).
-                _queue_orphaned_storage(s3_key=s3_key, file_path=finalized_local_path)
+                _queue_orphaned_storage(
+                    s3_key=s3_key,
+                    file_path=finalized_local_path,
+                    tenant_id=episode_tenant_id,
+                )
                 return {
                     "status": "absorbed",
                     "episode_id": episode_id,

--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -10,6 +10,7 @@ import uuid as uuid_module
 import logging
 from celery import Task, chain
 from celery.exceptions import SoftTimeLimitExceeded
+from sqlalchemy.orm.exc import StaleDataError
 from typing import Optional, List, Dict, Any
 from pydub import AudioSegment
 
@@ -17,7 +18,7 @@ from src.worker import celery_app
 from src.config import settings
 from src.database import SyncSessionLocal
 from src.models.episode import Episode
-from src.tasks.callbacks import _update_episode, _utcnow_iso
+from src.tasks.callbacks import _update_episode, _utcnow_iso, _queue_orphaned_storage
 from src.tasks.idempotency import acquire_generation_lock, release_generation_lock
 from src.tasks.s3_upload import (
     GENERATION_RUN_DIR_PREFIX,
@@ -615,6 +616,10 @@ def finalize_episode_generation_task(
 
             s3_url = None
             s3_key = None
+            # Tracks the durable local artifact when no S3 bucket is configured,
+            # so it can be queued for deletion (issue #366) without depending on
+            # the possibly-expired `episode` ORM object after a rollback below.
+            finalized_local_path = None
 
             # S3 upload (skip gracefully if bucket not configured)
             if settings.AWS_S3_BUCKET:
@@ -669,6 +674,7 @@ def finalize_episode_generation_task(
                 # per-run temp dir now that a persistent copy exists (issue #309).
                 persistent_path = _persist_local_audio(audio_file_path, episode_id)
                 episode.file_path = persistent_path
+                finalized_local_path = persistent_path
                 _cleanup_temp_file(audio_file_path)
                 logger.info(
                     f"AWS_S3_BUCKET not configured; persisted episode {episode_id} "
@@ -685,7 +691,38 @@ def finalize_episode_generation_task(
                 "progress": 100,
                 "status": "Generation complete",
             }
-            db.commit()
+            try:
+                db.commit()
+            except StaleDataError:
+                # The episode row was deleted by another transaction between the
+                # unlocked fetch above and this commit (issue #366) — the ORM's
+                # 0-row-matched UPDATE raises here even without a version_id_col.
+                # The audio is already durably uploaded/persisted with nothing
+                # left to reference it, so it must be queued for deletion instead
+                # of silently orphaned (IAM has no s3:ListBucket to find it later).
+                db.rollback()
+                still_present = db.get(Episode, uuid_module.UUID(episode_id)) is not None
+                if still_present:
+                    # Not the delete race this handles — fail cleanly rather than
+                    # guess at what else could cause a 0-row-matched UPDATE.
+                    logger.error(
+                        f"Episode {episode_id} commit reported stale data, but the "
+                        "row is still present; not absorbing"
+                    )
+                    return {"status": "failed", "error": "Stale data on episode commit"}
+
+                logger.warning(
+                    f"Episode {episode_id} was deleted mid-finalization; queuing "
+                    f"{'s3_key=' + s3_key if s3_key else 'file_path=' + str(finalized_local_path)} "
+                    "for deletion instead of orphaning it"
+                )
+                _queue_orphaned_storage(s3_key=s3_key, file_path=finalized_local_path if not s3_key else None)
+                return {
+                    "status": "absorbed",
+                    "episode_id": episode_id,
+                    "s3_key": s3_key,
+                    "file_path": finalized_local_path,
+                }
 
             logger.info(f"Episode {episode_id} finalized successfully")
             return {

--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -716,7 +716,9 @@ def finalize_episode_generation_task(
                     f"{'s3_key=' + s3_key if s3_key else 'file_path=' + str(finalized_local_path)} "
                     "for deletion instead of orphaning it"
                 )
-                _queue_orphaned_storage(s3_key=s3_key, file_path=finalized_local_path if not s3_key else None)
+                # s3_key and finalized_local_path are mutually exclusive by
+                # construction (only one of the two branches above runs).
+                _queue_orphaned_storage(s3_key=s3_key, file_path=finalized_local_path)
                 return {
                     "status": "absorbed",
                     "episode_id": episode_id,

--- a/apps/api/src/worker.py
+++ b/apps/api/src/worker.py
@@ -66,6 +66,7 @@ celery_app.conf.task_routes = {
     "on_workflow_complete": {"queue": "callbacks"},
     "on_workflow_failure": {"queue": "callbacks"},
     "reap_stuck_episodes": {"queue": "callbacks"},
+    "drain_storage_deletion_outbox": {"queue": "callbacks"},
 }
 
 # Beat schedule — periodic reaper that fails episodes stuck in a non-terminal
@@ -75,6 +76,14 @@ celery_app.conf.beat_schedule = {
     "reap-stuck-episodes": {
         "task": "reap_stuck_episodes",
         "schedule": timedelta(seconds=settings.REAP_STUCK_EPISODES_INTERVAL_SECONDS),
+    },
+    # Durable backstop for the storage-deletion outbox (issue #366): delete
+    # flows also trigger a prompt drain post-commit, but that trigger is
+    # best-effort (broker down must never fail the request), so this periodic
+    # tick is what guarantees a queued deletion is retried until it succeeds.
+    "drain-storage-deletion-outbox": {
+        "task": "drain_storage_deletion_outbox",
+        "schedule": timedelta(seconds=settings.STORAGE_GC_INTERVAL_SECONDS),
     },
 }
 

--- a/apps/api/tests/test_episodes.py
+++ b/apps/api/tests/test_episodes.py
@@ -383,11 +383,14 @@ async def test_delete_nonexistent_episode(client, project_and_auth):
 
 
 @pytest.mark.asyncio
-async def test_delete_episode_with_s3_key_calls_storage_delete(
-	client, project_and_auth, set_system_fields
+async def test_delete_episode_with_s3_key_queues_outbox_row(
+	client, project_and_auth, set_system_fields, test_db
 ):
-	"""Deleting an episode with an s3_key removes the S3 object (#308)."""
-	from unittest.mock import AsyncMock, patch
+	"""Deleting an episode with an s3_key queues a durable outbox row instead of
+	deleting from S3 synchronously (#366)."""
+	from unittest.mock import patch
+	from sqlalchemy import select
+	from src.models.storage_deletion_outbox import StorageDeletionOutbox
 
 	project_id, headers = project_and_auth
 	create_response = await client.post("/episodes", headers=headers, json={
@@ -398,21 +401,27 @@ async def test_delete_episode_with_s3_key_calls_storage_delete(
 	episode_id = create_response.json()["id"]
 	await set_system_fields(episode_id, s3_key="podcasts/episode.mp3")
 
-	with patch("src.services.episode_service.StorageService") as MockStorage:
-		mock_instance = MockStorage.return_value
-		mock_instance.delete_file = AsyncMock()
+	with patch("src.services.episode_service.drain_storage_deletion_outbox") as mock_drain:
+		mock_drain.delay = lambda: None
 		response = await client.delete(f"/episodes/{episode_id}", headers=headers)
 
 	assert response.status_code == 204
-	mock_instance.delete_file.assert_called_once_with("podcasts/episode.mp3")
+
+	result = await test_db.execute(
+		select(StorageDeletionOutbox).where(StorageDeletionOutbox.s3_key == "podcasts/episode.mp3")
+	)
+	row = result.scalar_one()
+	assert row.file_path is None
 
 
 @pytest.mark.asyncio
-async def test_delete_episode_without_s3_key_skips_storage_delete(
-	client, project_and_auth
+async def test_delete_episode_without_s3_key_queues_no_outbox_row(
+	client, project_and_auth, test_db
 ):
-	"""Deleting an episode with no s3_key makes no S3 call (#308)."""
-	from unittest.mock import AsyncMock, patch
+	"""Deleting an episode with no s3_key/file_path queues no outbox row (#366)."""
+	from unittest.mock import patch
+	from sqlalchemy import select
+	from src.models.storage_deletion_outbox import StorageDeletionOutbox
 
 	project_id, headers = project_and_auth
 	create_response = await client.post("/episodes", headers=headers, json={
@@ -422,34 +431,35 @@ async def test_delete_episode_without_s3_key_skips_storage_delete(
 	})
 	episode_id = create_response.json()["id"]
 
-	with patch("src.services.episode_service.StorageService") as MockStorage:
-		mock_instance = MockStorage.return_value
-		mock_instance.delete_file = AsyncMock()
+	with patch("src.services.episode_service.drain_storage_deletion_outbox") as mock_drain:
+		mock_drain.delay = lambda: None
 		response = await client.delete(f"/episodes/{episode_id}", headers=headers)
 
 	assert response.status_code == 204
-	mock_instance.delete_file.assert_not_called()
+
+	result = await test_db.execute(select(StorageDeletionOutbox))
+	assert result.scalars().all() == []
 
 
 @pytest.mark.asyncio
-async def test_delete_episode_s3_failure_does_not_block_delete(
+async def test_delete_episode_succeeds_when_drain_delay_fails(
 	client, project_and_auth, set_system_fields
 ):
-	"""An S3 delete failure is best-effort: the episode row is still removed (#308)."""
-	from unittest.mock import AsyncMock, patch
+	"""The post-commit best-effort drain trigger is best-effort: a broker-down
+	failure never blocks the delete or the response (#366)."""
+	from unittest.mock import patch
 
 	project_id, headers = project_and_auth
 	create_response = await client.post("/episodes", headers=headers, json={
 		"project_id": project_id,
 		"episode_number": 1,
-		"episode_metadata": {"title": "Flaky S3 Episode", "description": "Desc"}
+		"episode_metadata": {"title": "Flaky Broker Episode", "description": "Desc"}
 	})
 	episode_id = create_response.json()["id"]
 	await set_system_fields(episode_id, s3_key="podcasts/episode.mp3")
 
-	with patch("src.services.episode_service.StorageService") as MockStorage:
-		mock_instance = MockStorage.return_value
-		mock_instance.delete_file = AsyncMock(side_effect=Exception("S3 unavailable"))
+	with patch("src.services.episode_service.drain_storage_deletion_outbox") as mock_drain:
+		mock_drain.delay.side_effect = Exception("broker unavailable")
 		response = await client.delete(f"/episodes/{episode_id}", headers=headers)
 
 	assert response.status_code == 204
@@ -459,11 +469,15 @@ async def test_delete_episode_s3_failure_does_not_block_delete(
 
 
 @pytest.mark.asyncio
-async def test_delete_episode_removes_local_files(
-	client, project_and_auth, set_system_fields, tmp_path
+async def test_delete_episode_queues_local_file_paths_for_outbox(
+	client, project_and_auth, set_system_fields, test_db, tmp_path
 ):
-	"""Deleting an episode removes its local audio and transcript files (#308)."""
+	"""Deleting an episode queues its local audio/transcript paths for the GC
+	worker instead of removing them synchronously (#366)."""
 	import os
+	from unittest.mock import patch
+	from sqlalchemy import select
+	from src.models.storage_deletion_outbox import StorageDeletionOutbox
 
 	project_id, headers = project_and_auth
 	create_response = await client.post("/episodes", headers=headers, json={
@@ -484,20 +498,29 @@ async def test_delete_episode_removes_local_files(
 		transcript_path=str(transcript_path),
 	)
 
-	response = await client.delete(f"/episodes/{episode_id}", headers=headers)
+	with patch("src.services.episode_service.drain_storage_deletion_outbox") as mock_drain:
+		mock_drain.delay = lambda: None
+		response = await client.delete(f"/episodes/{episode_id}", headers=headers)
 	assert response.status_code == 204
 
-	assert not os.path.exists(audio_path)
-	assert not os.path.exists(transcript_path)
+	# Not removed synchronously — deletion is deferred to the GC worker.
+	assert os.path.exists(audio_path)
+	assert os.path.exists(transcript_path)
+
+	result = await test_db.execute(select(StorageDeletionOutbox.file_path))
+	queued_paths = {row[0] for row in result.all()}
+	assert queued_paths == {str(audio_path), str(transcript_path)}
 
 
 @pytest.mark.asyncio
-async def test_delete_episode_also_deletes_composition_s3_key(
+async def test_delete_episode_also_queues_composition_s3_key(
 	client, project_and_auth, test_db
 ):
-	"""Deleting an episode also deletes its EpisodeComposition's S3 audio (#308)."""
-	from unittest.mock import AsyncMock, patch
+	"""Deleting an episode also queues its EpisodeComposition's S3 audio (#366)."""
+	from unittest.mock import patch
+	from sqlalchemy import select
 	from src.models.episode_composition import EpisodeComposition
+	from src.models.storage_deletion_outbox import StorageDeletionOutbox
 	from src.services.auth_service import verify_jwt_token
 
 	project_id, headers = project_and_auth
@@ -519,13 +542,40 @@ async def test_delete_episode_also_deletes_composition_s3_key(
 	))
 	await test_db.flush()
 
-	with patch("src.services.episode_service.StorageService") as MockStorage:
-		mock_instance = MockStorage.return_value
-		mock_instance.delete_file = AsyncMock()
+	with patch("src.services.episode_service.drain_storage_deletion_outbox") as mock_drain:
+		mock_drain.delay = lambda: None
 		response = await client.delete(f"/episodes/{episode_id}", headers=headers)
 
 	assert response.status_code == 204
-	mock_instance.delete_file.assert_called_once_with("compositions/final.mp3")
+
+	result = await test_db.execute(
+		select(StorageDeletionOutbox).where(StorageDeletionOutbox.s3_key == "compositions/final.mp3")
+	)
+	assert result.scalar_one() is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_episode_triggers_drain_task(
+	client, project_and_auth, set_system_fields
+):
+	"""Deleting an episode with a queued key best-effort triggers a prompt drain
+	so audio disappears promptly instead of waiting for the beat schedule (#366)."""
+	from unittest.mock import patch
+
+	project_id, headers = project_and_auth
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "Drain Trigger Episode", "description": "Desc"}
+	})
+	episode_id = create_response.json()["id"]
+	await set_system_fields(episode_id, s3_key="podcasts/episode.mp3")
+
+	with patch("src.services.episode_service.drain_storage_deletion_outbox") as mock_drain:
+		response = await client.delete(f"/episodes/{episode_id}", headers=headers)
+
+	assert response.status_code == 204
+	mock_drain.delay.assert_called_once_with()
 
 
 # ============================================================================

--- a/apps/api/tests/test_episodes.py
+++ b/apps/api/tests/test_episodes.py
@@ -626,6 +626,53 @@ async def test_delete_episode_queues_s3_key_persisted_after_fetch(
 		"late-persisted s3_key was not queued for deletion — orphaned object"
 	)
 
+
+@pytest.mark.asyncio
+async def test_delete_episode_queues_content_source_s3_keys(
+	client, project_and_auth, test_db
+):
+	"""Content sources cascade-delete with the episode, so their uploaded
+	source objects (source_data["s3_key"], e.g. PDFs/images) must be queued
+	for deletion too — erase_user already does this; episode delete must match
+	(#366)."""
+	from unittest.mock import patch
+	from uuid import UUID
+
+	from sqlalchemy import select
+
+	from src.models.content_source import ContentSource
+	from src.models.storage_deletion_outbox import StorageDeletionOutbox
+	from src.services.episode_service import get_episode_by_id
+
+	project_id, headers = project_and_auth
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "PDF Episode", "description": "Desc"}
+	})
+	episode_id = create_response.json()["id"]
+	episode = await get_episode_by_id(test_db, UUID(episode_id))
+
+	test_db.add(ContentSource(
+		episode_id=episode.id,
+		tenant_id=episode.tenant_id,
+		source_type="pdf",
+		source_data={"filename": "doc.pdf", "s3_key": "uploads/doc.pdf"},
+		extraction_status="pending",
+	))
+	await test_db.flush()
+
+	with patch("src.services.episode_service.drain_storage_deletion_outbox"):
+		response = await client.delete(f"/episodes/{episode_id}", headers=headers)
+
+	assert response.status_code == 204
+	result = await test_db.execute(
+		select(StorageDeletionOutbox).where(StorageDeletionOutbox.s3_key == "uploads/doc.pdf")
+	)
+	assert result.scalar_one_or_none() is not None, (
+		"content-source s3_key was not queued — orphaned source object"
+	)
+
 # ============================================================================
 # PROJECT RELATIONSHIP TESTS
 # ============================================================================

--- a/apps/api/tests/test_episodes.py
+++ b/apps/api/tests/test_episodes.py
@@ -437,7 +437,16 @@ async def test_delete_episode_without_s3_key_queues_no_outbox_row(
 
 	assert response.status_code == 204
 
-	result = await test_db.execute(select(StorageDeletionOutbox))
+	# Scoped to this episode's tenant: the outbox has no RLS, so a global
+	# "table is empty" assertion is fragile against any concurrent writer.
+	from uuid import UUID as _UUID
+	from src.services.project_service import get_project_by_id
+	project = await get_project_by_id(test_db, _UUID(project_id))
+	result = await test_db.execute(
+		select(StorageDeletionOutbox).where(
+			StorageDeletionOutbox.tenant_id == project.tenant_id
+		)
+	)
 	assert result.scalars().all() == []
 
 
@@ -507,7 +516,13 @@ async def test_delete_episode_queues_local_file_paths_for_outbox(
 	assert os.path.exists(audio_path)
 	assert os.path.exists(transcript_path)
 
-	result = await test_db.execute(select(StorageDeletionOutbox.file_path))
+	# Scoped to the paths this test created (outbox has no RLS — a global
+	# read is fragile against concurrent writers).
+	result = await test_db.execute(
+		select(StorageDeletionOutbox.file_path).where(
+			StorageDeletionOutbox.file_path.in_([str(audio_path), str(transcript_path)])
+		)
+	)
 	queued_paths = {row[0] for row in result.all()}
 	assert queued_paths == {str(audio_path), str(transcript_path)}
 

--- a/apps/api/tests/test_episodes.py
+++ b/apps/api/tests/test_episodes.py
@@ -578,6 +578,54 @@ async def test_delete_episode_triggers_drain_task(
 	mock_drain.delay.assert_called_once_with()
 
 
+@pytest.mark.asyncio
+async def test_delete_episode_queues_s3_key_persisted_after_fetch(
+	client, project_and_auth, test_db
+):
+	"""A callback can persist s3_key between the caller's fetch and the delete
+	commit (#366 TOCTOU): delete_episode must re-read the row under lock so the
+	freshly-persisted key still lands in the outbox instead of being orphaned."""
+	from unittest.mock import patch
+	from uuid import UUID
+
+	from sqlalchemy import select, update
+
+	from src.models.episode import Episode
+	from src.models.storage_deletion_outbox import StorageDeletionOutbox
+	from src.services.episode_service import delete_episode, get_episode_by_id
+
+	project_id, headers = project_and_auth
+	create_response = await client.post("/episodes", headers=headers, json={
+		"project_id": project_id,
+		"episode_number": 1,
+		"episode_metadata": {"title": "Late Upload Episode", "description": "Desc"}
+	})
+	episode_id = create_response.json()["id"]
+
+	# Stale snapshot, as the router would hold it — s3_key not yet persisted.
+	episode = await get_episode_by_id(test_db, UUID(episode_id))
+	assert episode.s3_key is None
+
+	# Simulate on_upload_complete committing AFTER that fetch: a core UPDATE
+	# with synchronize_session off, so the in-memory object stays stale (the
+	# real callback runs in a different process entirely).
+	await test_db.execute(
+		update(Episode)
+		.where(Episode.id == episode.id)
+		.values(s3_key="podcasts/late.mp3")
+		.execution_options(synchronize_session=False)
+	)
+
+	with patch("src.services.episode_service.drain_storage_deletion_outbox"):
+		await delete_episode(test_db, episode)
+
+	result = await test_db.execute(
+		select(StorageDeletionOutbox).where(StorageDeletionOutbox.s3_key == "podcasts/late.mp3")
+	)
+	assert result.scalar_one_or_none() is not None, (
+		"late-persisted s3_key was not queued for deletion — orphaned object"
+	)
+
 # ============================================================================
 # PROJECT RELATIONSHIP TESTS
 # ============================================================================

--- a/apps/api/tests/test_offboarding.py
+++ b/apps/api/tests/test_offboarding.py
@@ -152,8 +152,11 @@ async def test_delete_me_queues_one_outbox_row_per_s3_key(seeded_user, client, t
 		)
 
 	assert response.status_code == 204
+	# Scoped to this user's tenant (outbox has no RLS — a global read is
+	# fragile against concurrent writers).
 	result = await test_db.execute(select(StorageDeletionOutbox.s3_key).where(
-		StorageDeletionOutbox.s3_key.isnot(None)
+		StorageDeletionOutbox.s3_key.isnot(None),
+		StorageDeletionOutbox.tenant_id == seeded_user["tenant_id"],
 	))
 	queued_keys = {row[0] for row in result.all()}
 	assert queued_keys == seeded_user["s3_keys"]

--- a/apps/api/tests/test_offboarding.py
+++ b/apps/api/tests/test_offboarding.py
@@ -8,7 +8,7 @@ objects, and local file artifacts.
 
 import pytest
 from datetime import date
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 from uuid import uuid4
 
 from sqlalchemy import select
@@ -22,6 +22,7 @@ from src.models.episode_composition import EpisodeComposition
 from src.models.audio_snippet import AudioSnippet
 from src.models.rss_feed import RSSFeed
 from src.models.content_source import ContentSource
+from src.models.storage_deletion_outbox import StorageDeletionOutbox
 from src.services.auth_service import verify_jwt_token
 
 
@@ -131,9 +132,7 @@ async def seeded_user(client, test_db):
 @pytest.mark.asyncio
 async def test_delete_me_returns_204(seeded_user, client):
 	"""DELETE /auth/me erases the account and returns 204."""
-	with patch("src.services.offboarding_service.StorageService") as MockStorage:
-		mock_instance = MockStorage.return_value
-		mock_instance.delete_file = AsyncMock()
+	with patch("src.services.offboarding_service.drain_storage_deletion_outbox"):
 		response = await client.request(
 			"DELETE", "/auth/me", headers=seeded_user["headers"],
 			json={"password": "SecurePass123!"},
@@ -143,29 +142,28 @@ async def test_delete_me_returns_204(seeded_user, client):
 
 
 @pytest.mark.asyncio
-async def test_delete_me_deletes_one_s3_object_per_key(seeded_user, client):
-	"""Every collected S3 key gets exactly one delete_file call."""
-	with patch("src.services.offboarding_service.StorageService") as MockStorage:
-		mock_instance = MockStorage.return_value
-		mock_instance.delete_file = AsyncMock()
+async def test_delete_me_queues_one_outbox_row_per_s3_key(seeded_user, client, test_db):
+	"""Every collected S3 key is queued as exactly one durable outbox row
+	instead of being deleted from S3 synchronously (#366)."""
+	with patch("src.services.offboarding_service.drain_storage_deletion_outbox"):
 		response = await client.request(
 			"DELETE", "/auth/me", headers=seeded_user["headers"],
 			json={"password": "SecurePass123!"},
 		)
 
 	assert response.status_code == 204
-	called_keys = {call.args[0] for call in mock_instance.delete_file.call_args_list}
-	assert called_keys == seeded_user["s3_keys"]
-	assert mock_instance.delete_file.call_count == len(seeded_user["s3_keys"])
+	result = await test_db.execute(select(StorageDeletionOutbox.s3_key).where(
+		StorageDeletionOutbox.s3_key.isnot(None)
+	))
+	queued_keys = {row[0] for row in result.all()}
+	assert queued_keys == seeded_user["s3_keys"]
 
 
 @pytest.mark.asyncio
 async def test_delete_me_removes_user_and_cascaded_rows(seeded_user, client, test_db):
 	"""The user row and everything that cascades from it (project, episode,
 	composition, audio snippet, RSS feed, content source) are gone."""
-	with patch("src.services.offboarding_service.StorageService") as MockStorage:
-		mock_instance = MockStorage.return_value
-		mock_instance.delete_file = AsyncMock()
+	with patch("src.services.offboarding_service.drain_storage_deletion_outbox"):
 		response = await client.request(
 			"DELETE", "/auth/me", headers=seeded_user["headers"],
 			json={"password": "SecurePass123!"},
@@ -235,9 +233,7 @@ async def test_delete_me_removes_billing_rows(seeded_user, client, test_db):
 	)
 	assert pre_usage.scalars().all()
 
-	with patch("src.services.offboarding_service.StorageService") as MockStorage:
-		mock_instance = MockStorage.return_value
-		mock_instance.delete_file = AsyncMock()
+	with patch("src.services.offboarding_service.drain_storage_deletion_outbox"):
 		response = await client.request(
 			"DELETE", "/auth/me", headers=seeded_user["headers"],
 			json={"password": "SecurePass123!"},
@@ -260,9 +256,7 @@ async def test_delete_me_removes_billing_rows(seeded_user, client, test_db):
 @pytest.mark.asyncio
 async def test_delete_me_invalidates_old_token(seeded_user, client):
 	"""After erasure, the user's old bearer token is rejected."""
-	with patch("src.services.offboarding_service.StorageService") as MockStorage:
-		mock_instance = MockStorage.return_value
-		mock_instance.delete_file = AsyncMock()
+	with patch("src.services.offboarding_service.drain_storage_deletion_outbox"):
 		response = await client.request(
 			"DELETE", "/auth/me", headers=seeded_user["headers"],
 			json={"password": "SecurePass123!"},
@@ -285,16 +279,14 @@ async def test_delete_me_wrong_password_rejected(seeded_user, client, test_db):
 	"""A wrong password confirmation is a 403 and nothing is erased."""
 	from uuid import UUID as _UUID
 
-	with patch("src.services.offboarding_service.StorageService") as MockStorage:
-		mock_instance = MockStorage.return_value
-		mock_instance.delete_file = AsyncMock()
+	with patch("src.services.offboarding_service.drain_storage_deletion_outbox") as mock_drain:
 		response = await client.request(
 			"DELETE", "/auth/me", headers=seeded_user["headers"],
 			json={"password": "WrongPass456!"},
 		)
 
 	assert response.status_code == 403
-	mock_instance.delete_file.assert_not_called()
+	mock_drain.delay.assert_not_called()
 	user_result = await test_db.execute(
 		select(User).where(User.id == _UUID(seeded_user["user_id"]))
 	)
@@ -312,16 +304,14 @@ async def test_delete_me_refused_while_episode_generating(seeded_user, client, t
 	episode = await get_episode_by_id(test_db, _UUID(seeded_user["episode_id"]))
 	await set_episode_system_fields(test_db, episode, generation_status="generating")
 
-	with patch("src.services.offboarding_service.StorageService") as MockStorage:
-		mock_instance = MockStorage.return_value
-		mock_instance.delete_file = AsyncMock()
+	with patch("src.services.offboarding_service.drain_storage_deletion_outbox") as mock_drain:
 		response = await client.request(
 			"DELETE", "/auth/me", headers=seeded_user["headers"],
 			json={"password": "SecurePass123!"},
 		)
 
 	assert response.status_code == 409
-	mock_instance.delete_file.assert_not_called()
+	mock_drain.delay.assert_not_called()
 	user_result = await test_db.execute(
 		select(User).where(User.id == _UUID(seeded_user["user_id"]))
 	)
@@ -329,13 +319,13 @@ async def test_delete_me_refused_while_episode_generating(seeded_user, client, t
 
 
 @pytest.mark.asyncio
-async def test_delete_me_s3_failure_does_not_block_erasure(seeded_user, client, test_db):
-	"""S3 cleanup is best-effort: delete_file raising never blocks the erasure."""
+async def test_delete_me_succeeds_when_drain_delay_fails(seeded_user, client, test_db):
+	"""The post-commit best-effort drain trigger is best-effort: a broker-down
+	failure never blocks the erasure (#366)."""
 	from uuid import UUID as _UUID
 
-	with patch("src.services.offboarding_service.StorageService") as MockStorage:
-		mock_instance = MockStorage.return_value
-		mock_instance.delete_file = AsyncMock(side_effect=Exception("S3 unavailable"))
+	with patch("src.services.offboarding_service.drain_storage_deletion_outbox") as mock_drain:
+		mock_drain.delay.side_effect = Exception("broker unavailable")
 		response = await client.request(
 			"DELETE", "/auth/me", headers=seeded_user["headers"],
 			json={"password": "SecurePass123!"},
@@ -346,3 +336,17 @@ async def test_delete_me_s3_failure_does_not_block_erasure(seeded_user, client, 
 		select(User).where(User.id == _UUID(seeded_user["user_id"]))
 	)
 	assert user_result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_delete_me_triggers_drain_task(seeded_user, client):
+	"""Erasing an account with queued keys best-effort triggers a prompt drain
+	so audio disappears promptly instead of waiting for the beat schedule (#366)."""
+	with patch("src.services.offboarding_service.drain_storage_deletion_outbox") as mock_drain:
+		response = await client.request(
+			"DELETE", "/auth/me", headers=seeded_user["headers"],
+			json={"password": "SecurePass123!"},
+		)
+
+	assert response.status_code == 204
+	mock_drain.delay.assert_called_once_with()

--- a/apps/api/tests/test_s3_upload.py
+++ b/apps/api/tests/test_s3_upload.py
@@ -11,6 +11,7 @@ import uuid
 from unittest.mock import MagicMock, patch
 
 from botocore.exceptions import ClientError
+from sqlalchemy.orm.exc import StaleDataError
 
 
 # ============================================================================
@@ -496,6 +497,113 @@ class TestFinalizeEpisodeGenerationTask:
         # The episode should have gone through 'uploading' then 'complete'
         assert "uploading" in status_history
         assert episode.generation_status == "complete"
+
+    def test_absorbs_orphaned_s3_object_when_episode_deleted_mid_finalization(self):
+        """Issue #366: the episode row fetched at the top of the task
+        (unlocked, via db.get) can be deleted by another transaction before the
+        final commit. SQLAlchemy raises StaleDataError on that 0-row-matched
+        UPDATE. The S3 object already uploaded by this point must be queued
+        for deletion instead of silently orphaned (no s3:ListBucket in IAM)."""
+        episode_id = str(uuid.uuid4())
+        user_id = str(uuid.uuid4())
+        episode = _make_mock_episode(episode_id, user_id)
+        generation_result = self._make_generation_result()
+
+        mock_db = MagicMock()
+        # First call: initial fetch (row exists). Second call: post-StaleDataError
+        # recheck confirming the row is genuinely gone.
+        mock_db.get.side_effect = [episode, None]
+        mock_db.__enter__ = MagicMock(return_value=mock_db)
+        mock_db.__exit__ = MagicMock(return_value=False)
+        # First commit ('uploading' status) succeeds; final commit hits the race.
+        mock_db.commit.side_effect = [None, StaleDataError("stale", 1, 0)]
+
+        upload_result = {
+            "status": "success",
+            "s3_key": f"podcasts/user-{user_id}/episode-{episode_id}.mp3",
+            "s3_url": "https://test-bucket.s3.amazonaws.com/test.mp3",
+            "file_size_bytes": 1000,
+            "error": None,
+        }
+
+        with (
+            patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=mock_db),
+            patch("src.tasks.podcast_generation.settings") as mock_settings,
+            patch("src.tasks.podcast_generation.upload_to_s3_task", return_value=upload_result),
+            patch("src.tasks.podcast_generation._queue_orphaned_storage") as mock_queue,
+        ):
+            mock_settings.AWS_S3_BUCKET = "test-bucket"
+            result = self._invoke_finalize(episode_id, generation_result, mock_db)
+
+        assert result["status"] == "absorbed"
+        mock_queue.assert_called_once_with(s3_key=upload_result["s3_key"], file_path=None)
+
+    def test_absorbs_orphaned_local_file_when_episode_deleted_mid_finalization_no_s3(
+        self, tmp_path
+    ):
+        """Same race as above, but with no S3 bucket configured: the durable
+        artifact is the locally-persisted copy, so that path is queued."""
+        episode_id = str(uuid.uuid4())
+        episode = _make_mock_episode(episode_id)
+        src_audio = tmp_path / "episode-abc.mp3"
+        src_audio.write_bytes(b"FAKE_MP3")
+        storage_dir = tmp_path / "audio"
+        generation_result = self._make_generation_result(audio_file_path=str(src_audio))
+
+        mock_db = MagicMock()
+        mock_db.get.side_effect = [episode, None]
+        mock_db.__enter__ = MagicMock(return_value=mock_db)
+        mock_db.__exit__ = MagicMock(return_value=False)
+        # No-S3 branch only ever commits once (the final commit).
+        mock_db.commit.side_effect = StaleDataError("stale", 1, 0)
+
+        with (
+            patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=mock_db),
+            patch("src.tasks.podcast_generation.settings") as mock_settings,
+            patch("src.tasks.podcast_generation._queue_orphaned_storage") as mock_queue,
+        ):
+            mock_settings.AWS_S3_BUCKET = None
+            mock_settings.LOCAL_AUDIO_STORAGE_PATH = str(storage_dir)
+            result = self._invoke_finalize(episode_id, generation_result, mock_db)
+
+        assert result["status"] == "absorbed"
+        expected_path = str(storage_dir / f"episode-{episode_id}.mp3")
+        mock_queue.assert_called_once_with(s3_key=None, file_path=expected_path)
+
+    def test_does_not_absorb_when_row_still_present_after_staledata_error(self):
+        """Extremely defensive: if the post-error recheck still finds the row,
+        something other than a delete race is going on — do not queue anything
+        for deletion, just fail cleanly."""
+        episode_id = str(uuid.uuid4())
+        user_id = str(uuid.uuid4())
+        episode = _make_mock_episode(episode_id, user_id)
+        generation_result = self._make_generation_result()
+
+        mock_db = MagicMock()
+        mock_db.get.side_effect = [episode, episode]  # still present on recheck
+        mock_db.__enter__ = MagicMock(return_value=mock_db)
+        mock_db.__exit__ = MagicMock(return_value=False)
+        mock_db.commit.side_effect = [None, StaleDataError("stale", 1, 0)]
+
+        upload_result = {
+            "status": "success",
+            "s3_key": f"podcasts/user-{user_id}/episode-{episode_id}.mp3",
+            "s3_url": "https://test-bucket.s3.amazonaws.com/test.mp3",
+            "file_size_bytes": 1000,
+            "error": None,
+        }
+
+        with (
+            patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=mock_db),
+            patch("src.tasks.podcast_generation.settings") as mock_settings,
+            patch("src.tasks.podcast_generation.upload_to_s3_task", return_value=upload_result),
+            patch("src.tasks.podcast_generation._queue_orphaned_storage") as mock_queue,
+        ):
+            mock_settings.AWS_S3_BUCKET = "test-bucket"
+            result = self._invoke_finalize(episode_id, generation_result, mock_db)
+
+        assert result["status"] == "failed"
+        mock_queue.assert_not_called()
 
 
 # ============================================================================

--- a/apps/api/tests/test_s3_upload.py
+++ b/apps/api/tests/test_s3_upload.py
@@ -23,6 +23,7 @@ def _make_mock_episode(episode_id: str, user_id: str = None) -> MagicMock:
     episode = MagicMock()
     episode.id = uuid.UUID(episode_id)
     episode.user_id = uuid.UUID(user_id) if user_id else uuid.uuid4()
+    episode.tenant_id = uuid.uuid4()
     episode.generation_status = "generating"
     episode.generation_progress = {}
     episode.file_path = None
@@ -536,7 +537,9 @@ class TestFinalizeEpisodeGenerationTask:
             result = self._invoke_finalize(episode_id, generation_result, mock_db)
 
         assert result["status"] == "absorbed"
-        mock_queue.assert_called_once_with(s3_key=upload_result["s3_key"], file_path=None)
+        mock_queue.assert_called_once_with(
+            s3_key=upload_result["s3_key"], file_path=None, tenant_id=episode.tenant_id
+        )
 
     def test_absorbs_orphaned_local_file_when_episode_deleted_mid_finalization_no_s3(
         self, tmp_path
@@ -568,7 +571,9 @@ class TestFinalizeEpisodeGenerationTask:
 
         assert result["status"] == "absorbed"
         expected_path = str(storage_dir / f"episode-{episode_id}.mp3")
-        mock_queue.assert_called_once_with(s3_key=None, file_path=expected_path)
+        mock_queue.assert_called_once_with(
+            s3_key=None, file_path=expected_path, tenant_id=episode.tenant_id
+        )
 
     def test_does_not_absorb_when_row_still_present_after_staledata_error(self):
         """Extremely defensive: if the post-error recheck still finds the row,

--- a/apps/api/tests/test_storage_deletion_outbox_gc.py
+++ b/apps/api/tests/test_storage_deletion_outbox_gc.py
@@ -188,8 +188,9 @@ def test_drain_stops_after_partial_batch():
 
 
 def test_drain_query_uses_skip_locked_order_by_created_at():
-	"""The batch SELECT must use FOR UPDATE SKIP LOCKED ordered by created_at
-	so concurrent drain invocations don't contend on the same rows."""
+	"""The batch SELECT must use FOR UPDATE SKIP LOCKED (concurrent drains
+	don't contend) ordered by attempts THEN created_at, so long-failing rows
+	sink behind newer, deletable work instead of starving it (#366)."""
 	from src.tasks import maintenance
 
 	session = _session_yielding_rows([])
@@ -203,7 +204,8 @@ def test_drain_query_uses_skip_locked_order_by_created_at():
 		dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
 	))
 	assert "SKIP LOCKED" in sql.upper()
-	assert "ORDER BY" in sql.upper()
+	order_clause = sql.upper().split("ORDER BY")[1]
+	assert order_clause.index("ATTEMPTS") < order_clause.index("CREATED_AT")
 
 
 @pytest.mark.parametrize("registered_name", ["drain_storage_deletion_outbox"])
@@ -240,7 +242,44 @@ def test_drain_stops_when_full_batch_makes_no_progress():
 		drained = maintenance.drain_storage_deletion_outbox.run()
 
 	assert drained == 0
-	# One fetch, then stop: zero progress on a full batch must not refetch.
-	session.execute.assert_called_once()
+	# Two fetches: one that attempts every row, then the wrap-around fetch
+	# that finds nothing unseen and stops — never a third.
+	assert session.execute.call_count == 2
 	for row in rows:
 		assert row.attempts == 1
+
+
+def test_drain_continues_past_fully_failing_batch_to_newer_rows():
+	"""A full batch of failing rows must not starve newer deletable rows
+	behind it (#366): the drain continues to the next batch in the same
+	invocation instead of stopping at the failing head."""
+	from src.tasks import maintenance
+
+	failing = [
+		_make_row(s3_key=f"podcasts/stuck-{i}.mp3")
+		for i in range(maintenance.STORAGE_GC_BATCH_SIZE)
+	]
+	# Missing local file counts as success (idempotent) — deletable rows.
+	deletable = [_make_row(file_path=f"/nonexistent/fresh-{i}.mp3") for i in range(3)]
+
+	session = MagicMock()
+	session.__enter__ = MagicMock(return_value=session)
+	session.__exit__ = MagicMock(return_value=False)
+	results = []
+	for batch in (failing, deletable):
+		r = MagicMock()
+		r.scalars.return_value.all.return_value = batch
+		results.append(r)
+	session.execute.side_effect = results
+	mock_storage = MagicMock()
+
+	with patch("src.tasks.maintenance.SyncSessionLocal", return_value=session), \
+		patch("src.tasks.maintenance.StorageService", return_value=mock_storage), \
+		patch("src.tasks.maintenance.asyncio.run", side_effect=Exception("S3 down")):
+		drained = maintenance.drain_storage_deletion_outbox.run()
+
+	assert drained == 3
+	for row in failing:
+		assert row.attempts == 1
+	for row in deletable:
+		session.delete.assert_any_call(row)

--- a/apps/api/tests/test_storage_deletion_outbox_gc.py
+++ b/apps/api/tests/test_storage_deletion_outbox_gc.py
@@ -1,0 +1,221 @@
+"""
+Unit tests for the storage-deletion-outbox GC worker (issue #366).
+
+Mirrors the reaper's test convention (tests/test_maintenance.py): the task
+uses a sync Celery session (SyncSessionLocal) independent of the async test-DB
+transaction, so the session and StorageService are mocked and the drain
+task's batch/retry logic is exercised directly via ``.run()``.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _session_yielding_rows(rows):
+	"""Mock a SyncSessionLocal context manager whose query returns ``rows``."""
+	session = MagicMock()
+	session.execute.return_value.scalars.return_value.all.return_value = rows
+	session.__enter__ = MagicMock(return_value=session)
+	session.__exit__ = MagicMock(return_value=False)
+	return session
+
+
+def _make_row(s3_key=None, file_path=None, attempts=0):
+	row = MagicMock()
+	row.s3_key = s3_key
+	row.file_path = file_path
+	row.attempts = attempts
+	row.last_attempt_at = None
+	return row
+
+
+def test_drain_noop_when_empty():
+	from src.tasks import maintenance
+
+	session = _session_yielding_rows([])
+	with patch("src.tasks.maintenance.SyncSessionLocal", return_value=session):
+		drained = maintenance.drain_storage_deletion_outbox.run()
+
+	assert drained == 0
+	session.commit.assert_not_called()
+
+
+def test_drain_deletes_s3_key_and_removes_row():
+	from src.tasks import maintenance
+
+	row = _make_row(s3_key="podcasts/episode.mp3")
+	session = _session_yielding_rows([row])
+	mock_storage = MagicMock()
+
+	with patch("src.tasks.maintenance.SyncSessionLocal", return_value=session), \
+		patch("src.tasks.maintenance.StorageService", return_value=mock_storage), \
+		patch("src.tasks.maintenance.asyncio.run") as mock_asyncio_run:
+		drained = maintenance.drain_storage_deletion_outbox.run()
+
+	assert drained == 1
+	mock_asyncio_run.assert_called_once()
+	session.delete.assert_called_once_with(row)
+	session.commit.assert_called_once()
+
+
+def test_drain_removes_local_file_and_deletes_row(tmp_path):
+	from src.tasks import maintenance
+
+	target = tmp_path / "audio.mp3"
+	target.write_bytes(b"AUDIO")
+	row = _make_row(file_path=str(target))
+	session = _session_yielding_rows([row])
+
+	with patch("src.tasks.maintenance.SyncSessionLocal", return_value=session):
+		drained = maintenance.drain_storage_deletion_outbox.run()
+
+	assert drained == 1
+	assert not target.exists()
+	session.delete.assert_called_once_with(row)
+
+
+def test_drain_treats_missing_local_file_as_success():
+	"""A local file that's already gone is not an error — delete_object-style
+	idempotency for the filesystem path (issue #366, AC5)."""
+	from src.tasks import maintenance
+
+	row = _make_row(file_path="/nonexistent/path/does-not-exist.mp3")
+	session = _session_yielding_rows([row])
+
+	with patch("src.tasks.maintenance.SyncSessionLocal", return_value=session):
+		drained = maintenance.drain_storage_deletion_outbox.run()
+
+	assert drained == 1
+	session.delete.assert_called_once_with(row)
+
+
+def test_drain_increments_attempts_on_s3_failure():
+	from src.tasks import maintenance
+
+	row = _make_row(s3_key="podcasts/episode.mp3", attempts=2)
+	session = _session_yielding_rows([row])
+	mock_storage = MagicMock()
+
+	with patch("src.tasks.maintenance.SyncSessionLocal", return_value=session), \
+		patch("src.tasks.maintenance.StorageService", return_value=mock_storage), \
+		patch("src.tasks.maintenance.asyncio.run", side_effect=Exception("S3 unavailable")):
+		drained = maintenance.drain_storage_deletion_outbox.run()
+
+	assert drained == 0
+	session.delete.assert_not_called()
+	assert row.attempts == 3
+	assert row.last_attempt_at is not None
+	session.commit.assert_called_once()
+
+
+def test_drain_increments_attempts_on_local_delete_failure():
+	from src.tasks import maintenance
+
+	row = _make_row(file_path="/some/path.mp3", attempts=0)
+	session = _session_yielding_rows([row])
+
+	with patch("src.tasks.maintenance.SyncSessionLocal", return_value=session), \
+		patch("src.tasks.maintenance.os.remove", side_effect=PermissionError("locked")):
+		drained = maintenance.drain_storage_deletion_outbox.run()
+
+	assert drained == 0
+	session.delete.assert_not_called()
+	assert row.attempts == 1
+
+
+def test_drain_only_touches_s3_when_local_delete_already_failed():
+	"""A row with both s3_key and file_path must not be marked drained (row
+	deleted) unless BOTH deletions succeeded."""
+	from src.tasks import maintenance
+
+	row = _make_row(s3_key="podcasts/episode.mp3", file_path="/some/path.mp3")
+	session = _session_yielding_rows([row])
+	mock_storage = MagicMock()
+
+	with patch("src.tasks.maintenance.SyncSessionLocal", return_value=session), \
+		patch("src.tasks.maintenance.StorageService", return_value=mock_storage), \
+		patch("src.tasks.maintenance.asyncio.run"), \
+		patch("src.tasks.maintenance.os.remove", side_effect=OSError("disk error")):
+		drained = maintenance.drain_storage_deletion_outbox.run()
+
+	assert drained == 0
+	session.delete.assert_not_called()
+	assert row.attempts == 1
+
+
+def test_drain_loops_while_full_batch_processed():
+	"""A backlog larger than one batch drains in a single invocation."""
+	from src.tasks import maintenance
+
+	batch_size = maintenance.STORAGE_GC_BATCH_SIZE
+	full_batch = [_make_row(s3_key=f"key-{i}") for i in range(batch_size)]
+	partial_batch = [_make_row(s3_key="key-last")]
+
+	session1 = _session_yielding_rows(full_batch)
+	session2 = _session_yielding_rows(partial_batch)
+	session3 = _session_yielding_rows([])
+	mock_storage = MagicMock()
+
+	with patch(
+		"src.tasks.maintenance.SyncSessionLocal",
+		side_effect=[session1, session2, session3],
+	), \
+		patch("src.tasks.maintenance.StorageService", return_value=mock_storage), \
+		patch("src.tasks.maintenance.asyncio.run"):
+		drained = maintenance.drain_storage_deletion_outbox.run()
+
+	assert drained == batch_size + 1
+
+
+def test_drain_stops_after_partial_batch():
+	"""A batch smaller than the limit means the queue is empty — no extra
+	round-trip to fetch a third (empty) batch."""
+	from src.tasks import maintenance
+
+	row = _make_row(s3_key="only-key")
+	session = _session_yielding_rows([row])
+	mock_storage = MagicMock()
+
+	with patch(
+		"src.tasks.maintenance.SyncSessionLocal", return_value=session
+	) as mock_factory, \
+		patch("src.tasks.maintenance.StorageService", return_value=mock_storage), \
+		patch("src.tasks.maintenance.asyncio.run"):
+		drained = maintenance.drain_storage_deletion_outbox.run()
+
+	assert drained == 1
+	assert mock_factory.call_count == 1
+
+
+def test_drain_query_uses_skip_locked_order_by_created_at():
+	"""The batch SELECT must use FOR UPDATE SKIP LOCKED ordered by created_at
+	so concurrent drain invocations don't contend on the same rows."""
+	from src.tasks import maintenance
+
+	session = _session_yielding_rows([])
+	with patch("src.tasks.maintenance.SyncSessionLocal", return_value=session):
+		maintenance.drain_storage_deletion_outbox.run()
+
+	from sqlalchemy.dialects import postgresql
+
+	compiled_query = session.execute.call_args[0][0]
+	sql = str(compiled_query.compile(
+		dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+	))
+	assert "SKIP LOCKED" in sql.upper()
+	assert "ORDER BY" in sql.upper()
+
+
+@pytest.mark.parametrize("registered_name", ["drain_storage_deletion_outbox"])
+def test_drain_task_registered_on_callbacks_queue(registered_name):
+	from src.worker import celery_app
+
+	assert celery_app.conf.task_routes[registered_name]["queue"] == "callbacks"
+
+
+def test_drain_task_has_beat_schedule_entry():
+	from src.worker import celery_app
+
+	assert "drain-storage-deletion-outbox" in celery_app.conf.beat_schedule
+	entry = celery_app.conf.beat_schedule["drain-storage-deletion-outbox"]
+	assert entry["task"] == "drain_storage_deletion_outbox"

--- a/apps/api/tests/test_storage_deletion_outbox_gc.py
+++ b/apps/api/tests/test_storage_deletion_outbox_gc.py
@@ -219,3 +219,28 @@ def test_drain_task_has_beat_schedule_entry():
 	assert "drain-storage-deletion-outbox" in celery_app.conf.beat_schedule
 	entry = celery_app.conf.beat_schedule["drain-storage-deletion-outbox"]
 	assert entry["task"] == "drain_storage_deletion_outbox"
+
+def test_drain_stops_when_full_batch_makes_no_progress():
+	"""A full batch where every deletion fails must terminate the drain loop
+	instead of re-fetching the same failing rows until the task time limit
+	kills it (e.g. an S3 outage during a large erasure) — the beat tick and
+	the next delete flow's trigger retry later (#366)."""
+	from src.tasks import maintenance
+
+	rows = [
+		_make_row(s3_key=f"podcasts/ep-{i}.mp3")
+		for i in range(maintenance.STORAGE_GC_BATCH_SIZE)
+	]
+	session = _session_yielding_rows(rows)
+	mock_storage = MagicMock()
+
+	with patch("src.tasks.maintenance.SyncSessionLocal", return_value=session), \
+		patch("src.tasks.maintenance.StorageService", return_value=mock_storage), \
+		patch("src.tasks.maintenance.asyncio.run", side_effect=Exception("S3 down")):
+		drained = maintenance.drain_storage_deletion_outbox.run()
+
+	assert drained == 0
+	# One fetch, then stop: zero progress on a full batch must not refetch.
+	session.execute.assert_called_once()
+	for row in rows:
+		assert row.attempts == 1

--- a/apps/api/tests/unit/test_celery_callbacks.py
+++ b/apps/api/tests/unit/test_celery_callbacks.py
@@ -782,3 +782,42 @@ class TestUpdateEpisodeHelper:
 			result = _update_episode(episode_id, updates={})
 
 		assert result is False
+
+
+class TestQueueOrphanedStorage:
+	"""_queue_orphaned_storage must be durable itself (issue #366): if the
+	outbox insert fails, the artifact it was recording is orphaned forever."""
+
+	def test_retries_transient_insert_failure_then_succeeds(self):
+		"""A transient DB error on the first insert attempt is retried; the
+		row lands and the helper reports success."""
+		from src.tasks.callbacks import _queue_orphaned_storage
+
+		good_ctx, good_session = _make_sync_session(None)
+		with patch(
+			"src.tasks.callbacks.SyncSessionLocal",
+			side_effect=[Exception("db blip"), good_ctx],
+		), patch("src.tasks.callbacks.time.sleep"):
+			queued = _queue_orphaned_storage(s3_key="key.mp3")
+
+		assert queued is True
+		good_session.commit.assert_called_once()
+
+	def test_logs_critical_with_key_after_exhausting_retries(self):
+		"""After all attempts fail, the key/path is logged at CRITICAL — the
+		log line is the only remaining trace of the orphan (no ListBucket)."""
+		import logging
+
+		from src.tasks.callbacks import _queue_orphaned_storage
+
+		with patch(
+			"src.tasks.callbacks.SyncSessionLocal",
+			side_effect=Exception("db down"),
+		), patch("src.tasks.callbacks.time.sleep"), patch(
+			"src.tasks.callbacks.logger"
+		) as mock_logger:
+			queued = _queue_orphaned_storage(s3_key="key.mp3")
+
+		assert queued is False
+		mock_logger.critical.assert_called_once()
+		assert "key.mp3" in str(mock_logger.critical.call_args)

--- a/apps/api/tests/unit/test_celery_callbacks.py
+++ b/apps/api/tests/unit/test_celery_callbacks.py
@@ -101,8 +101,10 @@ class TestOnUploadComplete:
 		# Session should not have been entered at all
 		mock_ctx.__enter__.assert_not_called()
 
-	def test_handles_missing_episode_gracefully(self):
-		"""Callback logs error but does not raise if episode is not found."""
+	def test_absorbs_orphaned_upload_when_episode_missing(self):
+		"""If the episode was deleted after this upload started (issue #366),
+		the callback queues the now-orphaned S3 key for deletion instead of
+		only logging — never raises."""
 		episode_id = str(uuid.uuid4())
 		mock_ctx, mock_session = _make_sync_session(None)  # .get() returns None
 
@@ -118,7 +120,12 @@ class TestOnUploadComplete:
 			# Should not raise
 			_invoke_task(on_upload_complete, result=result, episode_id=episode_id)
 
-		mock_session.commit.assert_not_called()
+		added_rows = [
+			call.args[0] for call in mock_session.add.call_args_list
+		]
+		assert len(added_rows) == 1
+		assert added_rows[0].s3_key == "key.mp3"
+		mock_session.commit.assert_called_once()
 
 	def test_updates_generation_progress(self):
 		"""generation_progress is updated with 'upload: complete' on success."""

--- a/apps/api/tests/unit/test_celery_callbacks.py
+++ b/apps/api/tests/unit/test_celery_callbacks.py
@@ -806,7 +806,6 @@ class TestQueueOrphanedStorage:
 	def test_logs_critical_with_key_after_exhausting_retries(self):
 		"""After all attempts fail, the key/path is logged at CRITICAL — the
 		log line is the only remaining trace of the orphan (no ListBucket)."""
-		import logging
 
 		from src.tasks.callbacks import _queue_orphaned_storage
 

--- a/apps/api/tests/unit/test_migration_017_storage_deletion_outbox.py
+++ b/apps/api/tests/unit/test_migration_017_storage_deletion_outbox.py
@@ -1,0 +1,119 @@
+"""
+Unit tests for migration 017_add_storage_deletion_outbox (issue #366).
+
+Tests cover:
+- Migration metadata (revision ID, down_revision chaining)
+- upgrade() creates the table, its index, and grants the app role
+- downgrade() drops the table
+"""
+
+import importlib.util
+import os
+from unittest.mock import patch
+
+
+def _load_migration():
+	migration_path = os.path.join(
+		os.path.dirname(__file__),
+		'..', '..', 'alembic', 'versions',
+		'017_add_storage_deletion_outbox.py',
+	)
+	migration_path = os.path.normpath(migration_path)
+	spec = importlib.util.spec_from_file_location(
+		'migration_017', migration_path
+	)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+# ============================================================================
+# METADATA TESTS
+# ============================================================================
+
+def test_migration_revision_id():
+	"""Migration must declare revision ID '017'."""
+	mod = _load_migration()
+	assert mod.revision == '017'
+
+
+def test_migration_down_revision():
+	"""Migration must chain onto revision '016'."""
+	mod = _load_migration()
+	assert mod.down_revision == '016'
+
+
+def test_migration_branch_labels_none():
+	mod = _load_migration()
+	assert mod.branch_labels is None
+
+
+def test_migration_depends_on_none():
+	mod = _load_migration()
+	assert mod.depends_on is None
+
+
+# ============================================================================
+# UPGRADE TESTS
+# ============================================================================
+
+def test_upgrade_creates_storage_deletion_outbox_table():
+	"""upgrade() must create the storage_deletion_outbox table."""
+	mod = _load_migration()
+	with patch('alembic.op.create_table') as mock_create_table, \
+		patch('alembic.op.create_index'), \
+		patch('alembic.op.execute'):
+		mod.upgrade()
+	table_names = [c.args[0] for c in mock_create_table.call_args_list]
+	assert 'storage_deletion_outbox' in table_names
+
+
+def test_upgrade_table_has_check_constraint_for_s3_key_or_file_path():
+	"""The table must include a CHECK that s3_key or file_path is set."""
+	mod = _load_migration()
+	with patch('alembic.op.create_table') as mock_create_table, \
+		patch('alembic.op.create_index'), \
+		patch('alembic.op.execute'):
+		mod.upgrade()
+	call = mock_create_table.call_args_list[0]
+	# CheckConstraint objects are passed as positional args alongside Columns.
+	from sqlalchemy import CheckConstraint
+	constraints = [arg for arg in call.args if isinstance(arg, CheckConstraint)]
+	assert len(constraints) == 1
+
+
+def test_upgrade_creates_created_at_index():
+	"""upgrade() must create an index on created_at for the drain query."""
+	mod = _load_migration()
+	with patch('alembic.op.create_table'), \
+		patch('alembic.op.create_index') as mock_create_index, \
+		patch('alembic.op.execute'):
+		mod.upgrade()
+	index_names = [c.args[0] for c in mock_create_index.call_args_list]
+	assert 'ix_storage_deletion_outbox_created_at' in index_names
+
+
+def test_upgrade_grants_app_role():
+	"""upgrade() must GRANT the podcastfy_app role access to the table."""
+	mod = _load_migration()
+	with patch('alembic.op.create_table'), \
+		patch('alembic.op.create_index'), \
+		patch('alembic.op.execute') as mock_execute:
+		mod.upgrade()
+	statements = [c.args[0] for c in mock_execute.call_args_list]
+	assert any(
+		'GRANT' in s and 'storage_deletion_outbox' in s and 'podcastfy_app' in s
+		for s in statements
+	)
+
+
+# ============================================================================
+# DOWNGRADE TESTS
+# ============================================================================
+
+def test_downgrade_drops_storage_deletion_outbox_table():
+	mod = _load_migration()
+	with patch('alembic.op.drop_table') as mock_drop:
+		mod.downgrade()
+	table_names = [c.args[0] for c in mock_drop.call_args_list]
+	assert 'storage_deletion_outbox' in table_names

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -158,13 +158,19 @@ EOF
 
 #### Step 4: Restart Celery
 
+`-B` runs beat embedded in this single worker process — no separate process
+starts a standalone beat, so without it nothing actually schedules
+`reap_stuck_episodes` or `drain_storage_deletion_outbox` (issue #366). This is
+only safe with exactly one worker process; running `-B` on more than one would
+double-schedule every beat task.
+
 ```bash
 ssh root@<SERVER_IP> << 'EOF'
 cd /opt/podcaststudiohub/api
 
 pm2 delete podcaststudiohub-celery 2>/dev/null || true
 pm2 start uv --name podcaststudiohub-celery --cwd /opt/podcaststudiohub/api \
-  -- run celery -A src.worker:celery_app worker --loglevel=info
+  -- run celery -A src.worker:celery_app worker -B --loglevel=info
 pm2 save
 EOF
 ```
@@ -589,10 +595,10 @@ pm2 start uv --name podcaststudiohub-api --cwd /opt/podcaststudiohub/api \
 cd /opt/podcaststudiohub/frontend
 PORT=3010 pm2 start npm --name podcaststudiohub-frontend --cwd /opt/podcaststudiohub/frontend -- start
 
-# Restart Celery
+# Restart Celery (-B: embedded beat — single worker process only, see Step 4)
 cd /opt/podcaststudiohub/api
 pm2 start uv --name podcaststudiohub-celery --cwd /opt/podcaststudiohub/api \
-  -- run celery -A src.worker:celery_app worker --loglevel=info
+  -- run celery -A src.worker:celery_app worker -B --loglevel=info
 
 pm2 save
 pm2 list

--- a/scripts/repo-maintainer/setup-demo-vps.sh
+++ b/scripts/repo-maintainer/setup-demo-vps.sh
@@ -248,11 +248,15 @@ module.exports = {
       },
     },
     {
+      // -B: embedded beat. No separate process starts a standalone beat, so
+      // without it nothing schedules reap_stuck_episodes or
+      // drain_storage_deletion_outbox (issue #366). Only safe because this is
+      // the single worker process for this deployment.
       name: 'demo-celery',
       cwd: '$DEMO_PATH/repo/apps/api',
       interpreter: 'none',
       script: '\$HOME/.cargo/bin/uv',
-      args: 'run celery -A src.worker:celery_app worker --loglevel=info',
+      args: 'run celery -A src.worker:celery_app worker -B --loglevel=info',
       env_file: '$DEMO_PATH/.env.demo',
     },
   ],

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -316,3 +316,11 @@ first compile); fresh CI venvs recompile. Clear __pycache__ to reproduce compile
   degradation path, or the test breeds false confidence. (Caught by post-PR GLM.)
 - `showboat exec` signature is `<file> <lang> [code]` — omitting the lang makes
   it treat the whole command string as argv[0] and fail with fork/exec noise.
+- `pytest | tail && git commit && git push` commits on FAILING tests — the
+  pipeline's exit code is tail's (0), not pytest's. Always `set -o pipefail`
+  (or check pytest's status separately) before chaining a test run into
+  commit/push. Cost: a broken push to a PR branch on #366.
+- Tests on tables without RLS (e.g. storage_deletion_outbox) must scope
+  assertions to the test's own tenant/keys, never assert global table
+  emptiness/equality — any concurrent writer to the shared dev DB (demo
+  agents, second pytest session) breaks them.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,23 +1,73 @@
-# Issue #312 — Distribution idempotency (P3.9)
+# Issue #366 — Durable storage-erasure queue (outbox/GC) for delete flows (P3.10)
 
-**Problem**: `distribute_to_platform_task` (max_retries=5, acks_late) has no idempotency guard —
-a redelivery after a successful publish re-publishes to Spotify/Apple or re-POSTs the webhook.
+**Problem** (follow-up to #308): S3/local cleanup in `delete_episode` and `erase_user` is
+best-effort and runs **before** the DB commit. Two windows: (1) commit fails after storage
+deletion → rows point at deleted audio; (2) in-flight generation TOCTOU → a task finishing
+after the 409 check / episode delete uploads audio that is orphaned forever (IAM has no
+`s3:ListBucket`, so orphans are unfindable).
 
-**Plan source**: CodeRabbit comment (verified against current code 2026-07-10; matches exactly).
-**Design choice**: record success in-task via existing `generation_progress["distribution"]` +
-`SELECT FOR UPDATE` pattern (no new table). Callback stays as idempotent redundancy.
+**Plan source**: self-authored (issue prescribes the architecture: durable deletion outbox +
+periodic GC worker; no plan comment existed).
+
+## Design (autonomous decisions)
+
+- **Pure outbox**: delete flows stop touching storage entirely. They insert
+  `storage_deletion_outbox` rows (s3_key / file_path) **in the same transaction** as the row
+  deletes, then commit. Commit fails → nothing was deleted from storage (closes window 1).
+- **Prompt drain**: post-commit, best-effort `drain_storage_deletion_outbox.delay()` so audio
+  disappears promptly; the beat schedule is the durable backstop.
+- **GC task** in existing `src/tasks/maintenance.py` (same module as the reaper): batch
+  `SELECT … FOR UPDATE SKIP LOCKED`, delete via `StorageService.delete_file` / `os.remove`
+  (missing local file = success; S3 delete_object is idempotent), delete row on success,
+  `attempts += 1` + `last_attempt_at` on failure. Loops while a full batch was processed.
+- **Absorb late uploads** (closes window 2): where upload results are persisted and the episode
+  row is found missing (`finalize_episode_generation_task`, `callbacks.on_upload_complete`, and
+  composition persist if applicable), insert an outbox row for the just-uploaded key instead of
+  only logging.
+- **No RLS on the outbox table** (deliberate): internal, never API-exposed; the Celery worker
+  must drain cross-tenant. `tenant_id` kept as a plain nullable UUID for audit. GRANT to
+  `podcastfy_app` in the migration.
+- **Beat actually runs**: `beat_schedule` exists but no deployment starts a beat process (the
+  reaper never fires in prod!). Add `-B` (embedded beat) to the single celery worker command in
+  deploy configs.
+- Keep: erase_user 409 guard (defense in depth); episode delete stays guard-free (it's the only
+  abort mechanism — per issue comment); absorb covers its orphan window.
 
 ## Steps
 
-- [x] 1. Tests first (RED): 17 unit tests (`test_distribution_idempotency.py`)
-- [x] 2. Services: optional `idempotency_key` → `Idempotency-Key` header
-- [x] 3. `platform_distribution.py`: `_idempotency_key()` helper (derived in helpers, not threaded — shorter diff), webhook header+payload, locked pre-check skip, in-task `record_platform_distribution` (extracted from `on_distribution_complete`)
-- [x] 4. Full suite 1720 passed, coverage 94.05%; ruff clean
-- [x] 5. Reviews (opencode pre-PR + post-PR, triaged), PR #371, demo posted
-- [x] 6. **Demo-found bug**: migration 001 `episodes_status_check` rejected `distributing`/`composing`/`uploading`/`distribution_failed` → callbacks silently never recorded results. Fixed via migration 016 + constraint regression test + web status labels. Filed #372 (psycopg Jsonb test-isolation poisoning).
-- [x] 7. CI green (12 checks) → squash-merged as PR #371 (2026-07-10)
+- [x] 1. Migration `017_add_storage_deletion_outbox` (+ structure unit test): table
+  (id UUID PK, tenant_id UUID null, s3_key Text null, file_path Text null,
+  CHECK s3_key/file_path not both null, attempts int default 0, created_at, last_attempt_at),
+  ix on created_at, GRANT, downgrade. Model `src/models/storage_deletion_outbox.py`,
+  registered in `models/__init__.py`.
+- [x] 2. `delete_episode` (episode_service.py:313-365): replace inline `storage.delete_file` /
+  `os.remove` loops with outbox inserts in-session; delete + commit; post-commit best-effort
+  `.delay()`. Update existing tests asserting inline deletion.
+- [x] 3. `erase_user` (offboarding_service.py): same rewire — existing key collection stays,
+  inserts replace inline deletion, cascade delete + audit + commit, post-commit `.delay()`.
+  Return shape becomes "queued" counts (endpoint returns 204; contract-safe).
+- [x] 4. `drain_storage_deletion_outbox` task in maintenance.py + `task_routes` entry +
+  `beat_schedule` entry (interval setting in config.py, mirror reaper's). Tests mirror
+  `test_maintenance.py` (mock SyncSessionLocal + StorageService).
+- [x] 5. Absorb late uploads in `finalize_episode_generation_task` + `on_upload_complete`
+  (+ composition callback if it persists keys): missing episode row → outbox insert via sync
+  session. Tests: upload completes after delete → key lands in outbox. Composition callback
+  confirmed N/A — `merge_audio_snippets_task` never uploads to S3 and `composed_s3_key` is
+  never written anywhere in the codebase (only declared and read by the delete flows), so
+  there's no composition-path orphan window to absorb.
+- [x] 6. Deployment: add `-B` to celery worker command in `.github/workflows/deploy-dev.yml`,
+  `deployment/README.md`, `scripts/repo-maintainer/setup-demo-vps.sh` (single-worker
+  assumption noted).
+- [x] 7. Full suite + coverage ≥85 + ruff. (1746 passed, 7 pre-existing skips, 94.07% coverage,
+  ruff clean on all touched files.) Deslop / opencode-GLM pre-PR review / internal review not
+  yet run — left to the orchestrator.
+- [ ] 8. PR → post-PR review comment → demo (hard gate) → CI green → docs sync → merge.
 
-## Acceptance criteria (from issue)
-- Pre-publish check skips platforms already recorded complete (locked read)
-- Stable `{episode_id}:{platform}` idempotency key passed to platform API + webhook payload/header
-- Success recorded transactionally
+## Acceptance criteria
+
+- [x] AC1: DB commit failure during a delete flow leaves storage untouched (no deletion before commit).
+- [x] AC2: Intended deletions are durably recorded and retried until success (attempts tracked).
+- [x] AC3: Late Celery upload after episode/account deletion gets absorbed into the outbox (no permanent orphan).
+- [x] AC4: GC runs periodically in deployed env (beat process actually scheduled) and promptly post-delete.
+- [x] AC5: Only `delete_object` on known keys — no `s3:ListBucket` dependency.
+- [x] AC6: erase_user 409 guard unchanged; episode delete remains guard-free.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -58,9 +58,13 @@ periodic GC worker; no plan comment existed).
 - [x] 6. Deployment: add `-B` to celery worker command in `.github/workflows/deploy-dev.yml`,
   `deployment/README.md`, `scripts/repo-maintainer/setup-demo-vps.sh` (single-worker
   assumption noted).
-- [x] 7. Full suite + coverage ≥85 + ruff. (1746 passed, 7 pre-existing skips, 94.07% coverage,
-  ruff clean on all touched files.) Deslop / opencode-GLM pre-PR review / internal review not
-  yet run — left to the orchestrator.
+- [x] 7. Quality gate done: 1751 passed / 7 pre-existing skips; diff coverage 100% (0 missing
+  lines); ruff clean; mutation check 4/4 killed; deslop clean (1 observation fixed: tenant_id
+  threaded into finalize absorb). Reviews: internal Critical fixed (content-source s3_keys
+  orphaned on episode delete); codex cross-family P2 fixed (absorb outbox insert now retried
+  inline + CRITICAL last-resort log); my own review fixed GC zero-progress hot loop + locked
+  the delete-flow key reads (TOCTOU). opencode timed out twice → codex served as the
+  cross-family reviewer.
 - [ ] 8. PR → post-PR review comment → demo (hard gate) → CI green → docs sync → merge.
 
 ## Acceptance criteria


### PR DESCRIPTION
## Summary
Implements #366: [P3.10] Durable storage-erasure queue (outbox/GC) for delete flows.

- New `storage_deletion_outbox` table (migration 017) — delete flows (`delete_episode`, `erase_user`) no longer touch S3/disk inline; they queue keys/paths **in the same transaction** as the row delete, so a failed commit leaves storage untouched (closes the commit-failure window from #308).
- New Celery GC task `drain_storage_deletion_outbox` (in `maintenance.py`): `FOR UPDATE SKIP LOCKED` batches, idempotent deletes, `attempts`/`last_attempt_at` on failure, stops on zero-progress full batches (no hot loop during an S3 outage). Beat entry + best-effort post-commit `.delay()` for prompt deletion.
- Late-upload absorption (closes the in-flight TOCTOU window): `on_upload_complete` (missing-row branch) and `finalize_episode_generation_task` (`StaleDataError` branch) queue the just-uploaded key into the outbox instead of orphaning it; the absorb insert itself is retried inline with a CRITICAL last-resort log.
- Delete flows read keys under `SELECT ... FOR UPDATE`/locked refresh, serializing against the callbacks' locks — a key persisted between fetch and delete-commit can no longer slip through.
- Episode delete now also queues content-source objects (`source_data["s3_key"]`, PDFs/images) that cascade-delete with the episode — `erase_user` already did; found by internal review.
- Deployment: celery worker now runs with `-B` (embedded beat) in deploy-dev/README/demo-VPS configs. **This also fixes `reap_stuck_episodes` never firing in deployed envs** — the beat schedule existed but no beat process ran it.
- Outbox table deliberately has **no RLS** (never API-exposed; the GC drains cross-tenant); `tenant_id` kept as a plain nullable UUID for audit.

## Acceptance Criteria
- [x] AC1: DB commit failure during a delete flow leaves storage untouched (nothing deleted pre-commit)
- [x] AC2: Intended deletions durably recorded and retried until success (attempts tracked)
- [x] AC3: Late Celery upload after episode/account deletion absorbed into the outbox (no permanent orphan)
- [x] AC4: GC actually runs when deployed (beat via `-B`) and promptly post-delete (`.delay()` trigger)
- [x] AC5: Only `delete_object` on known keys — no `s3:ListBucket` dependency
- [x] AC6: `erase_user` 409 guard unchanged; episode delete stays guard-free (it is the user's only abort mechanism)

## Test Plan
- [x] Unit tests written (TDD approach; RED confirmed before each GREEN)
- [x] All tests passing: 1751 passed, 7 pre-existing skips
- [x] Diff coverage 100% on changed lines (gate ≥85%)
- [x] Linting clean (ruff)
- [x] Internal code review (advisory) completed — 1 Critical found and fixed (content-source keys)
- [x] Cross-family review pass: **codex** — 1 P2 found and fixed (absorb insert durability). opencode (GLM) timed out twice on this diff and was abandoned.
- [x] Test mutation sanity check: 4/4 mutations killed

## Known Limitations / Intentionally Deferred
- **Callback DB-error orphan window (pre-existing, unchanged)**: if `on_upload_complete` hits a transient DB error while the episode row still exists, `s3_key` is never persisted and the uploaded object can be orphaned. Distinct from the two windows #366 targets; would need callback-level retries to close.
- **`erase_user` TOCTOU lock has no dedicated test** — the mechanism is identical to `delete_episode`'s, which is regression-tested (`test_delete_episode_queues_s3_key_persisted_after_fetch`); a symmetric test can't easily simulate cross-session races under the rollback-isolated fixture.
- **GC `os.remove` has no path-containment guard** — outbox `file_path` values are only ever system-written; defense-in-depth if the pattern is later extended to user-influenced paths.
- **Embedded beat (`-B`) assumes a single worker process** — noted in the deploy configs; split out a dedicated beat process if workers scale out.
- **Temp-file remnants in the absorbed finalize path** are `/tmp` per-run artifacts (issue #309 territory), not durable orphans — not queued.

## Implementation Notes
- Plan was self-authored (issue prescribed the architecture; no plan comment existed) — persisted in `tasks/todo.md`.
- The finalize absorb relies on SQLAlchemy raising `StaleDataError` on a 0-row-matched UPDATE (verified empirically; no `version_id_col` needed), with a defensive "row still present → fail, don't absorb" branch.
- Composition path confirmed N/A: `merge_audio_snippets_task` never uploads to S3 and `composed_s3_key` is never written anywhere in the codebase.

Closes #366