### PR TITLE
fix(distribution): default Spotify/Apple to the RSS-feed model; gate direct publish (#315)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -120,3 +120,10 @@ STRIPE_WEBHOOK_SECRET=your-stripe-webhook-signing-secret-here
 # snippets (intro/music before, outro/midroll/ad after) before S3 upload.
 # Default False.
 ENABLE_AUDIO_COMPOSITION=False
+
+# Direct platform publish (issue #315)
+# Spotify/Apple ingest episodes via the project's RSS feed; their direct
+# publish endpoints are unverified. When False (default), Spotify/Apple
+# distribution returns the project's RSS feed URL. When True, the
+# experimental direct API publish path is used instead.
+ENABLE_DIRECT_PLATFORM_PUBLISH=False

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -118,6 +118,10 @@ class Settings(BaseSettings):
     # Workflow feature flags
     ENABLE_AUDIO_COMPOSITION: bool = False
     ENABLE_PLATFORM_DISTRIBUTION: bool = False
+    # Spotify/Apple ingest episodes via the project's RSS feed; their direct
+    # publish endpoints are unverified (issue #315). Off = distribution returns
+    # the RSS feed URL; on = experimental direct API publish.
+    ENABLE_DIRECT_PLATFORM_PUBLISH: bool = False
 
     # Email / SMTP
     EMAIL_ENABLED: bool = False

--- a/apps/api/src/services/apple_podcasts_service.py
+++ b/apps/api/src/services/apple_podcasts_service.py
@@ -61,10 +61,14 @@ class ApplePodcastsService:
 		idempotency_key: Optional[str] = None,
 	) -> Dict[str, Any]:
 		"""
-		Publish a podcast episode to Apple Podcasts Connect.
+		EXPERIMENTAL/UNVERIFIED: attempt a direct episode publish to Apple.
 
-		Submits episode metadata and audio URL to the Apple Podcasts
-		Connect API using the JSONAPI request format.
+		Apple Podcasts ingests episodes through the show's RSS feed — that is
+		the supported distribution mechanism (see issue #315). The Podcasts
+		Connect endpoint used here is not a public episode-submission API, so
+		this call is expected to fail unless Apple grants the account such
+		access. It only runs when ENABLE_DIRECT_PLATFORM_PUBLISH is explicitly
+		enabled. Uses the JSONAPI request format.
 
 		Args:
 			show_id: Apple Podcasts show identifier (from DistributionTarget.config.show_id)

--- a/apps/api/src/services/spotify_service.py
+++ b/apps/api/src/services/spotify_service.py
@@ -59,10 +59,14 @@ class SpotifyService:
 		idempotency_key: Optional[str] = None,
 	) -> Dict[str, Any]:
 		"""
-		Publish a podcast episode to Spotify for Podcasters.
+		EXPERIMENTAL/UNVERIFIED: attempt a direct episode publish to Spotify.
 
-		Sends episode metadata and audio URL to the Spotify Web API.
-		The show must already exist on Spotify for Podcasters.
+		Spotify ingests episodes through the show's RSS feed — that is the
+		supported distribution mechanism (see issue #315). The Web API endpoint
+		used here does not accept episode submissions on any verified plan, so
+		this call is expected to fail (401/404/400) unless Spotify grants the
+		account such access. It only runs when ENABLE_DIRECT_PLATFORM_PUBLISH
+		is explicitly enabled.
 
 		Args:
 			show_id: Spotify show identifier (from DistributionTarget.config.show_id)

--- a/apps/api/src/tasks/platform_distribution.py
+++ b/apps/api/src/tasks/platform_distribution.py
@@ -4,7 +4,7 @@ Celery tasks for podcast platform distribution
 import copy
 from celery import Task
 from datetime import datetime, timezone
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 import logging
 
 from src.worker import celery_app
@@ -58,6 +58,49 @@ def _decrypt_platform_config(config: Dict[str, Any], platform: str) -> Dict[str,
         session.close()
 
     return decrypted
+
+
+def _rss_feed_url_for_project(db: Any, project_id: Any) -> Optional[str]:
+    """
+    Return the project's public RSS feed URL, or None if no feed has been
+    generated yet (issue #315). Uses the caller's open sync session.
+    """
+    from sqlalchemy import select
+
+    from src.models.rss_feed import RSSFeed
+
+    feed = db.execute(
+        select(RSSFeed).where(RSSFeed.project_id == project_id)
+    ).scalar_one_or_none()
+    return feed.public_url if feed is not None else None
+
+
+def _rss_distribution_result(platform: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Build the default RSS-based distribution result (issue #315).
+
+    Spotify and Apple Podcasts ingest episodes through the show's RSS feed,
+    not through direct audio-URL POSTs. Distribution therefore succeeds by
+    surfacing the project's feed URL; a missing feed is a permanent failure
+    (ValueError → not retried), never a fabricated platform success.
+    """
+    rss_feed_url = metadata.get("rss_feed_url")
+    if not rss_feed_url:
+        raise ValueError(
+            f"No RSS feed found for this project. {platform} ingests episodes via "
+            "the project's RSS feed — generate the feed first "
+            "(POST /projects/{project_id}/rss-feed/generate), or enable the "
+            "experimental ENABLE_DIRECT_PLATFORM_PUBLISH flag."
+        )
+    return {
+        "status": "success",
+        "platform": platform,
+        "method": "rss_feed",
+        "platform_episode_id": None,
+        "platform_url": rss_feed_url,
+        "rss_feed_url": rss_feed_url,
+        "error": None,
+    }
 
 
 def _idempotency_key(episode_id: str, platform: str) -> str:
@@ -163,6 +206,14 @@ def distribute_to_platform_task(
                     }
                 else:
                     episode_metadata = _merge_episode_metadata(episode, episode_metadata)
+                    # Spotify/Apple ingest via the project's RSS feed (issue
+                    # #315); resolve its URL here while the session is open.
+                    if platform in ("spotify", "apple_podcasts") and not episode_metadata.get(
+                        "rss_feed_url"
+                    ):
+                        feed_url = _rss_feed_url_for_project(db, episode.project_id)
+                        if feed_url:
+                            episode_metadata["rss_feed_url"] = feed_url
             else:
                 logger.warning(
                     "Episode %s not found while building distribution metadata",
@@ -285,7 +336,14 @@ def distribute_to_platform_task(
 
 
 def _distribute_to_spotify(episode_id: str, config: Dict, metadata: Dict, task: Task) -> Dict:
-    """Distribute to Spotify for Podcasters using the Spotify Web API."""
+    """
+    Distribute to Spotify.
+
+    Default: Spotify ingests episodes via the show's RSS feed, so return the
+    project's feed URL (issue #315). The direct Web-API publish below is
+    experimental/unverified and only runs when ENABLE_DIRECT_PLATFORM_PUBLISH
+    is set.
+    """
     from src.services.spotify_service import SpotifyService
 
     task.update_state(
@@ -294,13 +352,16 @@ def _distribute_to_spotify(episode_id: str, config: Dict, metadata: Dict, task: 
             'episode_id': episode_id,
             'platform': 'spotify',
             'progress': 25,
-            'status': 'Authenticating with Spotify...'
+            'status': 'Preparing Spotify distribution...'
         }
     )
 
     show_id = config.get("show_id")
     if not show_id:
         raise ValueError("Spotify show_id not configured for this distribution target")
+
+    if not settings.ENABLE_DIRECT_PLATFORM_PUBLISH:
+        return _rss_distribution_result("spotify", metadata)
 
     oauth_tokens = config.get("oauth_tokens", {})
     access_token = oauth_tokens.get("access_token")
@@ -378,7 +439,14 @@ def _distribute_to_spotify(episode_id: str, config: Dict, metadata: Dict, task: 
 
 
 def _distribute_to_apple(episode_id: str, config: Dict, metadata: Dict, task: Task) -> Dict:
-    """Distribute to Apple Podcasts Connect using the Apple Podcasts Connect API."""
+    """
+    Distribute to Apple Podcasts.
+
+    Default: Apple ingests episodes via the show's RSS feed, so return the
+    project's feed URL (issue #315). The direct Podcasts-Connect publish below
+    is experimental/unverified and only runs when ENABLE_DIRECT_PLATFORM_PUBLISH
+    is set.
+    """
     from src.services.apple_podcasts_service import ApplePodcastsService
 
     task.update_state(
@@ -387,13 +455,16 @@ def _distribute_to_apple(episode_id: str, config: Dict, metadata: Dict, task: Ta
             'episode_id': episode_id,
             'platform': 'apple_podcasts',
             'progress': 25,
-            'status': 'Authenticating with Apple Podcasts...'
+            'status': 'Preparing Apple Podcasts distribution...'
         }
     )
 
     show_id = config.get("show_id")
     if not show_id:
         raise ValueError("Apple Podcasts show_id not configured for this distribution target")
+
+    if not settings.ENABLE_DIRECT_PLATFORM_PUBLISH:
+        return _rss_distribution_result("apple_podcasts", metadata)
 
     credentials = config.get("credentials", {})
     api_key = credentials.get("api_key")

--- a/apps/api/src/tasks/platform_distribution.py
+++ b/apps/api/src/tasks/platform_distribution.py
@@ -89,7 +89,7 @@ def _rss_distribution_result(platform: str, metadata: Dict[str, Any]) -> Dict[st
         raise ValueError(
             f"No RSS feed found for this project. {platform} ingests episodes via "
             "the project's RSS feed — generate the feed first "
-            "(POST /projects/{project_id}/rss-feed/generate), or enable the "
+            "(POST /projects/<project_id>/rss-feed/generate), or enable the "
             "experimental ENABLE_DIRECT_PLATFORM_PUBLISH flag."
         )
     return {

--- a/apps/api/tests/unit/test_distribution_idempotency.py
+++ b/apps/api/tests/unit/test_distribution_idempotency.py
@@ -40,6 +40,7 @@ def _episode(**overrides):
 		"duration_seconds": 10.0,
 		"s3_url": "https://bucket.s3.amazonaws.com/e.mp3",
 		"generation_progress": {},
+		"project_id": "00000000-0000-0000-0000-0000000000aa",
 	}
 	data.update(overrides)
 	return SimpleNamespace(**data)
@@ -127,6 +128,7 @@ class TestAppleIdempotencyHeader:
 
 class TestHelpersForwardIdempotencyKey:
 	def test_spotify_helper_forwards_key(self):
+		from src.config import settings
 		from src.tasks.platform_distribution import _distribute_to_spotify
 
 		service = MagicMock()
@@ -134,7 +136,9 @@ class TestHelpersForwardIdempotencyKey:
 			"episode_id": "sp_1",
 			"platform_url": "https://open.spotify.com/episode/sp_1",
 		}
-		with patch("src.services.spotify_service.SpotifyService", return_value=service):
+		with patch.object(
+			settings, "ENABLE_DIRECT_PLATFORM_PUBLISH", True
+		), patch("src.services.spotify_service.SpotifyService", return_value=service):
 			_distribute_to_spotify(
 				EPISODE_ID,
 				{"show_id": "show1", "oauth_tokens": {"access_token": "tok"}},
@@ -146,6 +150,7 @@ class TestHelpersForwardIdempotencyKey:
 		assert kwargs["idempotency_key"] == f"{EPISODE_ID}:spotify"
 
 	def test_apple_helper_forwards_key(self):
+		from src.config import settings
 		from src.tasks.platform_distribution import _distribute_to_apple
 
 		service = MagicMock()
@@ -153,7 +158,9 @@ class TestHelpersForwardIdempotencyKey:
 			"episode_id": "ap_1",
 			"platform_url": None,
 		}
-		with patch(
+		with patch.object(
+			settings, "ENABLE_DIRECT_PLATFORM_PUBLISH", True
+		), patch(
 			"src.services.apple_podcasts_service.ApplePodcastsService",
 			return_value=service,
 		):

--- a/apps/api/tests/unit/test_platform_distribution_metadata.py
+++ b/apps/api/tests/unit/test_platform_distribution_metadata.py
@@ -22,6 +22,7 @@ def _episode(**overrides):
 		},
 		"duration_seconds": 123.0,
 		"s3_url": "https://bucket.s3.amazonaws.com/podcasts/episode-1.mp3",
+		"project_id": "00000000-0000-0000-0000-0000000000aa",
 	}
 	data.update(overrides)
 	return SimpleNamespace(**data)

--- a/apps/api/tests/unit/test_platform_distribution_services.py
+++ b/apps/api/tests/unit/test_platform_distribution_services.py
@@ -42,6 +42,13 @@ def _make_celery_retry_exc(task):
 	return task.MaxRetriesExceededError()
 
 
+def _direct_publish_enabled():
+	"""Enable the experimental direct-publish path (issue #315) for one test."""
+	from src.config import settings
+
+	return patch.object(settings, "ENABLE_DIRECT_PLATFORM_PUBLISH", True)
+
+
 # ===========================================================================
 # SpotifyService tests
 # ===========================================================================
@@ -76,6 +83,47 @@ class TestSpotifyServicePublishEpisode:
 
 		assert result["episode_id"] == "sp_ep_abc123"
 		assert result["platform_url"] == "https://open.spotify.com/episode/sp_ep_abc123"
+
+	def test_sends_expected_request_url_headers_and_body(self):
+		"""Asserts the exact outbound endpoint, auth header and JSON body (issue #315)."""
+		from src.services.spotify_service import SpotifyService
+
+		mock_response = _make_httpx_response(200, {"id": "ep1", "external_urls": {}})
+
+		with patch("httpx.Client") as mock_client_cls:
+			mock_client = MagicMock()
+			mock_client.__enter__ = MagicMock(return_value=mock_client)
+			mock_client.__exit__ = MagicMock(return_value=False)
+			mock_client.post.return_value = mock_response
+			mock_client_cls.return_value = mock_client
+
+			SpotifyService().publish_episode(
+				show_id="show123",
+				access_token="token_abc",
+				metadata={
+					"title": "My Episode",
+					"description": "Desc",
+					"audio_url": "https://cdn.example.com/audio.mp3",
+					"duration_seconds": 61.5,
+					"publish_date": "2026-01-15",
+					"explicit": True,
+				},
+				idempotency_key="ep-001:spotify",
+			)
+
+		args, kwargs = mock_client.post.call_args
+		assert args[0] == "https://api.spotify.com/v1/shows/show123/episodes"
+		assert kwargs["headers"]["Authorization"] == "Bearer token_abc"
+		assert kwargs["headers"]["Content-Type"] == "application/json"
+		assert kwargs["headers"]["Idempotency-Key"] == "ep-001:spotify"
+		assert kwargs["json"] == {
+			"name": "My Episode",
+			"description": "Desc",
+			"explicit": True,
+			"release_date": "2026-01-15",
+			"duration_ms": 61500,
+			"audio_url": "https://cdn.example.com/audio.mp3",
+		}
 
 	def test_platform_url_fallback_when_external_urls_absent(self):
 		"""Constructs fallback URL when external_urls missing from response."""
@@ -326,6 +374,52 @@ class TestApplePodcastsServicePublishEpisode:
 		assert result["episode_id"] == "apple_ep_001"
 		assert "apple_ep_001" in result["platform_url"]
 
+	def test_sends_expected_request_url_headers_and_body(self):
+		"""Asserts the exact outbound endpoint, auth header and JSONAPI body (issue #315)."""
+		from src.services.apple_podcasts_service import ApplePodcastsService
+
+		body = {"data": {"id": "ep1", "type": "episodes", "attributes": {}}}
+		mock_response = _make_httpx_response(201, body)
+
+		with patch("httpx.Client") as mock_client_cls:
+			mock_client = MagicMock()
+			mock_client.__enter__ = MagicMock(return_value=mock_client)
+			mock_client.__exit__ = MagicMock(return_value=False)
+			mock_client.post.return_value = mock_response
+			mock_client_cls.return_value = mock_client
+
+			ApplePodcastsService().publish_episode(
+				show_id="apple_show_1",
+				api_key="ak_test",
+				metadata={
+					"title": "My Episode",
+					"description": "Desc",
+					"audio_url": "https://cdn.example.com/audio.mp3",
+					"publish_date": "2026-01-15T00:00:00+00:00",
+					"explicit": False,
+				},
+				idempotency_key="ep-002:apple_podcasts",
+			)
+
+		args, kwargs = mock_client.post.call_args
+		assert args[0] == "https://api.podcastsconnect.apple.com/v1/episodes"
+		assert kwargs["headers"]["Authorization"] == "Bearer ak_test"
+		assert kwargs["headers"]["Content-Type"] == "application/json"
+		assert kwargs["headers"]["Idempotency-Key"] == "ep-002:apple_podcasts"
+		assert kwargs["json"] == {
+			"data": {
+				"type": "episodes",
+				"attributes": {
+					"title": "My Episode",
+					"description": "Desc",
+					"showId": "apple_show_1",
+					"publishDate": "2026-01-15T00:00:00+00:00",
+					"explicit": False,
+					"audioUrl": "https://cdn.example.com/audio.mp3",
+				},
+			}
+		}
+
 	def test_platform_url_fallback_when_website_url_absent(self):
 		"""Constructs fallback URL from show_id and episode_id when websiteUrl absent."""
 		from src.services.apple_podcasts_service import ApplePodcastsService
@@ -475,8 +569,62 @@ class TestDistributeToSpotify:
 		task.update_state = MagicMock()
 		return _distribute_to_spotify("ep-001", config, metadata or {}, task)
 
+	def test_rss_default_returns_feed_url_without_publishing(self):
+		"""Default (flag off): no publish_episode call; returns the RSS feed URL (issue #315)."""
+		from src.services.spotify_service import SpotifyService
+
+		config = {"show_id": "show1", "oauth_tokens": {"access_token": "tok"}}
+		feed_url = "https://cdn.example.com/rss-feeds/proj-1/feed.xml"
+
+		with patch.object(SpotifyService, "publish_episode") as mock_publish:
+			result = self._invoke(config, metadata={"rss_feed_url": feed_url})
+
+		mock_publish.assert_not_called()
+		assert result == {
+			"status": "success",
+			"platform": "spotify",
+			"method": "rss_feed",
+			"platform_episode_id": None,
+			"platform_url": feed_url,
+			"rss_feed_url": feed_url,
+			"error": None,
+		}
+
+	def test_rss_default_fails_clearly_without_feed_url(self):
+		"""Default (flag off): missing RSS feed is a clear permanent failure, not fake success."""
+		with pytest.raises(ValueError, match="RSS feed"):
+			self._invoke(config={"show_id": "show1", "oauth_tokens": {"access_token": "tok"}})
+
+	def test_rss_default_does_not_require_oauth_credentials(self):
+		"""Default (flag off): RSS ingestion needs no OAuth token."""
+		result = self._invoke(
+			config={"show_id": "show1"},
+			metadata={"rss_feed_url": "https://cdn.example.com/feed.xml"},
+		)
+		assert result["method"] == "rss_feed"
+
+	def test_direct_publish_called_once_with_expected_args_when_enabled(self):
+		"""Flag on: publish_episode called exactly once with show_id, metadata, idempotency key."""
+		from src.services.spotify_service import SpotifyService
+
+		config = {"show_id": "show1", "oauth_tokens": {"access_token": "tok"}}
+
+		with _direct_publish_enabled(), patch.object(
+			SpotifyService,
+			"publish_episode",
+			return_value={"episode_id": "e1", "platform_url": "https://open.spotify.com/episode/e1"},
+		) as mock_publish:
+			self._invoke(config, metadata={"title": "T"})
+
+		mock_publish.assert_called_once_with(
+			show_id="show1",
+			access_token="tok",
+			metadata={"title": "T"},
+			idempotency_key="ep-001:spotify",
+		)
+
 	def test_success_returns_real_episode_id(self):
-		"""Returns real episode_id from SpotifyService on success."""
+		"""Returns real episode_id from SpotifyService on success (direct path)."""
 		from src.services.spotify_service import SpotifyService
 
 		config = {
@@ -484,7 +632,7 @@ class TestDistributeToSpotify:
 			"oauth_tokens": {"access_token": "tok"},
 		}
 
-		with patch.object(
+		with _direct_publish_enabled(), patch.object(
 			SpotifyService,
 			"publish_episode",
 			return_value={"episode_id": "real_ep_id", "platform_url": "https://open.spotify.com/episode/real_ep_id"},
@@ -505,7 +653,7 @@ class TestDistributeToSpotify:
 			"oauth_tokens": {"access_token": "tok"},
 		}
 
-		with patch.object(
+		with _direct_publish_enabled(), patch.object(
 			SpotifyService,
 			"publish_episode",
 			return_value={"episode_id": "real_id", "platform_url": "https://open.spotify.com/episode/real_id"},
@@ -520,9 +668,10 @@ class TestDistributeToSpotify:
 			self._invoke(config={"oauth_tokens": {"access_token": "tok"}})
 
 	def test_raises_value_error_when_access_token_missing(self):
-		"""Raises ValueError when access_token absent from config."""
-		with pytest.raises(ValueError, match="access token"):
-			self._invoke(config={"show_id": "s", "oauth_tokens": {}})
+		"""Raises ValueError when access_token absent from config (direct path)."""
+		with _direct_publish_enabled():
+			with pytest.raises(ValueError, match="access token"):
+				self._invoke(config={"show_id": "s", "oauth_tokens": {}})
 
 	def test_refreshes_expired_token_before_publish(self):
 		"""Calls refresh_access_token when expires_at is in the past."""
@@ -551,6 +700,7 @@ class TestDistributeToSpotify:
 				return_value={"episode_id": "ep1", "platform_url": "https://open.spotify.com/episode/ep1"},
 			) as mock_publish,
 		):
+			mock_settings.ENABLE_DIRECT_PLATFORM_PUBLISH = True
 			mock_settings.SPOTIFY_CLIENT_ID = "cid"
 			mock_settings.SPOTIFY_CLIENT_SECRET = "csec"
 
@@ -581,6 +731,7 @@ class TestDistributeToSpotify:
 		}
 
 		with (
+			_direct_publish_enabled(),
 			patch.object(SpotifyService, "refresh_access_token") as mock_refresh,
 			patch.object(
 				SpotifyService,
@@ -605,6 +756,7 @@ class TestDistributeToSpotify:
 		}
 
 		with patch("src.tasks.platform_distribution.settings") as mock_settings:
+			mock_settings.ENABLE_DIRECT_PLATFORM_PUBLISH = True
 			mock_settings.SPOTIFY_CLIENT_ID = None
 			mock_settings.SPOTIFY_CLIENT_SECRET = None
 
@@ -627,8 +779,54 @@ class TestDistributeToApple:
 		task.update_state = MagicMock()
 		return _distribute_to_apple("ep-002", config, metadata or {}, task)
 
+	def test_rss_default_returns_feed_url_without_publishing(self):
+		"""Default (flag off): no publish_episode call; returns the RSS feed URL (issue #315)."""
+		from src.services.apple_podcasts_service import ApplePodcastsService
+
+		config = {"show_id": "apple_show_1", "credentials": {"api_key": "ak_test"}}
+		feed_url = "https://cdn.example.com/rss-feeds/proj-1/feed.xml"
+
+		with patch.object(ApplePodcastsService, "publish_episode") as mock_publish:
+			result = self._invoke(config, metadata={"rss_feed_url": feed_url})
+
+		mock_publish.assert_not_called()
+		assert result == {
+			"status": "success",
+			"platform": "apple_podcasts",
+			"method": "rss_feed",
+			"platform_episode_id": None,
+			"platform_url": feed_url,
+			"rss_feed_url": feed_url,
+			"error": None,
+		}
+
+	def test_rss_default_fails_clearly_without_feed_url(self):
+		"""Default (flag off): missing RSS feed is a clear permanent failure, not fake success."""
+		with pytest.raises(ValueError, match="RSS feed"):
+			self._invoke(config={"show_id": "s", "credentials": {"api_key": "k"}})
+
+	def test_direct_publish_called_once_with_expected_args_when_enabled(self):
+		"""Flag on: publish_episode called exactly once with show_id, metadata, idempotency key."""
+		from src.services.apple_podcasts_service import ApplePodcastsService
+
+		config = {"show_id": "apple_show_1", "credentials": {"api_key": "ak_test"}}
+
+		with _direct_publish_enabled(), patch.object(
+			ApplePodcastsService,
+			"publish_episode",
+			return_value={"episode_id": "e1", "platform_url": "https://podcasts.apple.com/podcast/id1?i=e1"},
+		) as mock_publish:
+			self._invoke(config, metadata={"title": "T"})
+
+		mock_publish.assert_called_once_with(
+			show_id="apple_show_1",
+			api_key="ak_test",
+			metadata={"title": "T"},
+			idempotency_key="ep-002:apple_podcasts",
+		)
+
 	def test_success_returns_real_episode_id(self):
-		"""Returns real episode_id from ApplePodcastsService on success."""
+		"""Returns real episode_id from ApplePodcastsService on success (direct path)."""
 		from src.services.apple_podcasts_service import ApplePodcastsService
 
 		config = {
@@ -636,7 +834,7 @@ class TestDistributeToApple:
 			"credentials": {"api_key": "ak_test"},
 		}
 
-		with patch.object(
+		with _direct_publish_enabled(), patch.object(
 			ApplePodcastsService,
 			"publish_episode",
 			return_value={
@@ -660,7 +858,7 @@ class TestDistributeToApple:
 			"credentials": {"api_key": "k"},
 		}
 
-		with patch.object(
+		with _direct_publish_enabled(), patch.object(
 			ApplePodcastsService,
 			"publish_episode",
 			return_value={"episode_id": "real_id", "platform_url": "https://podcasts.apple.com/podcast/id123?i=real_id"},
@@ -675,9 +873,10 @@ class TestDistributeToApple:
 			self._invoke(config={"credentials": {"api_key": "k"}})
 
 	def test_raises_value_error_when_api_key_missing(self):
-		"""Raises ValueError when api_key absent from config."""
-		with pytest.raises(ValueError, match="API key"):
-			self._invoke(config={"show_id": "s", "credentials": {}})
+		"""Raises ValueError when api_key absent from config (direct path)."""
+		with _direct_publish_enabled():
+			with pytest.raises(ValueError, match="API key"):
+				self._invoke(config={"show_id": "s", "credentials": {}})
 
 	def test_auth_error_propagates_from_service(self):
 		"""AppleAuthError raised by service propagates out of the task function."""
@@ -688,7 +887,7 @@ class TestDistributeToApple:
 			"credentials": {"api_key": "bad_key"},
 		}
 
-		with patch.object(
+		with _direct_publish_enabled(), patch.object(
 			ApplePodcastsService,
 			"publish_episode",
 			side_effect=AppleAuthError("HTTP 401"),
@@ -705,13 +904,88 @@ class TestDistributeToApple:
 			"credentials": {"api_key": "key"},
 		}
 
-		with patch.object(
+		with _direct_publish_enabled(), patch.object(
 			ApplePodcastsService,
 			"publish_episode",
 			side_effect=AppleAPIError("HTTP 500"),
 		):
 			with pytest.raises(AppleAPIError):
 				self._invoke(config)
+
+
+# ===========================================================================
+# RSS feed URL resolution + injection into the distribution task (issue #315)
+# ===========================================================================
+
+
+class TestRssFeedUrlResolution:
+	"""Tests for _rss_feed_url_for_project() and its wiring into the task."""
+
+	def test_resolver_returns_public_url(self):
+		from src.tasks.platform_distribution import _rss_feed_url_for_project
+
+		feed = MagicMock()
+		feed.public_url = "https://cdn.example.com/rss-feeds/proj-1/feed.xml"
+		db = MagicMock()
+		db.execute.return_value.scalar_one_or_none.return_value = feed
+
+		assert (
+			_rss_feed_url_for_project(db, "proj-1")
+			== "https://cdn.example.com/rss-feeds/proj-1/feed.xml"
+		)
+
+	def test_resolver_returns_none_when_no_feed(self):
+		from src.tasks.platform_distribution import _rss_feed_url_for_project
+
+		db = MagicMock()
+		db.execute.return_value.scalar_one_or_none.return_value = None
+
+		assert _rss_feed_url_for_project(db, "proj-1") is None
+
+	def test_task_injects_feed_url_into_spotify_metadata(self):
+		"""distribute_to_platform_task resolves the project's feed URL and passes it on."""
+		import src.tasks.platform_distribution as pd
+
+		episode_id = "11111111-2222-3333-4444-555555555555"
+		episode = MagicMock()
+		episode.generation_progress = {}
+		episode.project_id = "proj-1"
+		episode.episode_metadata = {"title": "T", "description": "D"}
+		episode.duration_seconds = None
+		episode.s3_url = "https://cdn.example.com/audio.mp3"
+
+		captured = {}
+
+		def fake_spotify(eid, config, metadata, task):
+			captured["metadata"] = metadata
+			return {
+				"status": "success",
+				"platform": "spotify",
+				"method": "rss_feed",
+				"platform_episode_id": None,
+				"platform_url": metadata.get("rss_feed_url"),
+				"rss_feed_url": metadata.get("rss_feed_url"),
+				"error": None,
+			}
+
+		with (
+			patch.object(pd, "SyncSessionLocal") as mock_ssl,
+			patch.object(
+				pd, "_rss_feed_url_for_project", return_value="https://cdn.example.com/feed.xml"
+			) as mock_resolver,
+			patch.object(pd, "_distribute_to_spotify", side_effect=fake_spotify),
+			patch("src.tasks.callbacks.record_platform_distribution", return_value=True),
+			patch.object(pd.distribute_to_platform_task, "update_state"),
+		):
+			mock_ssl.return_value.__enter__.return_value.get.return_value = episode
+			result = pd.distribute_to_platform_task(
+				episode_id, "spotify", {"show_id": "s"}, {}
+			)
+
+		mock_resolver.assert_called_once()
+		assert mock_resolver.call_args.args[1] == "proj-1"
+		assert captured["metadata"]["rss_feed_url"] == "https://cdn.example.com/feed.xml"
+		assert result["rss_feed_url"] == "https://cdn.example.com/feed.xml"
 
 
 # ===========================================================================

--- a/apps/api/tests/unit/test_platform_distribution_services.py
+++ b/apps/api/tests/unit/test_platform_distribution_services.py
@@ -950,6 +950,17 @@ class TestRssFeedUrlResolution:
 
 		assert _rss_feed_url_for_project(db, "proj-1") is None
 
+	def test_resolver_returns_none_when_feed_not_yet_generated(self):
+		"""A feed row mid-generation (public_url still NULL) must not count as a feed."""
+		from src.tasks.platform_distribution import _rss_feed_url_for_project
+
+		feed = MagicMock()
+		feed.public_url = None
+		db = MagicMock()
+		db.execute.return_value.scalar_one_or_none.return_value = feed
+
+		assert _rss_feed_url_for_project(db, "proj-1") is None
+
 	@pytest.mark.parametrize(
 		"platform,helper_name",
 		[("spotify", "_distribute_to_spotify"), ("apple_podcasts", "_distribute_to_apple")],

--- a/apps/api/tests/unit/test_platform_distribution_services.py
+++ b/apps/api/tests/unit/test_platform_distribution_services.py
@@ -805,6 +805,14 @@ class TestDistributeToApple:
 		with pytest.raises(ValueError, match="RSS feed"):
 			self._invoke(config={"show_id": "s", "credentials": {"api_key": "k"}})
 
+	def test_rss_default_does_not_require_api_credentials(self):
+		"""Default (flag off): RSS ingestion needs no Apple API key."""
+		result = self._invoke(
+			config={"show_id": "s"},
+			metadata={"rss_feed_url": "https://cdn.example.com/feed.xml"},
+		)
+		assert result["method"] == "rss_feed"
+
 	def test_direct_publish_called_once_with_expected_args_when_enabled(self):
 		"""Flag on: publish_episode called exactly once with show_id, metadata, idempotency key."""
 		from src.services.apple_podcasts_service import ApplePodcastsService
@@ -942,7 +950,11 @@ class TestRssFeedUrlResolution:
 
 		assert _rss_feed_url_for_project(db, "proj-1") is None
 
-	def test_task_injects_feed_url_into_spotify_metadata(self):
+	@pytest.mark.parametrize(
+		"platform,helper_name",
+		[("spotify", "_distribute_to_spotify"), ("apple_podcasts", "_distribute_to_apple")],
+	)
+	def test_task_injects_feed_url_into_metadata(self, platform, helper_name):
 		"""distribute_to_platform_task resolves the project's feed URL and passes it on."""
 		import src.tasks.platform_distribution as pd
 
@@ -956,11 +968,11 @@ class TestRssFeedUrlResolution:
 
 		captured = {}
 
-		def fake_spotify(eid, config, metadata, task):
+		def fake_helper(eid, config, metadata, task):
 			captured["metadata"] = metadata
 			return {
 				"status": "success",
-				"platform": "spotify",
+				"platform": platform,
 				"method": "rss_feed",
 				"platform_episode_id": None,
 				"platform_url": metadata.get("rss_feed_url"),
@@ -973,13 +985,13 @@ class TestRssFeedUrlResolution:
 			patch.object(
 				pd, "_rss_feed_url_for_project", return_value="https://cdn.example.com/feed.xml"
 			) as mock_resolver,
-			patch.object(pd, "_distribute_to_spotify", side_effect=fake_spotify),
+			patch.object(pd, helper_name, side_effect=fake_helper),
 			patch("src.tasks.callbacks.record_platform_distribution", return_value=True),
 			patch.object(pd.distribute_to_platform_task, "update_state"),
 		):
 			mock_ssl.return_value.__enter__.return_value.get.return_value = episode
 			result = pd.distribute_to_platform_task(
-				episode_id, "spotify", {"show_id": "s"}, {}
+				episode_id, platform, {"show_id": "s"}, {}
 			)
 
 		mock_resolver.assert_called_once()

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,57 +1,53 @@
-# Issue #314 — Multi-modal input scope-down to URL/Text/PDF (P4.2)
+# Issue #315 — Spotify/Apple direct-publish targets are not real publishing APIs
 
-Status: SHIPPED — merged 2026-07-12 as 2caa0fb via PR #377; issue #314 closed.
+Plan source: CodeRabbit comment (adapted). Branch: `fix/315-rss-distribution-default`.
 
-CodeRabbit plan chose the scope-down path (option 2): align every layer to the
-genuinely supported set (url, text, pdf), surface the already-built PDF upload
-backend in the web UI, and fix overstated copy/docs. No architectural fork.
+## Adapted plan
 
-## Plan adaptations (verified against current code, 2026-07-11)
+1. **Config flag**: add `ENABLE_DIRECT_PLATFORM_PUBLISH: bool = False` to `apps/api/src/config.py`
+   (next to `ENABLE_PLATFORM_DISTRIBUTION`), plus `.env.example` entry if the other flags have one.
+2. **RSS feed URL resolution in the task** (`apps/api/src/tasks/platform_distribution.py`):
+   small helper `_rss_feed_url_for_project(db, project_id)` querying `RSSFeed.public_url` via the
+   already-open sync session; inject as `episode_metadata["rss_feed_url"]` when platform is
+   spotify/apple_podcasts.
+3. **RSS-default distribution**: in `_distribute_to_spotify` / `_distribute_to_apple`:
+   validate `show_id` as today; when `settings.ENABLE_DIRECT_PLATFORM_PUBLISH` is False (default),
+   skip credentials/token/publish entirely and return
+   `{"status": "success", "method": "rss_feed", "platform_episode_id": None,
+     "platform_url": <rss_feed_url>, "rss_feed_url": ..., "error": None}`.
+   Missing `rss_feed_url` → raise `ValueError` with an actionable message (permanent failure, no
+   retry, no false success). Flag on → existing direct-publish path unchanged.
+4. **Docstrings**: mark `publish_episode` in `spotify_service.py` / `apple_podcasts_service.py` as
+   experimental/unverified; state RSS is the supported ingestion mechanism.
+5. **Tests** (`apps/api/tests/unit/test_platform_distribution_services.py`, TDD):
+   - Service-level: assert `mock_client.post.call_args` — exact endpoint URL, Authorization header,
+     Idempotency-Key, JSON body fields (both services).
+   - Task-level default (flag off): `publish_episode` NOT called; result has method=rss_feed,
+     feed URL as platform_url, platform_episode_id None. Missing feed URL → ValueError.
+   - Flag on: `publish_episode` called once with correct kwargs (existing success tests updated to
+     enable the flag — behavior-change adaptation, disclosed in PR).
+   - `TestRetryClassification` unchanged.
 
-1. **PDF backend already done** (PR #210/#242): upload endpoint
-   `POST /episodes/{episode_id}/content/upload` (routers/content.py:136-197),
-   S3 extraction, full test suite. Nothing to build server-side except the
-   validator `else` and message tweaks.
-2. **Frontend has no PDF at all**: `contentSourceSchema` is `z.enum(["url","text"])`
-   (validation.ts:32); dialog toggle at page.tsx:660-686; hint text at :708.
-   Work = ADD pdf, not remove youtube/image/topic (never existed client-side).
-3. **No web API client layer** (deleted in #264): use inline `fetch` with
-   `FormData` to `/api/proxy/episodes/{id}/content/upload` — proxy forwards
-   body/headers as-is, so multipart passes through.
-4. `validate_by_type` (source_validator_service.py:294-318) silently no-ops on
-   unknown types — add terminal `else` raising ValueError.
-5. `openapi.yaml` enum already `[url, pdf, text]`; `/content/upload` endpoint is
-   undocumented — add it.
-6. Docs drift: README:63,73 overstates (images/YouTube/topics); USER_GUIDE has
-   no PDF row; GAP_ANALYSIS GAP-024 stale (PDF extraction done), FR-002 "PDF
-   upload UI missing" fixed by this PR; env-config report:273 mentions YouTube.
+## Autonomous decisions / deviations from the CodeRabbit plan
 
-## TDD checklist
+- **No lazy feed generation** in the resolver. The distribution task is sync (Celery,
+  `SyncSessionLocal`); `RSSGenerationService` is fully async. Bridging asyncio+S3+metadata
+  validation into the worker for a convenience path isn't warranted — the issue's own acceptance
+  criteria says "RSS already generated". Missing feed → clear, actionable permanent failure
+  ("generate the project's RSS feed first"), never a fake success.
+- **Result envelope keeps `status: "success"`, distinguishes via `method: "rss_feed"` +
+  `platform_episode_id: None`**, not a new top-level status. `record_platform_distribution` and
+  `on_workflow_complete` treat any per-platform status ≠ "complete" as failure, and
+  `episodes.generation_status` has a DB CHECK constraint (migration 016) — a new status value would
+  need a migration + callback rewrite for zero user benefit. The RSS result is genuinely successful.
+- **No UI/schema messaging changes**: web status types are free `string` with fallbacks; the
+  distribution entry's `platform_url` becomes the RSS feed URL, which is the honest actionable link.
 
-### Backend (apps/api)
-- [x] Test: `validate_by_type` with unsupported type (e.g. 'youtube') raises
-      ValueError naming supported set → add terminal `else` (RED→GREEN)
-- [x] Update model comment content_source.py:24-33 (supported vs reserved types)
-- [x] Error messages in routers/content.py:409 + tasks/content_extraction.py:60
-      reference supported list ['url', 'pdf', 'text']
-- [x] openapi.yaml: document POST /episodes/{episode_id}/content/upload
+## Acceptance criteria
 
-### Frontend (apps/web)
-- [x] Tests: page.test.tsx — PDF toggle renders file input; PDF submit posts
-      FormData to /api/proxy/.../content/upload; oversize/wrong-type file shows
-      validation error (RED)
-- [x] validation.ts: add "pdf" to enum + superRefine (file required,
-      application/pdf, ≤50MB)
-- [x] page.tsx: PDF toggle button; file input (accept="application/pdf") with
-      RHF error pattern; FormData submit path incl. auto_extract; replace :708
-      hint with "Supports public HTTP/HTTPS article URLs" (GREEN)
-
-### Docs
-- [x] README.md:63,73 → websites, PDFs, plain text only
-- [x] docs/USER_GUIDE.md: add PDF row to Supported Content Types
-- [x] docs/GAP_ANALYSIS.md: GAP-024 closed; FR-002 complete
-- [x] docs/environment-configuration-report-2025-11-11.md:273 drop YouTube
-
-### Gates
-- [x] pytest + jest + lint green; deslop; internal review + opencode/GLM review
-- [x] PR, demo (agent-browser PDF upload flow), CI green, merge
+- [ ] Verified against current platform APIs: Spotify/Apple ingest via RSS, not direct POST
+      (documented in service docstrings; direct path no longer default).
+- [ ] Spotify/Apple targets pivot to the RSS-feed model by default.
+- [ ] Direct-publish gated behind explicit default-off flag and clearly marked experimental.
+- [ ] Tests assert the actual outbound request URL/headers/body.
+- [ ] No silent false-positive success when no RSS feed exists.


### PR DESCRIPTION
## Summary
Implements #315: Spotify/Apple direct-publish targets POST to endpoints that are not real publishing APIs.

- **RSS is now the default distribution result for Spotify/Apple**: the Celery task resolves the project's `RSSFeed.public_url` (sync query while the episode session is open) and injects it into the distribution metadata; the platform helpers return `{status: "success", method: "rss_feed", platform_url: <feed URL>, platform_episode_id: null}` — the honest, actionable result, since both platforms ingest via RSS.
- **Missing feed = clear permanent failure**: if the project has no generated feed (no row, or `public_url` still NULL mid-generation), distribution raises an actionable `ValueError` (non-retryable) instead of fabricating success.
- **Direct publish preserved but gated**: the legacy `publish_episode` path only runs behind the new default-off `ENABLE_DIRECT_PLATFORM_PUBLISH` flag; both service docstrings now state the direct endpoints are experimental/unverified.
- **Request-level test assertions**: tests now assert the exact outbound endpoint URL, `Authorization`/`Content-Type`/`Idempotency-Key` headers, and full JSON body for both services, plus the RSS default, the flag gate, and feed-URL injection for both platforms.

## Acceptance Criteria
- [x] Verified against platform reality: Spotify/Apple ingest via RSS; direct POST endpoints documented as unverified and no longer default
- [x] Spotify/Apple targets pivot to the RSS-feed submission model (feed already generated by the existing RSS subsystem)
- [x] Direct-publish gated behind an explicit default-off flag and clearly marked experimental
- [x] Tests assert the actual outbound request URL/headers/body
- [x] No silent false-positive success when no RSS feed exists

## Test Plan
- [x] Unit tests written first (TDD; RED run showed 19 failures before implementation)
- [x] Full backend suite: 1783 passed, 7 skipped, 0 failed
- [x] Diff coverage: 100% on changed lines (diff-cover vs main; ≥85% gate)
- [x] Linting clean (ruff); mypy shows only pre-existing errors (celery stubs)
- [x] Internal code review (advisory) completed — Critical it raised (fixture regression) was already fixed; both suggestions addressed (test added; follow-up filed as #378)
- [x] Cross-family review pass: opencode (GLM) — verdict APPROVE; its suggestions applied (parametrized injection test for both platforms, Apple no-credentials RSS test, error-message wording)
- [x] Mutation sanity check: 4 mutations (inverted flag gate, dropped Idempotency-Key, nulled platform_url, skipped feed-URL injection) — all caught by tests

## Known Limitations / Intentionally Deferred
- **No lazy feed generation**: the distribution task is sync (Celery) while `RSSGenerationService` is async; a project whose feed was never generated gets a clear permanent failure, not an auto-generated feed. First-attempt UX tracked in follow-up **#378**.
- **`show_id` still validated on the RSS path**: intentional — a Spotify/Apple target without a show_id is misconfigured regardless of delivery mechanism (matches the issue plan's config-validation requirement).
- **No UI/schema messaging changes**: web statuses are free strings with fallbacks; the distribution entry's `platform_url` now carries the RSS feed URL. Frontend distribution surface is separately tracked in #316.
- **Existing test expectation changes disclosed**: two idempotency-key forwarding tests now enable the flag (they exercise the gated direct path), and episode fixtures gained the non-nullable `project_id` — both are adaptations to the intentional behavior change, not gate-dodging.

## Implementation Notes
- Result envelope deliberately keeps top-level `status: "success"` with a `method: "rss_feed"` discriminator instead of a new status value: `record_platform_distribution`/`on_workflow_complete` treat any per-platform status ≠ `complete` as failure, and `episodes.generation_status` is constrained by a DB CHECK (migration 016) — a new status would require a migration + callback rewrite for no user benefit.

Closes #315