### PR TITLE
Fix test isolation: scope sys.modules patching so psycopg survives mocked-podcastfy windows (#372)

### DIFF
--- a/apps/api/tests/module_patching.py
+++ b/apps/api/tests/module_patching.py
@@ -1,0 +1,29 @@
+"""
+Scoped sys.modules patching for tests (issue #372).
+
+Never use ``unittest.mock.patch.dict(sys.modules, {...})``: its exit path
+clears the dict and re-applies a snapshot, evicting every module imported
+during the window. Evicting C-extension-backed packages (psycopg) breaks
+their global adapter state for the rest of the pytest session — see #372.
+
+``patch_modules`` restores only the keys it patched.
+"""
+import sys
+from contextlib import contextmanager
+
+_MISSING = object()
+
+
+@contextmanager
+def patch_modules(mapping):
+    """Temporarily set sys.modules entries; on exit restore only those keys."""
+    saved = {name: sys.modules.get(name, _MISSING) for name in mapping}
+    sys.modules.update(mapping)
+    try:
+        yield
+    finally:
+        for name, original in saved.items():
+            if original is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original

--- a/apps/api/tests/test_celery_workflow.py
+++ b/apps/api/tests/test_celery_workflow.py
@@ -10,6 +10,8 @@ infrastructure is required.
 import uuid
 from unittest.mock import MagicMock, patch
 
+from tests.module_patching import patch_modules
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -80,7 +82,6 @@ class TestFullWorkflowChain:
 
     def test_workflow_chain_dispatched_when_composition_enabled(self):
         """When enable_composition=True, build_generation_workflow is called."""
-        import sys
         import types
 
         episode_id = str(uuid.uuid4())
@@ -99,7 +100,7 @@ class TestFullWorkflowChain:
         from src.tasks.podcast_generation import generate_podcast_task
 
         with (
-            patch.dict(sys.modules, {"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
+            patch_modules({"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
             patch("src.tasks.podcast_generation.os.path.getsize", return_value=1000),
             patch("src.tasks.podcast_generation.AudioSegment") as mock_audio_cls,
             patch("src.tasks.podcast_generation.build_generation_workflow", return_value=mock_chain) as mock_builder,
@@ -128,7 +129,6 @@ class TestFullWorkflowChain:
 
     def test_workflow_chain_dispatched_when_distribution_enabled(self):
         """When enable_distribution=True with platforms, build_generation_workflow is called."""
-        import sys
         import types
 
         episode_id = str(uuid.uuid4())
@@ -148,7 +148,7 @@ class TestFullWorkflowChain:
         from src.tasks.podcast_generation import generate_podcast_task
 
         with (
-            patch.dict(sys.modules, {"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
+            patch_modules({"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
             patch("src.tasks.podcast_generation.os.path.getsize", return_value=2000),
             patch("src.tasks.podcast_generation.AudioSegment") as mock_audio_cls,
             patch("src.tasks.podcast_generation.build_generation_workflow", return_value=mock_chain) as mock_builder,
@@ -180,7 +180,6 @@ class TestFullWorkflowChain:
         runs would otherwise lose file_path/transcript_path/duration_seconds/
         file_size_bytes that the default finalize path records (issue #211).
         """
-        import sys
         import types
 
         episode_id = str(uuid.uuid4())
@@ -203,7 +202,7 @@ class TestFullWorkflowChain:
         from src.tasks.podcast_generation import generate_podcast_task
 
         with (
-            patch.dict(sys.modules, {"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
+            patch_modules({"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
             patch("src.tasks.podcast_generation.os.path.getsize", return_value=2000),
             patch("src.tasks.podcast_generation.AudioSegment") as mock_audio_cls,
             patch("src.tasks.podcast_generation.build_generation_workflow", return_value=MagicMock()),
@@ -227,7 +226,6 @@ class TestFullWorkflowChain:
 
     def test_finalize_task_used_when_no_composition_or_distribution(self):
         """Default path (no composition, no distribution) uses finalize_episode_generation_task."""
-        import sys
         import types
 
         episode_id = str(uuid.uuid4())
@@ -244,7 +242,7 @@ class TestFullWorkflowChain:
         from src.tasks.podcast_generation import generate_podcast_task
 
         with (
-            patch.dict(sys.modules, {"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
+            patch_modules({"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
             patch("src.tasks.podcast_generation.os.path.getsize", return_value=1000),
             patch("src.tasks.podcast_generation.AudioSegment") as mock_audio_cls,
             patch("src.tasks.podcast_generation.build_generation_workflow") as mock_builder,
@@ -268,7 +266,6 @@ class TestFullWorkflowChain:
 
     def test_finalize_task_used_when_distribution_enabled_but_no_platforms(self):
         """enable_distribution=True but platforms=None falls back to finalize task."""
-        import sys
         import types
 
         episode_id = str(uuid.uuid4())
@@ -285,7 +282,7 @@ class TestFullWorkflowChain:
         from src.tasks.podcast_generation import generate_podcast_task
 
         with (
-            patch.dict(sys.modules, {"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
+            patch_modules({"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
             patch("src.tasks.podcast_generation.os.path.getsize", return_value=1000),
             patch("src.tasks.podcast_generation.AudioSegment") as mock_audio_cls,
             patch("src.tasks.podcast_generation.build_generation_workflow") as mock_builder,
@@ -541,7 +538,6 @@ class TestConditionalComposition:
 
     def test_generate_task_passes_composition_timeline(self):
         """Task passes composition_timeline to build_generation_workflow."""
-        import sys
         import types
 
         episode_id = str(uuid.uuid4())
@@ -563,7 +559,7 @@ class TestConditionalComposition:
         from src.tasks.podcast_generation import generate_podcast_task
 
         with (
-            patch.dict(sys.modules, {"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
+            patch_modules({"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
             patch("src.tasks.podcast_generation.os.path.getsize", return_value=1000),
             patch("src.tasks.podcast_generation.AudioSegment") as mock_audio_cls,
             patch("src.tasks.podcast_generation.build_generation_workflow", return_value=mock_chain) as mock_builder,
@@ -593,7 +589,6 @@ class TestErrorHandling:
 
     def test_workflow_chain_not_called_on_generation_failure(self):
         """If podcast generation fails, build_generation_workflow is never called."""
-        import sys
         import types
 
         episode_id = str(uuid.uuid4())
@@ -606,7 +601,7 @@ class TestErrorHandling:
         from src.tasks.podcast_generation import generate_podcast_task
 
         with (
-            patch.dict(sys.modules, {"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
+            patch_modules({"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
             patch("src.tasks.podcast_generation.build_generation_workflow") as mock_builder,
             patch("src.tasks.podcast_generation.finalize_episode_generation_task"),
             patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=_mock_session_with_episode()),
@@ -628,7 +623,6 @@ class TestErrorHandling:
 
     def test_broker_error_during_workflow_dispatch_does_not_fail_generation(self):
         """A broker failure when dispatching the workflow chain does not change generation result."""
-        import sys
         import types
 
         episode_id = str(uuid.uuid4())
@@ -648,7 +642,7 @@ class TestErrorHandling:
         from src.tasks.podcast_generation import generate_podcast_task
 
         with (
-            patch.dict(sys.modules, {"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
+            patch_modules({"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
             patch("src.tasks.podcast_generation.os.path.getsize", return_value=1000),
             patch("src.tasks.podcast_generation.AudioSegment") as mock_audio_cls,
             patch("src.tasks.podcast_generation.build_generation_workflow", return_value=mock_chain),
@@ -671,7 +665,6 @@ class TestErrorHandling:
         """Fail closed: if the episode/user_id cannot be resolved, the upload
         chain is never dispatched, so nothing is written outside the
         podcasts/user-*/ tenant prefix (issue #215)."""
-        import sys
         import types
 
         episode_id = str(uuid.uuid4())
@@ -693,7 +686,7 @@ class TestErrorHandling:
         from src.tasks.podcast_generation import generate_podcast_task
 
         with (
-            patch.dict(sys.modules, {"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
+            patch_modules({"podcastfy": mock_podcastfy, "podcastfy.client": mock_client}),
             patch("src.tasks.podcast_generation.os.path.getsize", return_value=1000),
             patch("src.tasks.podcast_generation.AudioSegment") as mock_audio_cls,
             patch("src.tasks.podcast_generation.build_generation_workflow") as mock_builder,

--- a/apps/api/tests/test_sync_jsonb_isolation.py
+++ b/apps/api/tests/test_sync_jsonb_isolation.py
@@ -9,9 +9,10 @@ produced a fresh ``Jsonb`` class unknown to the already-registered adapter
 map, so any later sync-session ORM insert with a JSONB column failed with
 ``cannot adapt type 'Jsonb'``.
 
-This file sorts after ``tests/test_celery_workflow.py`` so, in a shared
-pytest session (including the full suite), the insert below exercises the
-exact poisoned path from the issue repro.
+This file sorts after ``tests/test_celery_workflow.py`` under pytest's
+default alphabetical collection, so in a full-suite run the insert below is
+a canary for the issue's repro path. The deterministic, ordering-independent
+guard is ``tests/unit/test_module_patching.py``.
 """
 import uuid
 

--- a/apps/api/tests/test_sync_jsonb_isolation.py
+++ b/apps/api/tests/test_sync_jsonb_isolation.py
@@ -1,0 +1,32 @@
+"""
+Regression test for issue #372.
+
+The mocked-podcastfy workflow tests used ``patch.dict(sys.modules, {...})``,
+whose exit path clears ``sys.modules`` and re-applies a snapshot — evicting
+every module imported *during* the patch window. The first such test lazily
+imported the whole ``psycopg`` tree inside the window; eviction + re-import
+produced a fresh ``Jsonb`` class unknown to the already-registered adapter
+map, so any later sync-session ORM insert with a JSONB column failed with
+``cannot adapt type 'Jsonb'``.
+
+This file sorts after ``tests/test_celery_workflow.py`` so, in a shared
+pytest session (including the full suite), the insert below exercises the
+exact poisoned path from the issue repro.
+"""
+import uuid
+
+from src.database import SyncSessionLocal
+from src.models.user import User
+
+
+def test_sync_orm_jsonb_insert_after_workflow_tests():
+    with SyncSessionLocal() as db:
+        user = User(
+            email=f"jsonb-isolation-{uuid.uuid4()}@test.local",
+            password_hash="x",
+            tenant_id=uuid.uuid4(),
+            encrypted_api_keys={"probe": "value"},
+        )
+        db.add(user)
+        db.flush()  # executes the INSERT (where Jsonb adaptation happens)
+        db.rollback()  # leave no row behind

--- a/apps/api/tests/unit/test_audio_composition_task.py
+++ b/apps/api/tests/unit/test_audio_composition_task.py
@@ -5,9 +5,10 @@ Covers issue #116: happy path merging, normalize/fade flags,
 empty timeline edge case, and error-path return shape.
 """
 
-import sys
 import types
 from unittest.mock import MagicMock, patch
+
+from tests.module_patching import patch_modules
 
 from src.tasks.audio_composition import merge_audio_snippets_task
 
@@ -49,7 +50,7 @@ class TestMergeAudioSnippetsTask:
 		]
 
 		with patch.object(merge_audio_snippets_task, "update_state") as mock_update, \
-			 patch.dict(sys.modules, mock_modules), \
+			 patch_modules(mock_modules), \
 			 patch("os.path.getsize", return_value=4096):
 
 			result = merge_audio_snippets_task.run(
@@ -92,7 +93,7 @@ class TestMergeAudioSnippetsTask:
 		]
 
 		with patch.object(merge_audio_snippets_task, "update_state"), \
-			 patch.dict(sys.modules, mock_modules), \
+			 patch_modules(mock_modules), \
 			 patch("os.path.getsize", return_value=2048):
 
 			result = merge_audio_snippets_task.run(
@@ -113,7 +114,7 @@ class TestMergeAudioSnippetsTask:
 		mock_cls.empty.return_value = empty_seg
 
 		with patch.object(merge_audio_snippets_task, "update_state"), \
-			 patch.dict(sys.modules, mock_modules), \
+			 patch_modules(mock_modules), \
 			 patch("os.path.getsize", return_value=0):
 
 			result = merge_audio_snippets_task.run(
@@ -136,7 +137,7 @@ class TestMergeAudioSnippetsTask:
 		timeline = [{"file_path": "/tmp/bad.mp3"}]
 
 		with patch.object(merge_audio_snippets_task, "update_state"), \
-			 patch.dict(sys.modules, mock_modules), \
+			 patch_modules(mock_modules), \
 			 patch.object(
 				merge_audio_snippets_task,
 				"retry",

--- a/apps/api/tests/unit/test_generation_idempotency.py
+++ b/apps/api/tests/unit/test_generation_idempotency.py
@@ -7,9 +7,10 @@ already-complete or in-flight episodes before any paid call, and (3) use a Redis
 lock to block concurrent/duplicate in-flight runs while self-healing via TTL.
 """
 
-import sys
 import types
 from unittest.mock import MagicMock, create_autospec, patch
+
+from tests.module_patching import patch_modules
 from uuid import uuid4
 
 from podcastfy.client import generate_podcast as real_generate_podcast
@@ -123,7 +124,7 @@ def _run_with_status(status, *, retries=0, acquire=True):
              patch("src.tasks.podcast_generation.acquire_generation_lock", return_value=acquire), \
              patch("src.tasks.podcast_generation.release_generation_lock"), \
              patch("src.tasks.podcast_generation._update_episode"), \
-             patch.dict(sys.modules, mock_modules), \
+             patch_modules(mock_modules), \
              patch("src.tasks.podcast_generation.os.path.getsize", return_value=1024), \
              patch("src.tasks.podcast_generation.AudioSegment") as mock_audio, \
              patch("src.tasks.podcast_generation.finalize_episode_generation_task"):

--- a/apps/api/tests/unit/test_generation_idempotency.py
+++ b/apps/api/tests/unit/test_generation_idempotency.py
@@ -9,9 +9,9 @@ lock to block concurrent/duplicate in-flight runs while self-healing via TTL.
 
 import types
 from unittest.mock import MagicMock, create_autospec, patch
+from uuid import uuid4
 
 from tests.module_patching import patch_modules
-from uuid import uuid4
 
 from podcastfy.client import generate_podcast as real_generate_podcast
 

--- a/apps/api/tests/unit/test_module_patching.py
+++ b/apps/api/tests/unit/test_module_patching.py
@@ -1,0 +1,47 @@
+"""
+Contract tests for tests.module_patching.patch_modules (issue #372).
+
+Deterministically guards the fix regardless of collection order:
+tests/test_sync_jsonb_isolation.py is the full-suite canary; these tests
+pin the helper's restore semantics directly.
+"""
+import sys
+import types
+
+from tests.module_patching import patch_modules
+
+
+def test_module_imported_inside_window_survives_exit():
+    # The #372 bug: patch.dict(sys.modules, ...) evicted modules imported
+    # during the window (psycopg tree). patch_modules must not.
+    probe = "xml.sax.saxutils"
+    sys.modules.pop(probe, None)
+    with patch_modules({"fake_pkg_372": types.ModuleType("fake_pkg_372")}):
+        import xml.sax.saxutils  # noqa: F401
+        assert probe in sys.modules
+    assert probe in sys.modules
+
+
+def test_patched_key_absent_before_is_removed_after():
+    fake = types.ModuleType("fake_pkg_372")
+    with patch_modules({"fake_pkg_372": fake}):
+        assert sys.modules["fake_pkg_372"] is fake
+    assert "fake_pkg_372" not in sys.modules
+
+
+def test_patched_key_present_before_is_restored_after():
+    original = sys.modules["uuid"]
+    with patch_modules({"uuid": types.ModuleType("uuid")}):
+        assert sys.modules["uuid"] is not original
+    assert sys.modules["uuid"] is original
+
+
+def test_keys_restored_when_body_raises():
+    original = sys.modules["uuid"]
+    try:
+        with patch_modules({"uuid": types.ModuleType("uuid"), "fake_pkg_372": types.ModuleType("f")}):
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert sys.modules["uuid"] is original
+    assert "fake_pkg_372" not in sys.modules

--- a/apps/api/tests/unit/test_podcast_generation_task.py
+++ b/apps/api/tests/unit/test_podcast_generation_task.py
@@ -18,9 +18,9 @@ import tempfile
 import types
 from typing import Any
 from unittest.mock import MagicMock, create_autospec, patch
+from uuid import uuid4
 
 from tests.module_patching import patch_modules
-from uuid import uuid4
 
 # Real podcastfy function — imported so tests assert against the ACTUAL
 # installed signature (not a permissive MagicMock). This is the drift guard.

--- a/apps/api/tests/unit/test_podcast_generation_task.py
+++ b/apps/api/tests/unit/test_podcast_generation_task.py
@@ -14,11 +14,12 @@ YouTube URLs arrive via ``urls``; file/PDF sources arrive pre-extracted via
 import inspect
 import os
 import shutil
-import sys
 import tempfile
 import types
 from typing import Any
 from unittest.mock import MagicMock, create_autospec, patch
+
+from tests.module_patching import patch_modules
 from uuid import uuid4
 
 # Real podcastfy function — imported so tests assert against the ACTUAL
@@ -56,7 +57,7 @@ def _run_task(**task_kwargs: Any) -> tuple[dict[str, Any], MagicMock]:
 	audio_instance.__len__ = MagicMock(return_value=60000)
 
 	with patch.object(generate_podcast_task, 'update_state'), \
-		 patch.dict(sys.modules, mock_modules), \
+		 patch_modules(mock_modules), \
 		 patch('src.tasks.podcast_generation.os.path.getsize', return_value=1024), \
 		 patch('src.tasks.podcast_generation.AudioSegment') as mock_audio, \
 		 patch('src.tasks.podcast_generation.finalize_episode_generation_task'):
@@ -191,7 +192,7 @@ def test_task_returns_success_result():
 	audio_instance.__len__ = MagicMock(return_value=120000)
 
 	with patch.object(generate_podcast_task, 'update_state'), \
-		 patch.dict(sys.modules, mock_modules), \
+		 patch_modules(mock_modules), \
 		 patch('src.tasks.podcast_generation.os.path.getsize', return_value=2048), \
 		 patch('src.tasks.podcast_generation.AudioSegment') as mock_audio, \
 		 patch('src.tasks.podcast_generation.finalize_episode_generation_task'):
@@ -217,7 +218,7 @@ def test_task_returns_failed_result_on_exception():
 	)
 
 	with patch.object(generate_podcast_task, 'update_state'), \
-		 patch.dict(sys.modules, mock_modules), \
+		 patch_modules(mock_modules), \
 		 patch.object(
 			generate_podcast_task,
 			"retry",
@@ -299,7 +300,7 @@ def test_terminal_failure_cleans_up_run_dir():
 			real_generate_podcast, side_effect=RuntimeError("boom")
 		)
 		with patch.object(generate_podcast_task, 'update_state'), \
-			 patch.dict(sys.modules, mock_modules), \
+			 patch_modules(mock_modules), \
 			 patch('src.tasks.podcast_generation.tempfile.mkdtemp', return_value=run_dir), \
 			 patch.object(
 				generate_podcast_task,
@@ -328,7 +329,7 @@ def test_soft_timeout_cleans_up_run_dir():
 			real_generate_podcast, side_effect=SoftTimeLimitExceeded()
 		)
 		with patch.object(generate_podcast_task, 'update_state'), \
-			 patch.dict(sys.modules, mock_modules), \
+			 patch_modules(mock_modules), \
 			 patch('src.tasks.podcast_generation.tempfile.mkdtemp', return_value=run_dir):
 			result = generate_podcast_task.run(
 				episode_id=str(uuid4()),

--- a/apps/api/tests/unit/test_task_retry.py
+++ b/apps/api/tests/unit/test_task_retry.py
@@ -8,9 +8,10 @@ Verifies that:
 - Non-retryable errors are handled appropriately per task
 """
 
-import sys
 import types
 from unittest.mock import MagicMock, patch
+
+from tests.module_patching import patch_modules
 
 from botocore.exceptions import ClientError
 
@@ -256,7 +257,7 @@ class TestMergeAudioSnippetsTaskRetry:
 		timeline = [{"file_path": "/tmp/seg.mp3"}]
 
 		with (
-			patch.dict(sys.modules, mock_modules),
+			patch_modules(mock_modules),
 			patch.object(merge_audio_snippets_task, "update_state"),
 			patch.object(
 				merge_audio_snippets_task,
@@ -283,7 +284,7 @@ class TestMergeAudioSnippetsTaskRetry:
 		mock_cls.from_file.side_effect = RuntimeError("Disk full")
 
 		with (
-			patch.dict(sys.modules, mock_modules),
+			patch_modules(mock_modules),
 			patch.object(merge_audio_snippets_task, "update_state"),
 			patch.object(
 				merge_audio_snippets_task,
@@ -414,7 +415,7 @@ class TestGeneratePodcastTaskRetry:
 		mock_gen.side_effect = RuntimeError("LLM API unavailable")
 
 		with (
-			patch.dict(sys.modules, mock_modules),
+			patch_modules(mock_modules),
 			patch.object(generate_podcast_task, "update_state"),
 			patch.object(
 				generate_podcast_task,
@@ -440,7 +441,7 @@ class TestGeneratePodcastTaskRetry:
 		mock_gen.side_effect = RuntimeError("LLM API unavailable")
 
 		with (
-			patch.dict(sys.modules, mock_modules),
+			patch_modules(mock_modules),
 			patch.object(generate_podcast_task, "update_state"),
 			patch.object(
 				generate_podcast_task,
@@ -465,7 +466,7 @@ class TestGeneratePodcastTaskRetry:
 		mock_gen.side_effect = RuntimeError("Persistent failure")
 
 		with (
-			patch.dict(sys.modules, mock_modules),
+			patch_modules(mock_modules),
 			patch.object(generate_podcast_task, "update_state"),
 			patch.object(
 				generate_podcast_task,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,81 +1,37 @@
-# Issue #366 — Durable storage-erasure queue (outbox/GC) for delete flows (P3.10)
+# Issue #372 — Test isolation: mocked-podcastfy workflow tests poison psycopg Jsonb adaptation
 
-**Problem** (follow-up to #308): S3/local cleanup in `delete_episode` and `erase_user` is
-best-effort and runs **before** the DB commit. Two windows: (1) commit fails after storage
-deletion → rows point at deleted audio; (2) in-flight generation TOCTOU → a task finishing
-after the 409 check / episode delete uploads audio that is orphaned forever (IAM has no
-`s3:ListBucket`, so orphans are unfindable).
+## Root cause (verified with import-audit diagnostic)
 
-**Plan source**: self-authored (issue prescribes the architecture: durable deletion outbox +
-periodic GC worker; no plan comment existed).
+`unittest.mock.patch.dict(sys.modules, {...})` restores the dict on exit by
+**clearing it and re-applying the snapshot** — evicting every module imported
+*during* the window, not just the patched keys. The first poisoning test in
+`tests/test_celery_workflow.py` lazily imports the entire `psycopg` tree
+(~80 modules incl. the `psycopg_binary` C extension) inside the window;
+eviction + later re-import creates a new `psycopg.types.json.Jsonb` class that
+psycopg's already-registered adapters map (held by the previously imported
+SQLAlchemy dialect) doesn't recognize → `cannot adapt type 'Jsonb'`.
 
-## Design (autonomous decisions)
+Diagnostic evidence: audit-hook plugin showed test 1 of `TestFullWorkflowChain`
+evicts all `psycopg*` modules at patch exit.
 
-- **Pure outbox**: delete flows stop touching storage entirely. They insert
-  `storage_deletion_outbox` rows (s3_key / file_path) **in the same transaction** as the row
-  deletes, then commit. Commit fails → nothing was deleted from storage (closes window 1).
-- **Prompt drain**: post-commit, best-effort `drain_storage_deletion_outbox.delay()` so audio
-  disappears promptly; the beat schedule is the durable backstop.
-- **GC task** in existing `src/tasks/maintenance.py` (same module as the reaper): batch
-  `SELECT … FOR UPDATE SKIP LOCKED`, delete via `StorageService.delete_file` / `os.remove`
-  (missing local file = success; S3 delete_object is idempotent), delete row on success,
-  `attempts += 1` + `last_attempt_at` on failure. Loops while a full batch was processed.
-- **Absorb late uploads** (closes window 2): where upload results are persisted and the episode
-  row is found missing (`finalize_episode_generation_task`, `callbacks.on_upload_complete`, and
-  composition persist if applicable), insert an outbox row for the just-uploaded key instead of
-  only logging.
-- **No RLS on the outbox table** (deliberate): internal, never API-exposed; the Celery worker
-  must drain cross-tenant. `tenant_id` kept as a plain nullable UUID for audit. GRANT to
-  `podcastfy_app` in the migration.
-- **Beat actually runs**: `beat_schedule` exists but no deployment starts a beat process (the
-  reaper never fires in prod!). Add `-B` (embedded beat) to the single celery worker command in
-  deploy configs.
-- Keep: erase_user 409 guard (defense in depth); episode delete stays guard-free (it's the only
-  abort mechanism — per issue comment); absorb covers its orphan window.
+Same pattern exists in 5 more files (25 sites total):
+`tests/test_celery_workflow.py` (10), `tests/unit/test_podcast_generation_task.py` (5),
+`tests/unit/test_audio_composition_task.py` (4), `tests/unit/test_task_retry.py` (5),
+`tests/unit/test_generation_idempotency.py` (1).
 
-## Steps
+## Plan (TDD)
 
-- [x] 1. Migration `017_add_storage_deletion_outbox` (+ structure unit test): table
-  (id UUID PK, tenant_id UUID null, s3_key Text null, file_path Text null,
-  CHECK s3_key/file_path not both null, attempts int default 0, created_at, last_attempt_at),
-  ix on created_at, GRANT, downgrade. Model `src/models/storage_deletion_outbox.py`,
-  registered in `models/__init__.py`.
-- [x] 2. `delete_episode` (episode_service.py:313-365): replace inline `storage.delete_file` /
-  `os.remove` loops with outbox inserts in-session; delete + commit; post-commit best-effort
-  `.delay()`. Update existing tests asserting inline deletion.
-- [x] 3. `erase_user` (offboarding_service.py): same rewire — existing key collection stays,
-  inserts replace inline deletion, cascade delete + audit + commit, post-commit `.delay()`.
-  Return shape becomes "queued" counts (endpoint returns 204; contract-safe).
-- [x] 4. `drain_storage_deletion_outbox` task in maintenance.py + `task_routes` entry +
-  `beat_schedule` entry (interval setting in config.py, mirror reaper's). Tests mirror
-  `test_maintenance.py` (mock SyncSessionLocal + StorageService).
-- [x] 5. Absorb late uploads in `finalize_episode_generation_task` + `on_upload_complete`
-  (+ composition callback if it persists keys): missing episode row → outbox insert via sync
-  session. Tests: upload completes after delete → key lands in outbox. Composition callback
-  confirmed N/A — `merge_audio_snippets_task` never uploads to S3 and `composed_s3_key` is
-  never written anywhere in the codebase (only declared and read by the delete flows), so
-  there's no composition-path orphan window to absorb.
-- [x] 6. Deployment: add `-B` to celery worker command in `.github/workflows/deploy-dev.yml`,
-  `deployment/README.md`, `scripts/repo-maintainer/setup-demo-vps.sh` (single-worker
-  assumption noted).
-- [x] 7. Quality gate done: 1751 passed / 7 pre-existing skips; diff coverage 100% (0 missing
-  lines); ruff clean; mutation check 4/4 killed; deslop clean (1 observation fixed: tenant_id
-  threaded into finalize absorb). Reviews: internal Critical fixed (content-source s3_keys
-  orphaned on episode delete); codex cross-family P2 fixed (absorb outbox insert now retried
-  inline + CRITICAL last-resort log); my own review fixed GC zero-progress hot loop + locked
-  the delete-flow key reads (TOCTOU). opencode timed out twice → codex served as the
-  cross-family reviewer.
-- [x] 8. PR #373 squash-merged 2026-07-11; issue #366 auto-closed. Post-PR codex review
-  (starvation P2 fixed in 7afb131) + repo bug-hunt bot (1 Critical rebutted with empirical
-  evidence: StaleDataError DOES fire on psycopg without version_id_col — bot re-verified
-  against SQLAlchemy source and cleared it). Demo hard gate: all 6 ACs verified with real
-  outcome evidence (real Postgres/beat/HTTP). CI 12/12 green. Docs synced (CLAUDE.md 017).
+- [ ] RED: `tests/test_sync_jsonb_isolation.py` — sync-session ORM flush of a
+      `User` row (JSONB `encrypted_api_keys`); file sorts after
+      `test_celery_workflow.py`. Confirm it FAILS after workflow tests, PASSES alone.
+- [ ] GREEN: add `tests/module_patching.py` with `patch_modules(mapping)` — a
+      context manager that sets the given `sys.modules` keys and on exit restores
+      **only those keys** (leaving modules imported during the window intact).
+      Replace all 25 `patch.dict(sys.modules, ...)` sites with it.
+- [ ] Verify: issue repro commands pass in both orders; full API test suite green;
+      ruff clean.
 
-## Acceptance criteria
+## Scope note
 
-- [x] AC1: DB commit failure during a delete flow leaves storage untouched (no deletion before commit).
-- [x] AC2: Intended deletions are durably recorded and retried until success (attempts tracked).
-- [x] AC3: Late Celery upload after episode/account deletion gets absorbed into the outbox (no permanent orphan).
-- [x] AC4: GC runs periodically in deployed env (beat process actually scheduled) and promptly post-delete.
-- [x] AC5: Only `delete_object` on known keys — no `s3:ListBucket` dependency.
-- [x] AC6: erase_user 409 guard unchanged; episode delete remains guard-free.
+Fixing all 6 files (not just test_celery_workflow.py) — identical latent bug,
+mechanical swap, per bug-ownership rule.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -14,21 +14,21 @@ SQLAlchemy dialect) doesn't recognize → `cannot adapt type 'Jsonb'`.
 Diagnostic evidence: audit-hook plugin showed test 1 of `TestFullWorkflowChain`
 evicts all `psycopg*` modules at patch exit.
 
-Same pattern exists in 5 more files (25 sites total):
-`tests/test_celery_workflow.py` (10), `tests/unit/test_podcast_generation_task.py` (5),
+Same pattern exists in 5 more files (24 call sites total):
+`tests/test_celery_workflow.py` (9), `tests/unit/test_podcast_generation_task.py` (5),
 `tests/unit/test_audio_composition_task.py` (4), `tests/unit/test_task_retry.py` (5),
 `tests/unit/test_generation_idempotency.py` (1).
 
 ## Plan (TDD)
 
-- [ ] RED: `tests/test_sync_jsonb_isolation.py` — sync-session ORM flush of a
+- [x] RED: `tests/test_sync_jsonb_isolation.py` — sync-session ORM flush of a
       `User` row (JSONB `encrypted_api_keys`); file sorts after
       `test_celery_workflow.py`. Confirm it FAILS after workflow tests, PASSES alone.
-- [ ] GREEN: add `tests/module_patching.py` with `patch_modules(mapping)` — a
+- [x] GREEN: add `tests/module_patching.py` with `patch_modules(mapping)` — a
       context manager that sets the given `sys.modules` keys and on exit restores
       **only those keys** (leaving modules imported during the window intact).
-      Replace all 25 `patch.dict(sys.modules, ...)` sites with it.
-- [ ] Verify: issue repro commands pass in both orders; full API test suite green;
+      Replace all 24 `patch.dict(sys.modules, ...)` sites with it.
+- [x] Verify: issue repro commands pass in both orders; full API test suite green;
       ruff clean.
 
 ## Scope note


### PR DESCRIPTION
Closes #372

## Root cause (verified with an import-audit diagnostic)

`unittest.mock.patch.dict(sys.modules, {...})` restores on exit by clearing the dict and re-applying its snapshot — evicting **every module imported during the window**, not just the patched keys. The first mocked-podcastfy workflow test lazily imported the entire `psycopg` tree (~80 modules incl. the `psycopg_binary` C extension) inside that window. Eviction + later re-import created a new `psycopg.types.json.Jsonb` class unknown to the adapter registrations held by the already-imported SQLAlchemy dialect → `cannot adapt type 'Jsonb' using placeholder '%s'` on any later sync-session ORM JSONB insert.

## Fix

- New `tests/module_patching.py::patch_modules(mapping)` — sets the given `sys.modules` keys and on exit restores **only those keys**, leaving modules imported during the window intact.
- Replaced all 24 `patch.dict(sys.modules, ...)` call sites across 5 test files (`test_celery_workflow.py`: 9, plus 4 `tests/unit/` task-test files: 15) — the same latent footgun existed in all of them.

## Tests

- `tests/test_sync_jsonb_isolation.py` — regression canary per the issue's acceptance criterion: real sync-session ORM `User` insert (JSONB `encrypted_api_keys`) ordered after `test_celery_workflow.py`. Confirmed RED before the fix (exact issue error), GREEN after.
- `tests/unit/test_module_patching.py` — deterministic, ordering-independent contract tests on the helper (module imported inside window survives; present/absent key restore; exception safety).
- Full API suite: **1753 passed, 7 skipped**, coverage gates green.

## Review

Pre-PR third-party review by opencode (GLM): no Critical findings; its one Major (ordering-dependent canary) addressed by adding the contract tests; RLS concern disproven empirically (insert succeeds — sync role bypasses RLS per #211). Post-PR pass: Major confirmed resolved, no new findings (one import-order nit, fixed in c3301b4).

## Known Limitations

- The canary test relies on pytest's default alphabetical collection to order after `test_celery_workflow.py`; the contract tests are the ordering-independent guard.
- Nothing prevents a future test from reintroducing `patch.dict(sys.modules, ...)`; the helper's docstring documents the hazard.