### PR TITLE
RSS feed pre-flight: auto-generate or warn before Spotify/Apple distribution (#378)

### DIFF
--- a/apps/api/src/routers/generation.py
+++ b/apps/api/src/routers/generation.py
@@ -288,9 +288,12 @@ async def generate_podcast(
             ]
             if rss_platforms and not settings.ENABLE_DIRECT_PLATFORM_PUBLISH:
                 rss_service = RSSGenerationService()
-                feed = await rss_service.get_rss_feed(db, episode.project_id)
-                if feed is None or not feed.public_url:
-                    try:
+                # The whole pre-flight is non-fatal: a failure here must skip
+                # the RSS-model platforms with a warning, never 500 the
+                # generation kickoff itself.
+                try:
+                    feed = await rss_service.get_rss_feed(db, episode.project_id)
+                    if feed is None or not feed.public_url:
                         await rss_service.generate_rss_for_project(
                             db, episode.project_id, current_user.id
                         )
@@ -299,30 +302,36 @@ async def generate_podcast(
                             "project %s ahead of %s distribution.",
                             episode_id, episode.project_id, ", ".join(rss_platforms),
                         )
-                    except Exception as exc:
-                        for p in rss_platforms:
-                            del platforms[p]
-                        # ValueError carries a user-actionable validation message
-                        # (same contract as the RSS router's 422); anything else
-                        # stays internal so infrastructure details never leak.
-                        reason = (
-                            str(exc) if isinstance(exc, ValueError)
-                            else "feed generation failed unexpectedly"
-                        )
-                        distribution_warnings.append(
-                            f"Skipped {' and '.join(rss_platforms)} distribution: "
-                            "these platforms ingest episodes via the project's RSS "
-                            f"feed, which has not been generated and could not be "
-                            f"auto-generated ({reason}). Set the podcast metadata "
-                            "and generate the feed from the project's distribution "
-                            "page, then regenerate."
-                        )
-                        logger.warning(
-                            "Episode %s: RSS pre-flight failed for project %s; "
-                            "skipping %s distribution: %s",
-                            episode_id, episode.project_id,
-                            ", ".join(rss_platforms), exc,
-                        )
+                except Exception as exc:
+                    for p in rss_platforms:
+                        del platforms[p]
+                    # ValueError carries a user-actionable validation message
+                    # (same contract as the RSS router's 422); anything else
+                    # stays internal so infrastructure details never leak.
+                    reason = (
+                        str(exc) if isinstance(exc, ValueError)
+                        else "feed generation failed unexpectedly"
+                    )
+                    display_names = {
+                        "spotify": "Spotify", "apple_podcasts": "Apple Podcasts"
+                    }
+                    skipped = " and ".join(
+                        display_names[p] for p in rss_platforms
+                    )
+                    distribution_warnings.append(
+                        f"Skipped {skipped} distribution: "
+                        "these platforms ingest episodes via the project's RSS "
+                        f"feed, which has not been generated and could not be "
+                        f"auto-generated ({reason}). Set the podcast metadata "
+                        "and generate the feed from the project's distribution "
+                        "page, then regenerate."
+                    )
+                    logger.warning(
+                        "Episode %s: RSS pre-flight failed for project %s; "
+                        "skipping %s distribution: %s",
+                        episode_id, episode.project_id,
+                        ", ".join(rss_platforms), exc,
+                    )
             if platforms:
                 extra_kwargs["platforms"] = platforms
         else:

--- a/apps/api/src/routers/generation.py
+++ b/apps/api/src/routers/generation.py
@@ -22,6 +22,7 @@ from ..dependencies import get_current_user
 from ..services.distribution_target_service import (
     get_active_distribution_targets_for_project,
 )
+from ..services.rss_generation_service import RSSGenerationService
 from ..tasks.podcast_generation import generate_podcast_task
 from ..tasks.callbacks import on_workflow_failure
 
@@ -240,6 +241,7 @@ async def generate_podcast(
     # no bucket the workflow-chain path would schedule an invalid empty-bucket
     # upload and fail the whole run, whereas the default finalization path degrades
     # gracefully — so only enable distribution when a bucket is configured.
+    distribution_warnings: list[str] = []
     if use_distribution and not settings.AWS_S3_BUCKET:
         logger.warning(
             "Episode %s: distribution requested but AWS_S3_BUCKET is not configured "
@@ -273,7 +275,56 @@ async def generate_podcast(
                     )
                     continue
                 platforms[target.target_type] = target.config
-            extra_kwargs["platforms"] = platforms
+
+            # RSS pre-flight (issue #378): under the RSS-feed model, the
+            # distribution task fails permanently for Spotify/Apple when the
+            # project has no generated feed. This router is async (unlike the
+            # sync Celery task), so auto-generating the feed here is one awaited
+            # service call. If it can't be generated (e.g. podcast metadata
+            # missing), skip those platforms and tell the caller instead of
+            # dispatching a guaranteed distribution_failed.
+            rss_platforms = [
+                p for p in ("spotify", "apple_podcasts") if p in platforms
+            ]
+            if rss_platforms and not settings.ENABLE_DIRECT_PLATFORM_PUBLISH:
+                rss_service = RSSGenerationService()
+                feed = await rss_service.get_rss_feed(db, episode.project_id)
+                if feed is None or not feed.public_url:
+                    try:
+                        await rss_service.generate_rss_for_project(
+                            db, episode.project_id, current_user.id
+                        )
+                        logger.info(
+                            "Episode %s: auto-generated missing RSS feed for "
+                            "project %s ahead of %s distribution.",
+                            episode_id, episode.project_id, ", ".join(rss_platforms),
+                        )
+                    except Exception as exc:
+                        for p in rss_platforms:
+                            del platforms[p]
+                        # ValueError carries a user-actionable validation message
+                        # (same contract as the RSS router's 422); anything else
+                        # stays internal so infrastructure details never leak.
+                        reason = (
+                            str(exc) if isinstance(exc, ValueError)
+                            else "feed generation failed unexpectedly"
+                        )
+                        distribution_warnings.append(
+                            f"Skipped {' and '.join(rss_platforms)} distribution: "
+                            "these platforms ingest episodes via the project's RSS "
+                            f"feed, which has not been generated and could not be "
+                            f"auto-generated ({reason}). Set the podcast metadata "
+                            "and generate the feed from the project's distribution "
+                            "page, then regenerate."
+                        )
+                        logger.warning(
+                            "Episode %s: RSS pre-flight failed for project %s; "
+                            "skipping %s distribution: %s",
+                            episode_id, episode.project_id,
+                            ", ".join(rss_platforms), exc,
+                        )
+            if platforms:
+                extra_kwargs["platforms"] = platforms
         else:
             logger.info(
                 "Episode %s: distribution requested but no active targets for "
@@ -335,12 +386,15 @@ async def generate_podcast(
             detail="Could not start generation (task queue unavailable); please retry.",
         )
 
-    return {
+    response = {
         "episode_id": str(episode_id),
         "task_id": new_task_id,
         "status": "queued",
         "message": "Podcast generation started",
     }
+    if distribution_warnings:
+        response["warnings"] = distribution_warnings
+    return response
 
 
 @router.get("/episodes/{episode_id}/progress")

--- a/apps/api/src/routers/generation.py
+++ b/apps/api/src/routers/generation.py
@@ -290,7 +290,13 @@ async def generate_podcast(
                 rss_service = RSSGenerationService()
                 # The whole pre-flight is non-fatal: a failure here must skip
                 # the RSS-model platforms with a warning, never 500 the
-                # generation kickoff itself.
+                # generation kickoff itself. It runs under a SAVEPOINT so a
+                # DB-level failure (e.g. the unique-RSSFeed race between two
+                # concurrent generations) aborts only the pre-flight work: a
+                # whole-session rollback would poison the later 'queued'
+                # commit path by expiring loaded instances (and, under the
+                # test harness's shared-session wrapping, wipe prior writes).
+                preflight_sp = await db.begin_nested()
                 try:
                     feed = await rss_service.get_rss_feed(db, episode.project_id)
                     if feed is None or not feed.public_url:
@@ -302,7 +308,13 @@ async def generate_podcast(
                             "project %s ahead of %s distribution.",
                             episode_id, episode.project_id, ", ".join(rss_platforms),
                         )
+                    # The service commits internally on success, consuming the
+                    # savepoint; release it only if it is still open.
+                    if preflight_sp.is_active:
+                        await preflight_sp.commit()
                 except Exception as exc:
+                    if preflight_sp.is_active:
+                        await preflight_sp.rollback()
                     for p in rss_platforms:
                         del platforms[p]
                     # ValueError carries a user-actionable validation message

--- a/apps/api/tests/test_distribution_wiring.py
+++ b/apps/api/tests/test_distribution_wiring.py
@@ -320,3 +320,190 @@ async def test_generate_omits_platforms_when_distribution_disabled(client):
     mock_delay.assert_called_once()
     assert "platforms" not in mock_delay.call_args.kwargs["kwargs"]
     assert mock_delay.call_args.kwargs["kwargs"]["enable_distribution"] is False
+
+
+# ---------------------------------------------------------------------------
+# Router: RSS feed pre-flight for Spotify/Apple targets (issue #378)
+# ---------------------------------------------------------------------------
+
+async def _create_apple_target(
+    client: AsyncClient, headers: Headers, project_id: str | None = None
+) -> dict:
+    body = {"show_id": "show-378", "api_key": "not-a-real-key"}
+    if project_id is not None:
+        body["project_id"] = project_id
+    resp = await client.post("/distribution-targets/apple", headers=headers, json=body)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _preflight_patches(rss_service_mock):
+    """Common settings/task patches for the pre-flight tests."""
+    return (
+        patch.object(generation_router.settings, "ENABLE_PLATFORM_DISTRIBUTION", True),
+        patch.object(generation_router.settings, "ENABLE_DIRECT_PLATFORM_PUBLISH", False),
+        patch.object(generation_router.settings, "AWS_S3_BUCKET", "test-bucket"),
+        patch("src.routers.generation.RSSGenerationService", rss_service_mock),
+        patch("src.routers.generation.generate_podcast_task.apply_async"),
+    )
+
+
+async def _generate_with_preflight(client, headers, episode_id, rss_service_mock):
+    p1, p2, p3, p4, p5 = _preflight_patches(rss_service_mock)
+    with p1, p2, p3, p4, p5 as mock_delay:
+        mock_delay.return_value = MagicMock(id="task-preflight")
+        resp = await client.post(
+            f"/generation/episodes/{episode_id}/generate?enable_distribution=true",
+            headers=headers,
+        )
+    return resp, mock_delay
+
+
+@pytest.mark.asyncio
+async def test_generate_autogenerates_missing_rss_feed(client):
+    """Apple/Spotify target + no feed → the feed is auto-generated pre-dispatch."""
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    episode_id = await _create_episode(client, headers, project_id)
+    await _create_text_source(client, episode_id, headers)
+    await _create_apple_target(client, headers, project_id)
+
+    from unittest.mock import AsyncMock
+
+    service = AsyncMock()
+    service.get_rss_feed.return_value = None
+    resp, mock_delay = await _generate_with_preflight(
+        client, headers, episode_id, MagicMock(return_value=service)
+    )
+
+    assert resp.status_code == 202, resp.text
+    service.generate_rss_for_project.assert_awaited_once()
+    platforms = mock_delay.call_args.kwargs["kwargs"]["platforms"]
+    assert "apple_podcasts" in platforms
+    assert "warnings" not in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_platform_and_warns_when_feed_ungeneratable(client):
+    """Auto-generation fails (missing metadata) → platform skipped + warning returned."""
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    episode_id = await _create_episode(client, headers, project_id)
+    await _create_text_source(client, episode_id, headers)
+    await _create_apple_target(client, headers, project_id)
+
+    from unittest.mock import AsyncMock
+
+    service = AsyncMock()
+    service.get_rss_feed.return_value = None
+    service.generate_rss_for_project.side_effect = ValueError(
+        "Missing required podcast metadata fields: show_title"
+    )
+    resp, mock_delay = await _generate_with_preflight(
+        client, headers, episode_id, MagicMock(return_value=service)
+    )
+
+    # Generation itself still proceeds — only the RSS-model platforms are skipped.
+    assert resp.status_code == 202, resp.text
+    assert "platforms" not in mock_delay.call_args.kwargs["kwargs"]
+    warnings = resp.json()["warnings"]
+    assert len(warnings) == 1
+    assert "RSS feed" in warnings[0]
+    assert "show_title" in warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_generate_preflight_warning_hides_internal_errors(client):
+    """Non-ValueError failures (e.g. S3) must not leak details into the warning."""
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    episode_id = await _create_episode(client, headers, project_id)
+    await _create_text_source(client, episode_id, headers)
+    await _create_apple_target(client, headers, project_id)
+
+    from unittest.mock import AsyncMock
+
+    internal_detail = "internal-s3-failure-detail"
+    service = AsyncMock()
+    service.get_rss_feed.return_value = None
+    service.generate_rss_for_project.side_effect = RuntimeError(internal_detail)
+    resp, mock_delay = await _generate_with_preflight(
+        client, headers, episode_id, MagicMock(return_value=service)
+    )
+
+    assert resp.status_code == 202, resp.text
+    assert "platforms" not in mock_delay.call_args.kwargs["kwargs"]
+    warnings = resp.json()["warnings"]
+    assert len(warnings) == 1
+    assert internal_detail not in warnings[0]
+    assert "RSS feed" in warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_generate_no_regeneration_when_feed_exists(client):
+    """An already-generated feed short-circuits the pre-flight."""
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    episode_id = await _create_episode(client, headers, project_id)
+    await _create_text_source(client, episode_id, headers)
+    await _create_apple_target(client, headers, project_id)
+
+    from unittest.mock import AsyncMock
+
+    service = AsyncMock()
+    service.get_rss_feed.return_value = MagicMock(
+        public_url="https://cdn.example.com/rss-feeds/p/feed.xml"
+    )
+    resp, mock_delay = await _generate_with_preflight(
+        client, headers, episode_id, MagicMock(return_value=service)
+    )
+
+    assert resp.status_code == 202, resp.text
+    service.generate_rss_for_project.assert_not_awaited()
+    assert "apple_podcasts" in mock_delay.call_args.kwargs["kwargs"]["platforms"]
+    assert "warnings" not in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_generate_no_preflight_for_webhook_only_targets(client):
+    """Webhook targets don't use the RSS model — no feed check at all."""
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    episode_id = await _create_episode(client, headers, project_id)
+    await _create_text_source(client, episode_id, headers)
+    await _create_webhook_target(client, headers, project_id, "https://hook.example.com/rss")
+
+    service_cls = MagicMock()
+    resp, mock_delay = await _generate_with_preflight(
+        client, headers, episode_id, service_cls
+    )
+
+    assert resp.status_code == 202, resp.text
+    service_cls.assert_not_called()
+    assert "webhook" in mock_delay.call_args.kwargs["kwargs"]["platforms"]
+    assert "warnings" not in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_generate_no_preflight_with_direct_publish_enabled(client):
+    """ENABLE_DIRECT_PLATFORM_PUBLISH bypasses the RSS model → no feed check."""
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    episode_id = await _create_episode(client, headers, project_id)
+    await _create_text_source(client, episode_id, headers)
+    await _create_apple_target(client, headers, project_id)
+
+    service_cls = MagicMock()
+    p1, _, p3, p4, p5 = _preflight_patches(service_cls)
+    with p1, patch.object(
+        generation_router.settings, "ENABLE_DIRECT_PLATFORM_PUBLISH", True
+    ), p3, p4, p5 as mock_delay:
+        mock_delay.return_value = MagicMock(id="task-direct")
+        resp = await client.post(
+            f"/generation/episodes/{episode_id}/generate?enable_distribution=true",
+            headers=headers,
+        )
+
+    assert resp.status_code == 202, resp.text
+    service_cls.assert_not_called()
+    assert "apple_podcasts" in mock_delay.call_args.kwargs["kwargs"]["platforms"]

--- a/apps/api/tests/test_distribution_wiring.py
+++ b/apps/api/tests/test_distribution_wiring.py
@@ -440,6 +440,40 @@ async def test_generate_preflight_warning_hides_internal_errors(client):
 
 
 @pytest.mark.asyncio
+async def test_generate_preflight_db_error_does_not_poison_the_request(client):
+    """A DB-level failure inside the pre-flight (e.g. the unique-RSSFeed race
+    between two concurrent generations) must roll the session back so the
+    subsequent 'queued' commit still succeeds — 202 + warning, never a 500."""
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    episode_id = await _create_episode(client, headers, project_id)
+    await _create_text_source(client, episode_id, headers)
+    await _create_apple_target(client, headers, project_id)
+
+    from unittest.mock import AsyncMock
+
+    from sqlalchemy import text
+
+    async def _poison_session(db, project_id, user_id):
+        # Real failing statement on the request session: leaves the session in
+        # a pending-rollback state exactly like an IntegrityError would.
+        await db.execute(text("SELECT * FROM nonexistent_table_issue_378"))
+
+    service = AsyncMock()
+    service.get_rss_feed.return_value = None
+    service.generate_rss_for_project.side_effect = _poison_session
+    resp, mock_delay = await _generate_with_preflight(
+        client, headers, episode_id, MagicMock(return_value=service)
+    )
+
+    assert resp.status_code == 202, resp.text
+    assert "platforms" not in mock_delay.call_args.kwargs["kwargs"]
+    warnings = resp.json()["warnings"]
+    assert len(warnings) == 1
+    assert "nonexistent_table_issue_378" not in warnings[0]  # internals masked
+
+
+@pytest.mark.asyncio
 async def test_generate_no_regeneration_when_feed_exists(client):
     """An already-generated feed short-circuits the pre-flight."""
     headers = await _register(client)

--- a/apps/api/tests/test_distribution_wiring.py
+++ b/apps/api/tests/test_distribution_wiring.py
@@ -465,6 +465,76 @@ async def test_generate_no_regeneration_when_feed_exists(client):
 
 
 @pytest.mark.asyncio
+async def test_generate_regenerates_when_feed_row_has_no_public_url(client):
+    """A stale RSSFeed row without a public_url (e.g. interrupted S3 upload)
+    must be treated like a missing feed and regenerated."""
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    episode_id = await _create_episode(client, headers, project_id)
+    await _create_text_source(client, episode_id, headers)
+    await _create_apple_target(client, headers, project_id)
+
+    from unittest.mock import AsyncMock
+
+    service = AsyncMock()
+    service.get_rss_feed.return_value = MagicMock(public_url=None)
+    resp, mock_delay = await _generate_with_preflight(
+        client, headers, episode_id, MagicMock(return_value=service)
+    )
+
+    assert resp.status_code == 202, resp.text
+    service.generate_rss_for_project.assert_awaited_once()
+    assert "apple_podcasts" in mock_delay.call_args.kwargs["kwargs"]["platforms"]
+    assert "warnings" not in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_generate_warning_names_all_skipped_rss_platforms(client, test_db):
+    """With Spotify AND Apple targets and an ungeneratable feed, both platforms
+    are skipped and the single warning names both in human-readable form."""
+    from uuid import UUID as _UUID
+
+    from src.models.distribution_target import DistributionTarget
+
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    episode_id = await _create_episode(client, headers, project_id)
+    await _create_text_source(client, episode_id, headers)
+    apple = await _create_apple_target(client, headers, project_id)
+
+    # Spotify targets are only created via the OAuth callback; insert directly.
+    await set_tenant_context(test_db, apple["tenant_id"])
+    test_db.add(DistributionTarget(
+        user_id=_UUID(apple["user_id"]),
+        project_id=_UUID(project_id),
+        tenant_id=_UUID(apple["tenant_id"]),
+        target_type="spotify",
+        config={"show_id": "spotify-show-378"},
+        is_active=True,
+    ))
+    await test_db.commit()
+
+    from unittest.mock import AsyncMock
+
+    service = AsyncMock()
+    service.get_rss_feed.return_value = None
+    service.generate_rss_for_project.side_effect = ValueError(
+        "Missing required podcast metadata fields: show_title"
+    )
+    resp, mock_delay = await _generate_with_preflight(
+        client, headers, episode_id, MagicMock(return_value=service)
+    )
+
+    assert resp.status_code == 202, resp.text
+    assert "platforms" not in mock_delay.call_args.kwargs["kwargs"]
+    warnings = resp.json()["warnings"]
+    assert len(warnings) == 1
+    assert "Spotify and Apple Podcasts" in warnings[0]
+    assert "spotify" not in warnings[0]  # raw platform keys never shown to users
+    assert "apple_podcasts" not in warnings[0]
+
+
+@pytest.mark.asyncio
 async def test_generate_no_preflight_for_webhook_only_targets(client):
     """Webhook targets don't use the RSS model — no feed check at all."""
     headers = await _register(client)

--- a/apps/web/__tests__/app/episodes/[id]/page.test.tsx
+++ b/apps/web/__tests__/app/episodes/[id]/page.test.tsx
@@ -19,6 +19,7 @@ jest.mock('next-auth/react', () => ({
 jest.mock('@/lib/toast', () => ({
   showSuccessToast: jest.fn(),
   showErrorToast: jest.fn(),
+  showWarningToast: jest.fn(),
 }))
 
 jest.mock('@/lib/download', () => ({
@@ -50,7 +51,7 @@ jest.mock('@/lib/event-source-manager', () => ({
   },
 }))
 
-const { showSuccessToast, showErrorToast } = jest.requireMock('@/lib/toast')
+const { showSuccessToast, showErrorToast, showWarningToast } = jest.requireMock('@/lib/toast')
 
 const draftEpisode = {
   id: 'ep1',
@@ -216,6 +217,26 @@ describe('EpisodePage generate flow', () => {
         { method: 'POST' }
       )
     })
+    expect(showSuccessToast).toHaveBeenCalledWith('Podcast generation started')
+    expect(showErrorToast).not.toHaveBeenCalled()
+  })
+
+  it('surfaces distribution warnings returned by the generate endpoint (#378)', async () => {
+    const warning =
+      'Skipped apple_podcasts distribution: the RSS feed has not been generated.'
+    const fetchMock = withOverride(
+      mockEpisodeFetchRouter(),
+      (url, init) => url.includes('/generate') && init?.method === 'POST',
+      () => Promise.resolve({ ok: true, json: async () => ({ warnings: [warning] }) })
+    )
+    global.fetch = fetchMock
+    render(<EpisodePage />)
+
+    const generateBtn = await screen.findByRole('button', { name: /generate podcast/i })
+    await waitFor(() => expect(generateBtn).toBeEnabled())
+    await userEvent.click(generateBtn)
+
+    await waitFor(() => expect(showWarningToast).toHaveBeenCalledWith(warning))
     expect(showSuccessToast).toHaveBeenCalledWith('Podcast generation started')
     expect(showErrorToast).not.toHaveBeenCalled()
   })

--- a/apps/web/__tests__/app/episodes/[id]/page.test.tsx
+++ b/apps/web/__tests__/app/episodes/[id]/page.test.tsx
@@ -223,7 +223,7 @@ describe('EpisodePage generate flow', () => {
 
   it('surfaces distribution warnings returned by the generate endpoint (#378)', async () => {
     const warning =
-      'Skipped apple_podcasts distribution: the RSS feed has not been generated.'
+      "Skipped Apple Podcasts distribution: these platforms ingest episodes via the project's RSS feed, which has not been generated and could not be auto-generated."
     const fetchMock = withOverride(
       mockEpisodeFetchRouter(),
       (url, init) => url.includes('/generate') && init?.method === 'POST',

--- a/apps/web/__tests__/lib/toast.test.ts
+++ b/apps/web/__tests__/lib/toast.test.ts
@@ -1,10 +1,11 @@
-import { showSuccessToast, showErrorToast, showLoadingToast, dismissToast, executeWithToast } from '@/lib/toast'
+import { showSuccessToast, showErrorToast, showWarningToast, showLoadingToast, dismissToast, executeWithToast } from '@/lib/toast'
 
 // Mock sonner
 jest.mock('sonner', () => ({
   toast: {
     success: jest.fn(),
     error: jest.fn(),
+    warning: jest.fn(),
     loading: jest.fn().mockReturnValue('toast-id-1'),
     dismiss: jest.fn(),
   },
@@ -28,6 +29,13 @@ describe('toast utilities', () => {
     it('calls toast.error with the message', () => {
       showErrorToast('Operation failed')
       expect(toast.error).toHaveBeenCalledWith('Operation failed')
+    })
+  })
+
+  describe('showWarningToast', () => {
+    it('calls toast.warning with the message', () => {
+      showWarningToast('Distribution skipped')
+      expect(toast.warning).toHaveBeenCalledWith('Distribution skipped')
     })
   })
 

--- a/apps/web/src/app/(auth)/episodes/[id]/page.tsx
+++ b/apps/web/src/app/(auth)/episodes/[id]/page.tsx
@@ -14,7 +14,7 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Progress } from "@/components/ui/progress"
 import { contentSourceSchema, type ContentSourceFormData } from "@/lib/validation"
-import { showSuccessToast, showErrorToast } from "@/lib/toast"
+import { showSuccessToast, showErrorToast, showWarningToast } from "@/lib/toast"
 import { RobustEventSource, startPolling, ConnectionStatus } from "@/lib/event-source-manager"
 import { AudioPlayerSkeleton } from "@/components/skeletons/AudioPlayerSkeleton"
 import { EmptyState } from "@/components/empty-state/EmptyState"
@@ -484,6 +484,12 @@ export default function EpisodePage() {
       )
       if (response.ok) {
         showSuccessToast("Podcast generation started")
+        // Distribution pre-flight warnings (#378): generation proceeds, but
+        // e.g. Spotify/Apple were skipped because the RSS feed is missing.
+        const data = (await response.json().catch(() => null)) as
+          | { warnings?: string[] }
+          | null
+        data?.warnings?.forEach((w) => showWarningToast(w))
         loadEpisode()
       } else {
         showErrorToast("Failed to generate podcast: " + response.statusText)

--- a/apps/web/src/lib/toast.ts
+++ b/apps/web/src/lib/toast.ts
@@ -8,6 +8,10 @@ export const showErrorToast = (message: string) => {
   toast.error(message)
 }
 
+export const showWarningToast = (message: string) => {
+  toast.warning(message)
+}
+
 export const showLoadingToast = (message: string): string | number => {
   return toast.loading(message)
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -330,3 +330,8 @@ first compile); fresh CI venvs recompile. Clear __pycache__ to reproduce compile
   assertions to the test's own tenant/keys, never assert global table
   emptiness/equality — any concurrent writer to the shared dev DB (demo
   agents, second pytest session) breaks them.
+
+## Mutation checks vs uncommitted work (2026-07-12, #378)
+`git checkout <file>` to revert a test mutation also wipes any uncommitted edits in that file.
+When running mutation sanity checks, either commit pending work first or revert the mutation by
+re-applying the exact inverse edit — never a whole-file checkout.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,83 +1,57 @@
-# Issue #316 — Distribution, RSS feed, and analytics frontend surface
+# Issue #378 — [P4.3.1] First Spotify/Apple distribution fails until the project RSS feed is generated
 
-Status: SHIPPED — merged 2026-07-12 as 9e87b32 via PR #380; issue #316 closed; follow-up #381 filed (metadata clear semantics).
+Status: IN PROGRESS. Plan source: self-authored (no plan on the issue).
 
-Plan source: CodeRabbit comment (adapted). Branch: `feature/issue-316-distribution-analytics-frontend` (deleted).
+## Design decision (autonomous — no architectural fork)
 
-## Key adaptations vs the CodeRabbit plan
+The issue offers Option 1 (auto-generate the feed before distribution; flagged as expensive because
+the Celery task is sync and `RSSGenerationService` is async) and Option 2 (pre-flight check/warn,
+recommended as cheaper). Key finding: the sync-bridge cost only exists inside the Celery task — the
+**generation router** (`apps/api/src/routers/generation.py`) is async and already resolves active
+distribution targets before dispatch. So the cheap path is a router pre-flight that:
 
-- **RSS-first framing (post-#379)**: all connect endpoints are live/ungated, but episode distribution
-  to Spotify/Apple defaults to the RSS-feed model (`ENABLE_DIRECT_PLATFORM_PUBLISH=False`). UI presents
-  Spotify/Apple as "platforms ingest your RSS feed"; RSS feed generation is the prerequisite
-  (422 if `show_title`/`author`/`description` missing from project metadata; 404 on GET = never generated).
-- **Spotify OAuth**: `POST /distribution-targets/spotify/authorize` returns JSON `{authorize_url, state}`;
-  client does `window.location.href = authorize_url` (proxy strips cross-origin redirects — cannot rely on it).
-- **Types**: inline types per page (repo convention); one shared module only for the distribution-target
-  shape (`src/lib/types/distribution.ts`) since it's reused by the page + 3 dialogs. No analytics/rss type modules.
-- **Envelopes**: distribution list = `{targets, total, page, page_size, total_pages}`; analytics + RSS = bare objects.
-  Project rows use `name` (API) → `title` (view-model) mapping per #337/#340 convention.
-- **Middleware**: add `'/distribution'` to `PROTECTED_PATHS` in `src/middleware.ts`. No CSP changes needed.
-- **No tabs/table/chart primitives exist** — sub-nav is a simple link strip; weekly trend is a simple bar list.
-- **Jest**: every new hugeicon must be added to `__mocks__/@hugeicons/core-free-icons.ts`; 80% coverage
-  enforced on all four metrics — every new page needs full branch tests (ok / non-ok / reject / empty / mutations).
+1. **Auto-generates** the feed when possible (project metadata valid) — one awaited service call,
+   no new infrastructure. Feed with zero complete episodes is valid RSS.
+2. **Skips Spotify/Apple + returns a clear warning** when auto-generation is impossible (missing
+   `show_title`/`author`/`description` → `ValueError`) or errors (S3 down) — mirroring the existing
+   graceful-skip precedents (no S3 bucket, no active targets), instead of a guaranteed
+   `distribution_failed`.
+
+This satisfies both halves of the acceptance criterion ("no guaranteed first-attempt failure, OR
+clearly told beforehand").
 
 ## Steps
 
-1. **Foundation (nav + middleware + shared types + icon mocks)** — done first, on the branch directly.
-   - `src/components/navigation/MainNav.tsx`: add Dashboard + Distribution links (HugeiconsIcon, token classes).
-   - `src/middleware.ts`: `PROTECTED_PATHS` += `'/distribution'`.
-   - `src/lib/types/distribution.ts`: `DistributionTarget` response shape + list envelope.
-   - `__mocks__/@hugeicons/core-free-icons.ts`: pre-add ALL icons used by later steps (avoids parallel conflicts).
-   - Tests: `__tests__/components/navigation/MainNav.test.tsx` additions; middleware test if one exists.
+1. **Backend pre-flight (TDD)** — `apps/api/src/routers/generation.py`
+   - After the `platforms` dict is built: if `spotify`/`apple_podcasts` present and
+     `not settings.ENABLE_DIRECT_PLATFORM_PUBLISH`, check `RSSGenerationService.get_rss_feed()`.
+   - No feed / no `public_url` → `await generate_rss_for_project(db, project_id, user.id)`.
+   - On any exception: log warning, drop spotify/apple from `platforms`, collect a warning string.
+   - Response: additive `warnings: [...]` key (only when non-empty) on the 202 payload.
+   - Tests: `apps/api/tests/test_distribution_wiring.py` (existing file covers router→platforms
+     wiring): (a) no feed + valid metadata → feed auto-created, spotify kept, no warnings;
+     (b) no feed + missing metadata → spotify dropped, warning returned, still 202;
+     (c) feed exists → no regeneration; (d) webhook-only → no pre-flight;
+     (e) `ENABLE_DIRECT_PLATFORM_PUBLISH=True` → no pre-flight.
 
-2. **Global /distribution page + connect dialogs** (parallel agent A)
-   - `src/app/(auth)/distribution/page.tsx`: three-branch render; list targets from
-     `GET /api/proxy/distribution-targets`; Cards with platform_name, target_type, is_active Badge,
-     token_valid/token_expires_at for Spotify; actions: test (`POST .../{id}/test`), toggle
-     (`PUT .../{id}` `{is_active}`), refresh token (`POST .../{id}/refresh-token`, Spotify only),
-     delete (ConfirmDeleteDialog → `DELETE .../{id}`). OAuth return query params (`success`/`error`) → toast + refetch.
-   - Dialogs in `src/components/dialogs/`: SpotifyConnectDialog (authorize → window.location),
-     AppleConnectDialog (authorize instructions → show_id+api_key form), WebhookConnectDialog
-     (name + https URL + method/headers). Zod schemas in `src/lib/validation.ts` (apple, webhook).
-   - RSS-model note in the UI: connecting Spotify/Apple records distribution; episodes reach platforms via the project RSS feed.
-   - Skeleton `src/components/skeletons/DistributionSkeleton.tsx`; EmptyState CTA.
-   - Tests: page + dialogs + validation schema cases.
+2. **Frontend warning surface (TDD)** — `apps/web/src/app/(auth)/episodes/[id]/page.tsx`
+   - Generate handler (~line 482): if the 202 response has `warnings`, show them (toast/notice).
+   - Test: extend `apps/web/__tests__` episode page test with a warnings-response case.
 
-3. **Project RSS feed page** (parallel agent B)
-   - `src/app/(auth)/projects/[id]/distribution/page.tsx`: `GET /api/proxy/projects/{id}/rss-feed`;
-     404 → EmptyState with Generate CTA; show public_url + copy button, last_generated,
-     validation_status; Generate/Regenerate → `POST .../rss-feed/generate` (422 → error toast telling
-     user which metadata field is missing); EditPodcastMetadataDialog → `PUT .../rss-feed`
-     with `{podcast_metadata: {...}}` (show_title, author, description, category, language, explicit,
-     copyright, artwork_url, website_url). Zod schema `podcastMetadataSchema`.
-   - Tests: page + dialog.
+3. **Follow-up issue** — the RSS feed is never regenerated when an episode completes, so
+   Spotify/Apple never see new episodes until a manual regenerate. Out of scope here; file as
+   `[P4.3.2]`.
 
-4. **Project analytics page + project sub-nav** (parallel agent C)
-   - `src/app/(auth)/projects/[id]/analytics/page.tsx`: `GET /api/proxy/projects/{id}/analytics?days=N`
-     (Select for 7/30/90); summary cards (total_downloads, total_plays, total_listen_hours);
-     weekly trend bar-list from `trends.weekly_downloads[{week,downloads}]`; top_episodes list.
-   - Sub-nav link strip on `src/app/(auth)/projects/[id]/page.tsx` → Analytics + Distribution (RSS).
-   - Skeleton `src/components/skeletons/AnalyticsSkeleton.tsx`.
-   - Tests: page + projects page nav additions.
+## Acceptance criteria
 
-5. **Episode analytics section + event tracking** (parallel agent D)
-   - `src/app/(auth)/episodes/[id]/page.tsx`: analytics Card from `GET /api/proxy/analytics/episodes/{id}`
-     (metrics, device_breakdown, app_breakdown, top_countries); contained loading + zero-state.
-   - `onPlay` on the native `<audio>` → best-effort `POST /api/proxy/analytics/events`
-     `{event_type:"play", episode_id, project_id}` (fire-and-forget, swallow errors, fire once per mount).
-   - DownloadButton: `onDownloaded?` callback prop; page fires `event_type:"download"`.
-   - Tests: episode page + DownloadButton updates.
+- [ ] Project with valid podcast metadata: adding a Spotify/Apple target + generating an episode
+      does NOT produce a first-attempt `distribution_failed` (feed auto-generated at kickoff).
+- [ ] Project without metadata: user is clearly told (API warning surfaced in UI; platforms
+      skipped, episode generation still proceeds).
+- [ ] Existing feed / webhook-only / direct-publish-flag paths unchanged.
 
-6. **Integration**: merge worktree branches, full suite (`npm run test:web`), lint, typecheck, coverage.
+## Known limitations (by design, noted for PR)
 
-## Acceptance criteria (from issue)
-
-- [x] Launch scope confirmed → in scope, build it (CodeRabbit Design Choice 1; #379 settled the model).
-- [x] Distribution page + nav entry exist and work against the live backend contract (demoed live).
-- [x] RSS feed management surface exists (project-scoped; feed generated to real S3 in demo).
-- [x] Analytics pages/sections exist (project + episode; demoed with real aggregated events).
-- [x] No launch-messaging change needed (feature is now real).
-
-Post-review fixes shipped on the branch: Spotify callback 302-redirects to the app (was bare
-JSON), array-form 422 details surfaced, S3 ACL dropped (ACL-disabled bucket), Apple dialog
-message/setup-link fix, play-event guard reset on episode navigation, ui/progress value forward.
+- The warning is returned in the API response and shown as a toast; it is not persisted in
+  `generation_progress` (that dict is overwritten at dispatch and managed by worker callbacks).
+- Feed staleness (new episode not in the feed) is pre-existing and tracked by the follow-up issue.


### PR DESCRIPTION
## Summary
Implements #378: first Spotify/Apple distribution no longer fails permanently just because the project's RSS feed was never generated.

- **Backend** (`apps/api/src/routers/generation.py`): after the `platforms` mapping is built, if Spotify/Apple targets are active under the RSS-feed model (`ENABLE_DIRECT_PLATFORM_PUBLISH=False`) and the project has no `RSSFeed.public_url`, the router **auto-generates the feed** before dispatch (the router is async, so this is one awaited `RSSGenerationService` call — no sync-bridge into Celery needed). If generation is impossible (missing podcast metadata → `ValueError`) or errors, those platforms are **skipped with an actionable `warnings` entry** on the 202 response instead of dispatching a guaranteed `distribution_failed`. The whole pre-flight is non-fatal to generation kickoff.
- **Frontend** (`apps/web/src/app/(auth)/episodes/[id]/page.tsx`, `src/lib/toast.ts`): `warnings` from the generate response surface as warning toasts (`showWarningToast`, new sonner wrapper).
- `ValueError` messages (user-actionable validation, same contract as the RSS router's 422) are shown verbatim; any other failure is masked as generic so infrastructure details never leak.

## Acceptance Criteria
- [x] A user who adds a Spotify/Apple target and generates an episode does not hit a guaranteed first-attempt `distribution_failed`: with valid podcast metadata the feed is auto-generated pre-dispatch.
- [x] Otherwise the user is clearly told: platforms skipped + human-readable warning ("Skipped Spotify and Apple Podcasts distribution: … set the podcast metadata and generate the feed …") returned on the 202 and shown as a toast; episode generation still proceeds.
- [x] Existing-feed, stale-feed-row (`public_url=NULL`), webhook-only, and `ENABLE_DIRECT_PLATFORM_PUBLISH` paths covered by tests; webhook/direct paths unchanged.

## Test Plan
- [x] TDD: all 8 new backend tests (`tests/test_distribution_wiring.py`) + 2 frontend tests written RED-first or mutation-verified
- [x] Full suites green: backend 1792 passed / 7 skipped; frontend 490 passed
- [x] Diff coverage 100% on changed lines, both apps (gate ≥85%)
- [x] Lint clean (ruff, ESLint) + `tsc --noEmit` clean
- [x] Internal review (advisory): no Critical/Major findings
- [x] Cross-family review pass: **opencode (GLM)** — verdict APPROVE; its suggestions (stale-row test, combined-platform warning test, human-readable platform names, non-fatal feed lookup) applied
- [x] Mutation sanity checks: direct-publish gate, internal-error redaction, and stale-row branch each fail their test when mutated

## Known Limitations / Intentionally Deferred
- **Stale-feed interplay (explicit, per review)**: a feed row with a `public_url` short-circuits the pre-flight by design ("existing feed unchanged"), so RSS-model distributions reference the feed as-is; combined with the point below, a new episode does not appear on the platforms until feed regeneration on completion lands (#382).
- **Feed staleness**: the feed is not regenerated when an episode completes, so an auto-generated first feed contains zero items and platforms won't see new episodes until a manual regenerate — pre-existing gap, tracked in #382 (P4.3.2).
- **Web UI can't trigger distribution yet**: the episode page never passes `enable_distribution=true`, so this path is currently reachable only via direct API calls; the warning toast is wired for when #383 (P4.3.3) lands.
- **Pre-flight latency**: auto-generation performs an S3 upload inline in the 202 request path (one-time per project); no timeout/circuit-breaker added — acceptable for now, revisit if kickoff latency alerts.
- Warnings are response-only (toast), not persisted in `generation_progress` (that dict is overwritten at dispatch and owned by worker callbacks).

## Implementation Notes
Plan was self-authored (no plan on the issue). The issue framed Option 1 (auto-generate, "expensive sync-bridge") vs Option 2 (pre-flight warn); the key finding is that the sync-bridge cost only applies inside the Celery task — the generation router is async, so this PR takes the cheap union of both options. See `tasks/todo.md` for the full plan.

Closes #378
