### PR TITLE
Scope content ingestion to url/text/pdf and surface PDF upload in the UI (#314)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ podcaststudiohub/
 ## Features
 
 ### Core Podcast Generation
-- Transform multi-modal content (websites, PDFs, images, YouTube) into engaging audio conversations
+- Transform content (websites, PDFs, plain text) into engaging audio conversations
 - Support for 100+ LLM models via LiteLLM (OpenAI, Anthropic, Google Gemini)
 - Multiple TTS providers (OpenAI, ElevenLabs, Google, Edge TTS)
 - Short-form (2-5 min) and long-form (30+ min) podcasts
@@ -70,7 +70,7 @@ podcaststudiohub/
 - **User Management**: Secure authentication with JWT tokens
 - **Project Organization**: Group episodes into projects
 - **Episode Management**: Create, track, and manage podcast episodes
-- **Content Sources**: Support for URLs, files, and user-provided topics
+- **Content Sources**: Support for web URLs, PDF uploads, and plain text
 - **Background Processing**: Async generation with progress tracking
 - **Multi-tenant**: Complete data isolation per user
 - **Storage**: Local filesystem with optional S3 integration

--- a/apps/api/src/models/content_source.py
+++ b/apps/api/src/models/content_source.py
@@ -21,16 +21,16 @@ class ContentSource(Base):
     episode_id = Column(UUID(as_uuid=True), ForeignKey("episodes.id", ondelete="CASCADE"), nullable=False, index=True)
     tenant_id = Column(UUID(as_uuid=True), nullable=False, index=True)
 
-    # Source type: 'url', 'pdf', 'youtube', 'text', 'image', 'topic'
+    # Source type. Currently supported (accepted by API, validator, extraction):
+    # 'url', 'pdf', 'text'. Reserved but UNIMPLEMENTED: 'youtube', 'image',
+    # 'topic' — allowed only by the DB CHECK constraint for future use; the API
+    # schema, validator, and extraction dispatch all reject them.
     source_type = Column(Text, nullable=False, index=True)
 
     # Source data - flexible structure based on source_type
     # For URL: {"url": "https://...", "title": "..."}
     # For PDF: {"filename": "doc.pdf", "s3_key": "uploads/...", "mime_type": "application/pdf"}
-    # For YouTube: {"url": "https://youtube.com/watch?v=...", "video_id": "..."}
     # For Text: {"content": "raw text content", "title": "..."}
-    # For Image: {"filename": "image.jpg", "s3_key": "uploads/...", "mime_type": "image/jpeg"}
-    # For Topic: {"topic": "AI in healthcare", "search_results": [...]}
     source_data = Column(JSONB, nullable=False)
 
     # Extraction status and results (separate columns per migration)

--- a/apps/api/src/routers/content.py
+++ b/apps/api/src/routers/content.py
@@ -409,7 +409,10 @@ async def trigger_content_extraction(
     if content_source.source_type not in ('url', 'pdf', 'text'):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=f"Source type '{content_source.source_type}' does not support extraction"
+            detail=(
+                f"Source type '{content_source.source_type}' does not support extraction. "
+                "Supported types: url, pdf, text"
+            )
         )
 
     try:

--- a/apps/api/src/services/source_validator_service.py
+++ b/apps/api/src/services/source_validator_service.py
@@ -316,3 +316,9 @@ class SourceValidatorService:
 		elif source_type == 'pdf':
 			s3_key = source_data.get('s3_key', '')
 			await self.validate_pdf_source(s3_key)
+
+		else:
+			raise ValueError(
+				f"Unsupported source type '{source_type}'. "
+				"Supported types: url, pdf, text"
+			)

--- a/apps/api/src/tasks/content_extraction.py
+++ b/apps/api/src/tasks/content_extraction.py
@@ -57,7 +57,9 @@ async def _extract_content_async(
 		elif source_type == 'text':
 			result = await service.extract_from_text(db, content_uuid)
 		else:
-			raise ValueError(f"Unsupported source type: {source_type}")
+			raise ValueError(
+				f"Unsupported source type: {source_type}. Supported types: url, pdf, text"
+			)
 
 		return {
 			"status": "complete" if result.success else "failed",

--- a/apps/api/tests/unit/test_source_validation.py
+++ b/apps/api/tests/unit/test_source_validation.py
@@ -537,6 +537,21 @@ async def test_validate_by_type_pdf_empty_key():
 		)
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("unsupported", ['youtube', 'image', 'topic', 'bogus'])
+async def test_validate_by_type_unsupported_type_raises(unsupported):
+	"""validate_by_type rejects unsupported types instead of silently passing."""
+	validator = make_validator()
+	with pytest.raises(ValueError) as exc_info:
+		await validator.validate_by_type(
+			source_type=unsupported,
+			source_data={},
+		)
+	message = str(exc_info.value)
+	assert unsupported in message
+	assert 'url' in message and 'pdf' in message and 'text' in message
+
+
 # ===========================================================================
 # Error message quality
 # ===========================================================================

--- a/apps/web/__tests__/app/episodes/[id]/page.test.tsx
+++ b/apps/web/__tests__/app/episodes/[id]/page.test.tsx
@@ -516,6 +516,90 @@ describe('EpisodePage content sources', () => {
     })
   })
 
+  it('adds a PDF content source via multipart upload', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter({ contentSources: [] }),
+      (url, init) => /\/api\/proxy\/episodes\/[^/]+\/content\/upload$/.test(url) && init?.method === 'POST',
+      () => Promise.resolve({ ok: true, json: async () => ({}) })
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'Add Content' })[0])
+    await userEvent.click(screen.getByRole('button', { name: 'PDF' }))
+    const pdfFile = new File(['%PDF-1.4'], 'doc.pdf', { type: 'application/pdf' })
+    await userEvent.upload(screen.getByLabelText(/pdf file/i), pdfFile)
+    const submitButtons = screen.getAllByRole('button', { name: /add content/i })
+    await userEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/proxy/episodes/ep1/content/upload',
+        expect.objectContaining({ method: 'POST', body: expect.any(FormData) })
+      )
+    })
+    const uploadCall = fetchMock.mock.calls.find(
+      ([url]: [string]) => url === '/api/proxy/episodes/ep1/content/upload'
+    )
+    const formData = uploadCall![1].body as FormData
+    expect((formData.get('file') as File).name).toBe('doc.pdf')
+    expect(formData.get('auto_extract')).toBe('true')
+    expect(showSuccessToast).toHaveBeenCalledWith('Content source added')
+  })
+
+  it('rejects a non-PDF file with a validation error and does not upload', async () => {
+    const fetchMock = mockEpisodeFetchRouter({ contentSources: [] })
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'Add Content' })[0])
+    await userEvent.click(screen.getByRole('button', { name: 'PDF' }))
+    const textFile = new File(['hello'], 'notes.txt', { type: 'text/plain' })
+    await userEvent.upload(screen.getByLabelText(/pdf file/i), textFile, { applyAccept: false })
+
+    expect(await screen.findByText('File must be a PDF')).toBeInTheDocument()
+    const submitButtons = screen.getAllByRole('button', { name: /add content/i })
+    expect(submitButtons[submitButtons.length - 1]).toBeDisabled()
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/api/proxy/episodes/ep1/content/upload',
+      expect.anything()
+    )
+  })
+
+  it('shows an error toast when the PDF upload fails', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter({ contentSources: [] }),
+      (url, init) => /\/api\/proxy\/episodes\/[^/]+\/content\/upload$/.test(url) && init?.method === 'POST',
+      () => Promise.resolve({ ok: false, statusText: 'Payload Too Large' })
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'Add Content' })[0])
+    await userEvent.click(screen.getByRole('button', { name: 'PDF' }))
+    const pdfFile = new File(['%PDF-1.4'], 'doc.pdf', { type: 'application/pdf' })
+    await userEvent.upload(screen.getByLabelText(/pdf file/i), pdfFile)
+    const submitButtons = screen.getAllByRole('button', { name: /add content/i })
+    await userEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to add content source: Payload Too Large')
+    )
+  })
+
+  it('does not advertise YouTube support in the URL hint', async () => {
+    global.fetch = mockEpisodeFetchRouter({ contentSources: [] })
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'Add Content' })[0])
+
+    expect(screen.queryByText(/youtube/i)).not.toBeInTheDocument()
+  })
+
   it('opens the add-content dialog from the empty state action', async () => {
     global.fetch = mockEpisodeFetchRouter({ contentSources: [] })
     render(<EpisodePage />)

--- a/apps/web/__tests__/app/episodes/[id]/page.test.tsx
+++ b/apps/web/__tests__/app/episodes/[id]/page.test.tsx
@@ -598,6 +598,33 @@ describe('EpisodePage content sources', () => {
     )
   })
 
+  it('falls back to statusText when the error detail is not a string (FastAPI 422 array)', async () => {
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter({ contentSources: [] }),
+      (url, init) => /\/api\/proxy\/episodes\/[^/]+\/content\/upload$/.test(url) && init?.method === 'POST',
+      () =>
+        Promise.resolve({
+          ok: false,
+          statusText: 'Unprocessable Entity',
+          json: async () => ({ detail: [{ loc: ['body', 'file'], msg: 'bad', type: 'x' }] }),
+        })
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+    await screen.findByText('Test Episode')
+
+    await userEvent.click(screen.getAllByRole('button', { name: 'Add Content' })[0])
+    await userEvent.click(screen.getByRole('button', { name: 'PDF' }))
+    const pdfFile = new File(['%PDF-1.4'], 'doc.pdf', { type: 'application/pdf' })
+    await userEvent.upload(screen.getByLabelText(/pdf file/i), pdfFile)
+    const submitButtons = screen.getAllByRole('button', { name: /add content/i })
+    await userEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith('Failed to add content source: Unprocessable Entity')
+    )
+  })
+
   it('does not advertise YouTube support in the URL hint', async () => {
     global.fetch = mockEpisodeFetchRouter({ contentSources: [] })
     render(<EpisodePage />)

--- a/apps/web/__tests__/app/episodes/[id]/page.test.tsx
+++ b/apps/web/__tests__/app/episodes/[id]/page.test.tsx
@@ -572,7 +572,12 @@ describe('EpisodePage content sources', () => {
     const fetchMock = withOverride(
       mockEpisodeFetchRouter({ contentSources: [] }),
       (url, init) => /\/api\/proxy\/episodes\/[^/]+\/content\/upload$/.test(url) && init?.method === 'POST',
-      () => Promise.resolve({ ok: false, statusText: 'Payload Too Large' })
+      () =>
+        Promise.resolve({
+          ok: false,
+          statusText: 'Payload Too Large',
+          json: async () => ({ detail: 'File too large. Maximum allowed size is 50 MB' }),
+        })
     )
     global.fetch = fetchMock
     render(<EpisodePage />)
@@ -585,8 +590,11 @@ describe('EpisodePage content sources', () => {
     const submitButtons = screen.getAllByRole('button', { name: /add content/i })
     await userEvent.click(submitButtons[submitButtons.length - 1])
 
+    // Prefers the backend's actionable JSON detail over the bare statusText
     await waitFor(() =>
-      expect(showErrorToast).toHaveBeenCalledWith('Failed to add content source: Payload Too Large')
+      expect(showErrorToast).toHaveBeenCalledWith(
+        'Failed to add content source: File too large. Maximum allowed size is 50 MB'
+      )
     )
   })
 

--- a/apps/web/__tests__/lib/validation.test.ts
+++ b/apps/web/__tests__/lib/validation.test.ts
@@ -200,3 +200,67 @@ describe("contentSourceSchema - text type", () => {
     expect(result.success).toBe(true)
   })
 })
+
+describe("contentSourceSchema - PDF type", () => {
+  const makePdf = (overrides: { type?: string; size?: number } = {}) => {
+    const file = new File(["%PDF-1.4"], "doc.pdf", {
+      type: overrides.type ?? "application/pdf",
+    })
+    if (overrides.size !== undefined) {
+      Object.defineProperty(file, "size", { value: overrides.size })
+    }
+    return file
+  }
+
+  it("accepts a selected PDF file", () => {
+    const result = contentSourceSchema.safeParse({
+      sourceType: "pdf",
+      file: [makePdf()],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects when no file is selected", () => {
+    const result = contentSourceSchema.safeParse({
+      sourceType: "pdf",
+      file: [],
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const fileError = result.error.issues.find((i) => i.path.includes("file"))
+      expect(fileError?.message).toBe("PDF file is required")
+    }
+  })
+
+  it("rejects a non-PDF file", () => {
+    const result = contentSourceSchema.safeParse({
+      sourceType: "pdf",
+      file: [makePdf({ type: "text/plain" })],
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const fileError = result.error.issues.find((i) => i.path.includes("file"))
+      expect(fileError?.message).toBe("File must be a PDF")
+    }
+  })
+
+  it("rejects a PDF over 50MB", () => {
+    const result = contentSourceSchema.safeParse({
+      sourceType: "pdf",
+      file: [makePdf({ size: 50 * 1024 * 1024 + 1 })],
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const fileError = result.error.issues.find((i) => i.path.includes("file"))
+      expect(fileError?.message).toBe("PDF must be 50MB or less")
+    }
+  })
+
+  it("accepts a PDF of exactly 50MB", () => {
+    const result = contentSourceSchema.safeParse({
+      sourceType: "pdf",
+      file: [makePdf({ size: 50 * 1024 * 1024 })],
+    })
+    expect(result.success).toBe(true)
+  })
+})

--- a/apps/web/__tests__/lib/validation.test.ts
+++ b/apps/web/__tests__/lib/validation.test.ts
@@ -244,6 +244,35 @@ describe("contentSourceSchema - PDF type", () => {
     }
   })
 
+  it("accepts a .pdf file with a missing MIME type (backend is extension-based)", () => {
+    const result = contentSourceSchema.safeParse({
+      sourceType: "pdf",
+      file: [makePdf({ type: "" })],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts a .pdf file reported as application/octet-stream", () => {
+    const result = contentSourceSchema.safeParse({
+      sourceType: "pdf",
+      file: [makePdf({ type: "application/octet-stream" })],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects a file without a .pdf extension even if typed application/pdf", () => {
+    const file = new File(["%PDF-1.4"], "doc.txt", { type: "application/pdf" })
+    const result = contentSourceSchema.safeParse({
+      sourceType: "pdf",
+      file: [file],
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const fileError = result.error.issues.find((i) => i.path.includes("file"))
+      expect(fileError?.message).toBe("File must be a PDF")
+    }
+  })
+
   it("rejects a PDF over 50MB", () => {
     const result = contentSourceSchema.safeParse({
       sourceType: "pdf",

--- a/apps/web/src/app/(auth)/episodes/[id]/page.tsx
+++ b/apps/web/src/app/(auth)/episodes/[id]/page.tsx
@@ -340,15 +340,17 @@ export default function EpisodePage() {
         loadContentSources()
       } else {
         // Backend puts the actionable message (size/format limits) in JSON detail
-        let detail: string | undefined
+        let detail: unknown
         try {
           detail = (await response.json())?.detail
         } catch {
           // no JSON body
         }
-        showErrorToast(
-          "Failed to add content source: " + (detail || response.statusText || "Request failed")
-        )
+        // FastAPI 422s return detail as an array; only surface string details
+        const message = typeof detail === "string" && detail
+          ? detail
+          : response.statusText || "Request failed"
+        showErrorToast("Failed to add content source: " + message)
       }
     } catch (error) {
       console.error("Failed to add content source:", error)
@@ -749,7 +751,7 @@ export default function EpisodePage() {
                   <Input
                     id="content-pdf"
                     type="file"
-                    accept="application/pdf"
+                    accept=".pdf,application/pdf"
                     aria-invalid={errors.file ? "true" : "false"}
                     aria-describedby={errors.file ? "content-pdf-error" : undefined}
                     {...register("file")}

--- a/apps/web/src/app/(auth)/episodes/[id]/page.tsx
+++ b/apps/web/src/app/(auth)/episodes/[id]/page.tsx
@@ -299,26 +299,39 @@ export default function EpisodePage() {
 
   const onSubmitContent = async (data: ContentSourceFormData) => {
     try {
-      const body = data.sourceType === "url"
-        ? {
-            episode_id: params.id,
-            source_type: "url",
-            source_data: { url: data.url, title: "Web Article" },
-          }
-        : {
-            episode_id: params.id,
-            source_type: "text",
-            source_data: { content: data.content, title: "Custom Text" },
-          }
+      let response: Response
+      if (data.sourceType === "pdf") {
+        // The upload endpoint takes multipart/form-data; the browser sets the
+        // Content-Type boundary, so no headers here.
+        const formData = new FormData()
+        formData.append("file", data.file![0])
+        formData.append("auto_extract", "true")
+        response = await fetch(
+          `/api/proxy/episodes/${params.id}/content/upload`,
+          { method: "POST", body: formData }
+        )
+      } else {
+        const body = data.sourceType === "url"
+          ? {
+              episode_id: params.id,
+              source_type: "url",
+              source_data: { url: data.url, title: "Web Article" },
+            }
+          : {
+              episode_id: params.id,
+              source_type: "text",
+              source_data: { content: data.content, title: "Custom Text" },
+            }
 
-      const response = await fetch(
-        `/api/proxy/episodes/${params.id}/content`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(body),
-        }
-      )
+        response = await fetch(
+          `/api/proxy/episodes/${params.id}/content`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }
+        )
+      }
 
       if (response.ok) {
         showSuccessToast("Content source added")
@@ -682,6 +695,17 @@ export default function EpisodePage() {
                   >
                     Text
                   </Button>
+                  <Button
+                    type="button"
+                    variant={sourceType === "pdf" ? "default" : "outline"}
+                    aria-pressed={sourceType === "pdf"}
+                    onClick={() => {
+                      setValue("sourceType", "pdf", { shouldValidate: true })
+                    }}
+                    className="flex-1"
+                  >
+                    PDF
+                  </Button>
                 </div>
               </div>
 
@@ -705,7 +729,30 @@ export default function EpisodePage() {
                     </p>
                   )}
                   <p className="text-muted-foreground text-xs mt-1">
-                    Supports HTTP, HTTPS, and YouTube URLs
+                    Supports public HTTP/HTTPS article URLs
+                  </p>
+                </div>
+              ) : sourceType === "pdf" ? (
+                <div>
+                  <Label htmlFor="content-pdf" className="mb-1">
+                    PDF File <span className="text-destructive">*</span>
+                  </Label>
+                  <Input
+                    id="content-pdf"
+                    type="file"
+                    accept="application/pdf"
+                    aria-invalid={errors.file ? "true" : "false"}
+                    aria-describedby={errors.file ? "content-pdf-error" : undefined}
+                    {...register("file")}
+                    className={errors.file ? "border-destructive" : ""}
+                  />
+                  {errors.file && (
+                    <p id="content-pdf-error" className="text-destructive text-sm mt-1" role="alert">
+                      {errors.file.message}
+                    </p>
+                  )}
+                  <p className="text-muted-foreground text-xs mt-1">
+                    PDF files up to 50MB
                   </p>
                 </div>
               ) : (

--- a/apps/web/src/app/(auth)/episodes/[id]/page.tsx
+++ b/apps/web/src/app/(auth)/episodes/[id]/page.tsx
@@ -339,7 +339,16 @@ export default function EpisodePage() {
         reset()
         loadContentSources()
       } else {
-        showErrorToast("Failed to add content source: " + response.statusText)
+        // Backend puts the actionable message (size/format limits) in JSON detail
+        let detail: string | undefined
+        try {
+          detail = (await response.json())?.detail
+        } catch {
+          // no JSON body
+        }
+        showErrorToast(
+          "Failed to add content source: " + (detail || response.statusText || "Request failed")
+        )
       }
     } catch (error) {
       console.error("Failed to add content source:", error)

--- a/apps/web/src/lib/validation.ts
+++ b/apps/web/src/lib/validation.ts
@@ -106,7 +106,13 @@ export const contentSourceSchema = z
         })
         return
       }
-      if (file.type !== "application/pdf") {
+      // Mirrors the backend validate_pdf_format: .pdf extension required,
+      // MIME type lenient (browsers may report empty or octet-stream)
+      const validType =
+        !file.type ||
+        file.type === "application/pdf" ||
+        file.type === "application/octet-stream"
+      if (!file.name.toLowerCase().endsWith(".pdf") || !validType) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: "File must be a PDF",

--- a/apps/web/src/lib/validation.ts
+++ b/apps/web/src/lib/validation.ts
@@ -29,8 +29,8 @@ export type EpisodeFormData = z.infer<typeof episodeSchema>
 // Content source validation
 export const contentSourceSchema = z
   .object({
-    sourceType: z.enum(["url", "text"], {
-      error: () => "Select URL or Text",
+    sourceType: z.enum(["url", "text", "pdf"], {
+      error: () => "Select URL, Text, or PDF",
     }),
     url: z
       .string()
@@ -38,6 +38,8 @@ export const contentSourceSchema = z
     content: z
       .string()
       .optional(),
+    // FileList from an <input type="file"> (array-like of File)
+    file: z.custom<FileList>().optional(),
   })
   .superRefine((data, ctx) => {
     if (data.sourceType === "url") {
@@ -51,7 +53,7 @@ export const contentSourceSchema = z
       }
       try {
         const parsed = new URL(data.url)
-        // Accept http and https (YouTube and other common hosts use https)
+        // Accept http and https article URLs
         const isAllowed =
           parsed.protocol === "http:" ||
           parsed.protocol === "https:"
@@ -91,6 +93,32 @@ export const contentSourceSchema = z
           code: z.ZodIssueCode.custom,
           message: "Content must be under 50,000 characters",
           path: ["content"],
+        })
+      }
+    }
+    if (data.sourceType === "pdf") {
+      const file = data.file?.[0]
+      if (!file) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "PDF file is required",
+          path: ["file"],
+        })
+        return
+      }
+      if (file.type !== "application/pdf") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "File must be a PDF",
+          path: ["file"],
+        })
+      }
+      // Mirrors the backend MAX_PDF_SIZE_BYTES limit (50MB)
+      if (file.size > 50 * 1024 * 1024) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "PDF must be 50MB or less",
+          path: ["file"],
         })
       }
     }

--- a/docs/GAP_ANALYSIS.md
+++ b/docs/GAP_ANALYSIS.md
@@ -199,7 +199,7 @@ But the API uses JWT token-based auth, not cookies.
 | GAP-021 | StorageService async methods use sync boto3 | `services/storage_service.py:43-152` | HIGH |
 | GAP-022 | PodcastService methods return hardcoded lists | `services/podcast_service.py:20-30` | MEDIUM |
 | GAP-023 | Script generation has no timeout for Gemini API | `services/script_generation_service.py:170` | MEDIUM |
-| GAP-024 | S3 PDF extraction not implemented (TODO comment) | `services/content_extraction_service.py:187` | HIGH |
+| GAP-024 | ~~S3 PDF extraction not implemented~~ RESOLVED (#242): `extract_from_pdf` implemented | `services/content_extraction_service.py` | HIGH |
 | GAP-025 | Transcript validation is minimal (only checks tags) | `services/script_generation_service.py:314-326` | LOW |
 
 **StorageService Blocking Issue:**
@@ -429,7 +429,7 @@ def _distribute_to_apple(...):
 | Requirement | Status | What's Missing |
 |-------------|--------|----------------|
 | FR-001: GUI without CLI | PARTIAL | Many workflows need CLI knowledge |
-| FR-002: Import URLs, PDFs, text | PARTIAL | PDF upload UI missing |
+| FR-002: Import URLs, PDFs, text | COMPLETE | PDF upload UI added (#314); YouTube/image/topic out of scope |
 | FR-003: Multiple TTS providers | PARTIAL | No selection UI |
 | FR-004: Podcast formats | NOT IMPL | No format selector |
 | FR-005: Real-time progress | PARTIAL | Auth issues, basic UI |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -40,6 +40,7 @@ Podcastfy Studio Hub is a web-based platform that transforms your written conten
 |-------------|-------------|---------|
 | **Web URLs** | Any publicly accessible webpage | Blog posts, news articles, documentation |
 | **Plain Text** | Direct text input | Your own writing, research notes, scripts |
+| **PDF Files** | Uploaded PDF documents (up to 50MB) | Reports, papers, ebooks |
 
 ---
 
@@ -455,7 +456,7 @@ A: There's no limit on the number of projects or episodes you can create.
 A: Blog posts, articles, and documentation pages work best. Avoid:
 - Pages requiring login
 - Video-heavy pages without text
-- PDF links (direct PDF support coming soon)
+- PDF links (use the PDF upload option instead)
 - Social media posts
 
 **Q: Can I use paywalled content?**

--- a/docs/environment-configuration-report-2025-11-11.md
+++ b/docs/environment-configuration-report-2025-11-11.md
@@ -270,7 +270,7 @@ All optional or future scope:
 ### Recommended Development Order (Phase 2)
 
 **Week 1-2: Core Podcast Generation (No S3 Required)**
-- ✅ Ready: Content extraction (websites, YouTube, PDFs)
+- ✅ Ready: Content extraction (websites, PDFs, plain text)
 - ✅ Ready: LLM script generation (Gemini/OpenAI)
 - ✅ Ready: TTS audio generation (ElevenLabs)
 - ⚠️ Temporary: Store generated audio locally

--- a/specs/001-gui-podcast-studio/contracts/openapi.yaml
+++ b/specs/001-gui-podcast-studio/contracts/openapi.yaml
@@ -347,6 +347,46 @@ paths:
               schema:
                 $ref: '#/components/schemas/ContentSourceResponse'
 
+  /episodes/{episode_id}/content/upload:
+    parameters:
+      - $ref: '#/components/parameters/EpisodeIdParam'
+
+    post:
+      tags: [content]
+      summary: Upload PDF content source
+      description: Upload a PDF file as a content source (FR-002)
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: PDF file (application/pdf, max 50MB)
+                description:
+                  type: string
+                  maxLength: 500
+                  description: Optional description
+                auto_extract:
+                  type: boolean
+                  default: true
+                  description: Trigger extraction immediately after upload
+      responses:
+        '201':
+          description: PDF uploaded and content source created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContentSourceResponse'
+        '413':
+          description: PDF exceeds the 50MB size limit
+        '422':
+          description: Invalid file format (not a PDF) or empty file
+
   # Podcast Generation
   /episodes/{episode_id}/generate:
     parameters:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,50 +1,55 @@
-# Issue #313 — Wire the audio-composition timeline (P4.1) — SHIPPED via PR #375
+# Issue #314 — Multi-modal input scope-down to URL/Text/PDF (P4.2)
 
-Status: merged 2026-07-11 as 6ea063c. Follow-up: #376 (download S3-backed
-snippets to the worker so they actually compose).
+CodeRabbit plan chose the scope-down path (option 2): align every layer to the
+genuinely supported set (url, text, pdf), surface the already-built PDF upload
+backend in the web UI, and fix overstated copy/docs. No architectural fork.
 
-## Problem (verified against current code)
+## Plan adaptations (verified against current code, 2026-07-11)
 
-- `routers/generation.py:309-317` dispatches `generate_podcast_task` with
-  `enable_composition` but never `composition_timeline` → defaults to `None`.
-- `podcast_generation.py:417` forwards it to `build_generation_workflow`, which
-  passes `composition_timeline or []` into `merge_audio_snippets_task.si` (line 850).
-- `audio_composition.py:49-82`: empty timeline → `AudioSegment.empty()` exported
-  → zero-length silent MP3 replaces the generated audio at upload (composed file
-  is `final_audio_path`).
-- `tests/unit/test_audio_composition_task.py:110` codifies the bug
-  (`test_empty_timeline_returns_success`).
-
-## Plan adaptations vs CodeRabbit plan
-
-1. `audio_snippet_service.get_audio_snippets` is **async** (AsyncSession); Celery
-   uses `SyncSessionLocal`. Resolver does its own sync `select(AudioSnippet)` query.
-2. `AudioSnippet.file_path` stores the **S3 key** when S3 is configured (see
-   `upload_audio_snippet`), so a snippet file may not exist on the worker's disk.
-   Resolver includes only snippets whose `file_path` is a local file; skips others
-   with a warning. S3-snippet download = documented Known Limitation / follow-up.
-3. Empty-timeline `ValueError` raised **before** the merge task's try block so it
-   propagates (deterministic error — retrying is pointless) and the chain's
-   `link_error` (`on_workflow_failure`) marks the episode failed.
+1. **PDF backend already done** (PR #210/#242): upload endpoint
+   `POST /episodes/{episode_id}/content/upload` (routers/content.py:136-197),
+   S3 extraction, full test suite. Nothing to build server-side except the
+   validator `else` and message tweaks.
+2. **Frontend has no PDF at all**: `contentSourceSchema` is `z.enum(["url","text"])`
+   (validation.ts:32); dialog toggle at page.tsx:660-686; hint text at :708.
+   Work = ADD pdf, not remove youtube/image/topic (never existed client-side).
+3. **No web API client layer** (deleted in #264): use inline `fetch` with
+   `FormData` to `/api/proxy/episodes/{id}/content/upload` — proxy forwards
+   body/headers as-is, so multipart passes through.
+4. `validate_by_type` (source_validator_service.py:294-318) silently no-ops on
+   unknown types — add terminal `else` raising ValueError.
+5. `openapi.yaml` enum already `[url, pdf, text]`; `/content/upload` endpoint is
+   undocumented — add it.
+6. Docs drift: README:63,73 overstates (images/YouTube/topics); USER_GUIDE has
+   no PDF row; GAP_ANALYSIS GAP-024 stale (PDF extraction done), FR-002 "PDF
+   upload UI missing" fixed by this PR; env-config report:273 mentions YouTube.
 
 ## TDD checklist
 
-- [x] RED: invert `test_empty_timeline_returns_success` → `pytest.raises(ValueError)`;
-      add resolver unit tests (ordering, always-includes-main, skips-missing-file,
-      never-empty, degrades-to-main-only on DB error); add workflow test asserting
-      `build_generation_workflow` receives a non-empty timeline with the generated
-      audio as `main_content` when composition is enabled and no timeline supplied.
-- [x] GREEN: guard in `merge_audio_snippets_task` (before try);
-      `resolve_composition_timeline(db, project_id, audio_file_path)` in
-      `podcast_generation.py` — project snippets ordered intro/music → main_content
-      → outro/midroll/ad/other, each entry `{file_path, segment_type}`; wire into
-      `generate_podcast_task`'s existing episode-load block (caller-supplied
-      timeline wins; resolution failure degrades to `[main]`, never empty).
-- [x] Full pytest + ruff + coverage gates; review; PR; demo; CI; merge.
+### Backend (apps/api)
+- [ ] Test: `validate_by_type` with unsupported type (e.g. 'youtube') raises
+      ValueError naming supported set → add terminal `else` (RED→GREEN)
+- [ ] Update model comment content_source.py:24-33 (supported vs reserved types)
+- [ ] Error messages in routers/content.py:409 + tasks/content_extraction.py:60
+      reference supported list ['url', 'pdf', 'text']
+- [ ] openapi.yaml: document POST /episodes/{episode_id}/content/upload
 
-## Known limitations
+### Frontend (apps/web)
+- [ ] Tests: page.test.tsx — PDF toggle renders file input; PDF submit posts
+      FormData to /api/proxy/.../content/upload; oversize/wrong-type file shows
+      validation error (RED)
+- [ ] validation.ts: add "pdf" to enum + superRefine (file required,
+      application/pdf, ≤50MB)
+- [ ] page.tsx: PDF toggle button; file input (accept="application/pdf") with
+      RHF error pattern; FormData submit path incl. auto_extract; replace :708
+      hint with "Supports public HTTP/HTTPS article URLs" (GREEN)
 
-- Snippets stored only in S3 (no local file) are skipped, not downloaded.
-- Timeline resolved on the generation worker; assumes chain tasks share a host
-  filesystem (same assumption the existing chain already makes for
-  `final_audio_path`).
+### Docs
+- [ ] README.md:63,73 → websites, PDFs, plain text only
+- [ ] docs/USER_GUIDE.md: add PDF row to Supported Content Types
+- [ ] docs/GAP_ANALYSIS.md: GAP-024 closed; FR-002 complete
+- [ ] docs/environment-configuration-report-2025-11-11.md:273 drop YouTube
+
+### Gates
+- [ ] pytest + jest + lint green; deslop; internal review + opencode/GLM review
+- [ ] PR, demo (agent-browser PDF upload flow), CI green, merge


### PR DESCRIPTION
Closes #314.

Implements the scope-down path chosen in the CodeRabbit plan on the issue: align every layer to the genuinely supported content-source set (URL, Text, PDF), surface the already-built PDF upload backend in the web UI, and remove overstated YouTube/image/topic claims.

## Changes

**Backend (apps/api)**
- `source_validator_service.validate_by_type` now raises a `ValueError` naming the supported set for any unsupported type (was a silent no-op fall-through).
- Extraction guard (`routers/content.py`) and Celery dispatch (`tasks/content_extraction.py`) error messages name the supported list.
- `content_source.py` model comment marks `youtube`/`image`/`topic` as reserved-but-unimplemented (DB CHECK retained, no migration).

**Frontend (apps/web)**
- Add-Content dialog gains a **PDF** option: file input (`accept="application/pdf"`), client-side validation mirroring the backend (`.pdf` extension required, empty/octet-stream MIME tolerated, ≤50MB), multipart `FormData` POST to the existing `/api/proxy/episodes/{id}/content/upload`.
- URL hint no longer advertises YouTube ("Supports public HTTP/HTTPS article URLs").
- Failure toast now surfaces the backend's JSON `detail` (size/format messages) instead of bare `statusText`.

**Contract & docs**
- `openapi.yaml`: documented `POST /episodes/{episode_id}/content/upload` (was live but unspecified).
- README, USER_GUIDE (PDF row added), GAP_ANALYSIS (GAP-024 resolved, FR-002 complete), env-config report aligned with the supported set.

## Testing
- Backend: 1769 passed, 7 skipped (incl. 4 new `validate_by_type` unsupported-type tests); ruff clean.
- Web: 354 passed (incl. 9 new PDF schema tests + 4 new dialog flow tests); coverage 96.1% stmts / 84.05% branches; `tsc --noEmit` and ESLint clean.

## Third-party review
Pre-PR review by opencode (GLM): no Critical/Major findings; both Minor findings (strict client MIME check, discarded backend error detail) fixed in 62e9e42.

## Known limitations
- YouTube/image/topic ingestion remains unimplemented by design; DB CHECK constraint still permits the values for future use.
- PDF upload description field is not exposed in the dialog (endpoint supports it; YAGNI for now).