### PR TITLE
Regenerate the project RSS feed when an episode completes (#382)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -74,7 +74,7 @@ jobs:
         env:
           DATABASE_URL: postgresql+asyncpg://podcastfy:podcastfy_password@localhost:5432/podcastfy
           ENCRYPTION_KEY: test-encryption-key-for-ci-00000
-          JWT_SECRET_KEY: test-jwt-secret-for-ci
+          JWT_SECRET_KEY: test-jwt-secret-for-ci-0000000000
         run: uv run alembic upgrade head
 
       - name: Run API tests
@@ -84,7 +84,7 @@ jobs:
           DATABASE_URL: postgresql+asyncpg://podcastfy:podcastfy_password@localhost:5432/podcastfy
           SECRET_KEY: test-secret-key-for-ci
           ENCRYPTION_KEY: test-encryption-key-for-ci-00000
-          JWT_SECRET_KEY: test-jwt-secret-for-ci
+          JWT_SECRET_KEY: test-jwt-secret-for-ci-0000000000
           CELERY_BROKER_URL: redis://localhost:6379/0
           CELERY_RESULT_BACKEND: redis://localhost:6379/0
         run: |

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -148,7 +148,7 @@ jobs:
           DATABASE_URL: postgresql+asyncpg://podcastfy_app:postgres@localhost:5432/podcastfy
           MIGRATION_DATABASE_URL: postgresql+asyncpg://podcastfy_user:postgres@localhost:5432/podcastfy
           ENCRYPTION_KEY: test-encryption-key-for-ci-00000
-          JWT_SECRET_KEY: test-jwt-secret-for-ci
+          JWT_SECRET_KEY: test-jwt-secret-for-ci-0000000000
         run: |
           uv sync
           uv run alembic upgrade head
@@ -180,7 +180,7 @@ jobs:
           ENVIRONMENT: development
           DATABASE_URL: postgresql+asyncpg://podcastfy_app:postgres@localhost:5432/podcastfy
           ENCRYPTION_KEY: test-encryption-key-for-ci-00000
-          JWT_SECRET_KEY: test-jwt-secret-for-ci
+          JWT_SECRET_KEY: test-jwt-secret-for-ci-0000000000
           CELERY_BROKER_URL: redis://localhost:6379/0
           CELERY_RESULT_BACKEND: redis://localhost:6379/0
           CORS_ORIGINS: '["http://localhost:3200"]'

--- a/apps/api/src/database.py
+++ b/apps/api/src/database.py
@@ -83,9 +83,15 @@ async def celery_async_session() -> AsyncGenerator[AsyncSession, None]:
     setup cost is irrelevant. Do NOT use this in request handlers — they have
     a live loop and must use ``AsyncSessionLocal``.
     """
-    task_engine = create_async_engine(settings.DATABASE_URL, poolclass=NullPool)
+    task_engine = create_async_engine(
+        settings.DATABASE_URL,
+        echo=settings.DEBUG,
+        poolclass=NullPool,
+    )
     try:
-        async with AsyncSession(task_engine, expire_on_commit=False) as session:
+        async with AsyncSession(
+            task_engine, expire_on_commit=False, autoflush=False
+        ) as session:
             yield session
     finally:
         await task_engine.dispose()

--- a/apps/api/src/database.py
+++ b/apps/api/src/database.py
@@ -1,8 +1,10 @@
 """
 Async database configuration and session management
 """
+from contextlib import asynccontextmanager
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.pool import NullPool
 from sqlalchemy import create_engine, text
 from typing import AsyncGenerator
 from fastapi import Request
@@ -64,6 +66,29 @@ def SyncSessionLocal():
             autoflush=False,
         )
     return _sync_session_factory()
+
+
+@asynccontextmanager
+async def celery_async_session() -> AsyncGenerator[AsyncSession, None]:
+    """
+    Async session for Celery's asyncio.run() bridges — one throwaway engine per call.
+
+    ``asyncio.run()`` destroys its event loop on return, but connections checked
+    back into the shared ``engine`` pool stay bound to that dead loop: the next
+    checkout from a later ``asyncio.run()`` in the same worker process raises
+    "got Future attached to a different loop" (empirically: every other call
+    fails). A per-call NullPool engine never shares connections across loops.
+
+    Celery prefork children run one task at a time, so the per-call connection
+    setup cost is irrelevant. Do NOT use this in request handlers — they have
+    a live loop and must use ``AsyncSessionLocal``.
+    """
+    task_engine = create_async_engine(settings.DATABASE_URL, poolclass=NullPool)
+    try:
+        async with AsyncSession(task_engine, expire_on_commit=False) as session:
+            yield session
+    finally:
+        await task_engine.dispose()
 
 
 # Base class for SQLAlchemy models

--- a/apps/api/src/tasks/callbacks.py
+++ b/apps/api/src/tasks/callbacks.py
@@ -17,6 +17,7 @@ from src.database import SyncSessionLocal
 from src.models.episode import Episode
 from src.models.storage_deletion_outbox import StorageDeletionOutbox
 from src.tasks.retry_utils import calculate_backoff
+from src.tasks.rss_refresh import refresh_project_rss_feed
 from src.tasks.s3_upload import _cleanup_temp_file
 from src.worker import celery_app
 
@@ -384,6 +385,9 @@ def on_workflow_complete(self: Task, result: Dict[str, Any], episode_id: str) ->
 			current_progress["completed_at"] = completed_at
 			episode.generation_progress = current_progress
 
+			project_id = episode.project_id
+			owner_id = episode.user_id
+
 			db.commit()
 
 		if failed_platforms:
@@ -394,6 +398,10 @@ def on_workflow_complete(self: Task, result: Dict[str, Any], episode_id: str) ->
 			)
 		else:
 			logger.info("Episode %s workflow completed successfully", episode_id)
+			# The feed on S3 predates this episode; refresh it so RSS-model
+			# platforms (Spotify/Apple) pick the episode up (issue #382).
+			# Best-effort: never fails the already-committed completion.
+			refresh_project_rss_feed(project_id, owner_id)
 	except Exception as exc:
 		logger.error(
 			"Failed to finalize episode %s: %s", episode_id, exc, exc_info=True

--- a/apps/api/src/tasks/callbacks.py
+++ b/apps/api/src/tasks/callbacks.py
@@ -400,8 +400,16 @@ def on_workflow_complete(self: Task, result: Dict[str, Any], episode_id: str) ->
 			logger.info("Episode %s workflow completed successfully", episode_id)
 			# The feed on S3 predates this episode; refresh it so RSS-model
 			# platforms (Spotify/Apple) pick the episode up (issue #382).
-			# Best-effort: never fails the already-committed completion.
-			refresh_project_rss_feed(project_id, owner_id)
+			# Best-effort, and guarded locally: the outer except would log a
+			# misleading "Failed to finalize" for an episode that committed.
+			try:
+				refresh_project_rss_feed(project_id, owner_id)
+			except Exception as rss_exc:
+				logger.error(
+					"RSS refresh after completing episode %s failed: %s",
+					episode_id,
+					rss_exc,
+				)
 	except Exception as exc:
 		logger.error(
 			"Failed to finalize episode %s: %s", episode_id, exc, exc_info=True

--- a/apps/api/src/tasks/content_extraction.py
+++ b/apps/api/src/tasks/content_extraction.py
@@ -29,8 +29,9 @@ async def _extract_content_async(
 	"""
 	Async helper that runs the ContentExtractionService.
 
-	Uses AsyncSessionLocal to create an async database session compatible
-	with the service's async interface.
+	Uses celery_async_session to create an async database session compatible
+	with the service's async interface (per-call engine — the shared pool
+	cannot be reused across asyncio.run() event loops).
 
 	Args:
 		content_source_id: UUID string of the content source to extract
@@ -43,13 +44,13 @@ async def _extract_content_async(
 		ValueError: If content source not found or type mismatch
 		Exception: On extraction errors (caller handles retry)
 	"""
-	from src.database import AsyncSessionLocal
+	from src.database import celery_async_session
 	from src.services.content_extraction_service import ContentExtractionService
 
 	service = ContentExtractionService()
 	content_uuid = uuid_module.UUID(content_source_id)
 
-	async with AsyncSessionLocal() as db:
+	async with celery_async_session() as db:
 		if source_type == 'url':
 			result = await service.extract_from_url(db, content_uuid)
 		elif source_type == 'pdf':

--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -821,8 +821,15 @@ def finalize_episode_generation_task(
 
             # The feed on S3 predates this episode; refresh it so RSS-model
             # platforms (Spotify/Apple) pick the episode up (issue #382).
-            # Best-effort: never fails the already-committed completion.
-            refresh_project_rss_feed(episode.project_id, episode.user_id)
+            # Best-effort, and guarded locally: the surrounding except calls
+            # self.retry, and a feed problem must never re-run finalization
+            # of an already-committed completion.
+            try:
+                refresh_project_rss_feed(episode.project_id, episode.user_id)
+            except Exception as rss_exc:
+                logger.error(
+                    f"RSS refresh after finalizing episode {episode_id} failed: {rss_exc}"
+                )
 
             return {
                 "status": "success",

--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -22,6 +22,7 @@ from src.models.audio_snippet import AudioSnippet
 from src.models.episode import Episode
 from src.tasks.callbacks import _update_episode, _utcnow_iso, _queue_orphaned_storage
 from src.tasks.idempotency import acquire_generation_lock, release_generation_lock
+from src.tasks.rss_refresh import refresh_project_rss_feed
 from src.tasks.s3_upload import (
     GENERATION_RUN_DIR_PREFIX,
     _cleanup_temp_file,
@@ -817,6 +818,12 @@ def finalize_episode_generation_task(
                 }
 
             logger.info(f"Episode {episode_id} finalized successfully")
+
+            # The feed on S3 predates this episode; refresh it so RSS-model
+            # platforms (Spotify/Apple) pick the episode up (issue #382).
+            # Best-effort: never fails the already-committed completion.
+            refresh_project_rss_feed(episode.project_id, episode.user_id)
+
             return {
                 "status": "success",
                 "episode_id": episode_id,

--- a/apps/api/src/tasks/rss_refresh.py
+++ b/apps/api/src/tasks/rss_refresh.py
@@ -10,8 +10,10 @@ model) would never see the new episode. Both episode-completion sites
 
 The refresh is deliberately best-effort: it never raises, so a feed problem
 (incomplete podcast metadata, S3 outage) can never fail an episode that has
-already completed. It is also idempotent — the service does a single upsert
-per project — so concurrent completions in one project are safe.
+already completed. The service does a single upsert per project, so concurrent
+completions can't duplicate rows — but the S3 write is last-write-wins, so a
+racing pair may briefly publish a feed missing the newest episode. Eventually
+consistent: the next completion (or a manual regenerate) heals it.
 """
 import asyncio
 import logging

--- a/apps/api/src/tasks/rss_refresh.py
+++ b/apps/api/src/tasks/rss_refresh.py
@@ -17,7 +17,7 @@ import asyncio
 import logging
 from uuid import UUID
 
-from src.database import AsyncSessionLocal
+from src.database import celery_async_session
 from src.services.rss_generation_service import RSSGenerationService
 
 logger = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ def refresh_project_rss_feed(project_id, user_id) -> bool:
 
 async def _refresh_async(project_id: UUID, user_id: UUID) -> bool:
     service = RSSGenerationService()
-    async with AsyncSessionLocal() as db:
+    async with celery_async_session() as db:
         # Celery sessions don't arm the tenant GUC; like the other task-side
         # queries, isolation comes from the explicit project_id filter.
         feed = await service.get_rss_feed(db, project_id)

--- a/apps/api/src/tasks/rss_refresh.py
+++ b/apps/api/src/tasks/rss_refresh.py
@@ -1,0 +1,70 @@
+"""
+Post-completion RSS feed refresh (issue #382).
+
+When an episode reaches ``complete``, the project's RSS feed XML on S3 is
+stale — platforms consuming it (Spotify/Apple under the RSS-feed distribution
+model) would never see the new episode. Both episode-completion sites
+(``on_workflow_complete`` for the workflow chain, and
+``finalize_episode_generation_task`` for the no-chain path) call
+``refresh_project_rss_feed`` to regenerate it.
+
+The refresh is deliberately best-effort: it never raises, so a feed problem
+(incomplete podcast metadata, S3 outage) can never fail an episode that has
+already completed. It is also idempotent — the service does a single upsert
+per project — so concurrent completions in one project are safe.
+"""
+import asyncio
+import logging
+from uuid import UUID
+
+from src.database import AsyncSessionLocal
+from src.services.rss_generation_service import RSSGenerationService
+
+logger = logging.getLogger(__name__)
+
+
+def refresh_project_rss_feed(project_id, user_id) -> bool:
+    """
+    Regenerate the project's RSS feed if one has already been generated.
+
+    Skips projects with no RSSFeed row: no platform consumes their feed yet
+    (the #378 distribution pre-flight creates it when distribution starts).
+
+    Args:
+        project_id: Project UUID (or string form, as Celery tasks hold).
+        user_id: Owning user's UUID, for the service's access check.
+
+    Returns:
+        True if the feed was regenerated, False if skipped or failed.
+        Never raises.
+    """
+    try:
+        # Normalize before any IO so garbage input can never reach the DB.
+        project_uuid = UUID(str(project_id))
+        user_uuid = UUID(str(user_id))
+        return asyncio.run(_refresh_async(project_uuid, user_uuid))
+    except Exception as exc:
+        logger.error(
+            "RSS feed refresh failed for project %s: %s",
+            project_id,
+            exc,
+            exc_info=True,
+        )
+        return False
+
+
+async def _refresh_async(project_id: UUID, user_id: UUID) -> bool:
+    service = RSSGenerationService()
+    async with AsyncSessionLocal() as db:
+        # Celery sessions don't arm the tenant GUC; like the other task-side
+        # queries, isolation comes from the explicit project_id filter.
+        feed = await service.get_rss_feed(db, project_id)
+        if feed is None:
+            logger.info(
+                "Project %s has no RSS feed yet; skipping post-completion refresh",
+                project_id,
+            )
+            return False
+        await service.generate_rss_for_project(db, project_id, user_id)
+    logger.info("RSS feed refreshed for project %s after episode completion", project_id)
+    return True

--- a/apps/api/tests/test_celery_async_session.py
+++ b/apps/api/tests/test_celery_async_session.py
@@ -1,0 +1,26 @@
+"""
+Regression test for the Celery sync→async DB bridge (issue #382 review).
+
+Celery tasks run async services via ``asyncio.run()``, which destroys its
+event loop on return. With the shared pooled engine, a connection checked
+back into the pool stays bound to that dead loop and the next ``asyncio.run()``
+in the same worker process fails on checkout with "got Future attached to a
+different loop" (empirically: every other call). ``celery_async_session``
+must therefore survive arbitrarily many sequential event loops.
+"""
+import asyncio
+
+from sqlalchemy import text
+
+from src.database import celery_async_session
+
+
+def test_celery_async_session_survives_sequential_event_loops():
+    """Three asyncio.run() calls in one process must all reach the DB."""
+
+    async def query() -> int:
+        async with celery_async_session() as db:
+            result = await db.execute(text("SELECT 1"))
+            return result.scalar()
+
+    assert [asyncio.run(query()) for _ in range(3)] == [1, 1, 1]

--- a/apps/api/tests/test_s3_upload.py
+++ b/apps/api/tests/test_s3_upload.py
@@ -610,6 +610,76 @@ class TestFinalizeEpisodeGenerationTask:
         assert result["status"] == "failed"
         mock_queue.assert_not_called()
 
+    def test_refreshes_rss_feed_on_complete(self, tmp_path):
+        """Finalize path (no chain) must also refresh the RSS feed (issue #382)."""
+        episode_id = str(uuid.uuid4())
+        episode = _make_mock_episode(episode_id)
+        episode.project_id = uuid.uuid4()
+        src_audio = tmp_path / "episode-abc.mp3"
+        src_audio.write_bytes(b"FAKE_MP3")
+        generation_result = self._make_generation_result(audio_file_path=str(src_audio))
+        mock_db = self._make_db_context_manager(episode)
+
+        with (
+            patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=mock_db),
+            patch("src.tasks.podcast_generation.settings") as mock_settings,
+            patch("src.tasks.podcast_generation.refresh_project_rss_feed") as mock_refresh,
+        ):
+            mock_settings.AWS_S3_BUCKET = None
+            mock_settings.LOCAL_AUDIO_STORAGE_PATH = str(tmp_path / "audio")
+            result = self._invoke_finalize(episode_id, generation_result, mock_db)
+
+        assert result["status"] == "success"
+        assert episode.generation_status == "complete"
+        mock_refresh.assert_called_once_with(episode.project_id, episode.user_id)
+
+    def test_no_rss_refresh_when_generation_failed(self):
+        """A failed generation never touches the feed (issue #382)."""
+        episode_id = str(uuid.uuid4())
+        episode = _make_mock_episode(episode_id)
+        generation_result = self._make_generation_result(
+            status="failed", error="TTS exploded"
+        )
+        mock_db = self._make_db_context_manager(episode)
+
+        with (
+            patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=mock_db),
+            patch("src.tasks.podcast_generation.settings") as mock_settings,
+            patch("src.tasks.podcast_generation.refresh_project_rss_feed") as mock_refresh,
+        ):
+            mock_settings.AWS_S3_BUCKET = None
+            result = self._invoke_finalize(episode_id, generation_result, mock_db)
+
+        assert result["status"] == "failed"
+        mock_refresh.assert_not_called()
+
+    def test_no_rss_refresh_when_episode_absorbed(self, tmp_path):
+        """The deleted-mid-finalization absorb branch must not refresh (issue #382)."""
+        episode_id = str(uuid.uuid4())
+        episode = _make_mock_episode(episode_id)
+        src_audio = tmp_path / "episode-abc.mp3"
+        src_audio.write_bytes(b"FAKE_MP3")
+        generation_result = self._make_generation_result(audio_file_path=str(src_audio))
+
+        mock_db = MagicMock()
+        mock_db.get.side_effect = [episode, None]
+        mock_db.__enter__ = MagicMock(return_value=mock_db)
+        mock_db.__exit__ = MagicMock(return_value=False)
+        mock_db.commit.side_effect = StaleDataError("stale", 1, 0)
+
+        with (
+            patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=mock_db),
+            patch("src.tasks.podcast_generation.settings") as mock_settings,
+            patch("src.tasks.podcast_generation._queue_orphaned_storage"),
+            patch("src.tasks.podcast_generation.refresh_project_rss_feed") as mock_refresh,
+        ):
+            mock_settings.AWS_S3_BUCKET = None
+            mock_settings.LOCAL_AUDIO_STORAGE_PATH = str(tmp_path / "audio")
+            result = self._invoke_finalize(episode_id, generation_result, mock_db)
+
+        assert result["status"] == "absorbed"
+        mock_refresh.assert_not_called()
+
 
 # ============================================================================
 # generate_podcast_task chains finalize task

--- a/apps/api/tests/test_s3_upload.py
+++ b/apps/api/tests/test_s3_upload.py
@@ -633,6 +633,35 @@ class TestFinalizeEpisodeGenerationTask:
         assert episode.generation_status == "complete"
         mock_refresh.assert_called_once_with(episode.project_id, episode.user_id)
 
+    def test_rss_refresh_error_does_not_retry_finalization(self, tmp_path):
+        """A refresh blow-up must not trigger self.retry on an episode that
+        already completed (issue #382): the surrounding except calls retry."""
+        from src.tasks.podcast_generation import finalize_episode_generation_task
+
+        episode_id = str(uuid.uuid4())
+        episode = _make_mock_episode(episode_id)
+        src_audio = tmp_path / "episode-abc.mp3"
+        src_audio.write_bytes(b"FAKE_MP3")
+        generation_result = self._make_generation_result(audio_file_path=str(src_audio))
+        mock_db = self._make_db_context_manager(episode)
+
+        with (
+            patch("src.tasks.podcast_generation.SyncSessionLocal", return_value=mock_db),
+            patch("src.tasks.podcast_generation.settings") as mock_settings,
+            patch(
+                "src.tasks.podcast_generation.refresh_project_rss_feed",
+                side_effect=RuntimeError("S3 unreachable"),
+            ),
+            patch.object(finalize_episode_generation_task, "retry") as mock_retry,
+        ):
+            mock_settings.AWS_S3_BUCKET = None
+            mock_settings.LOCAL_AUDIO_STORAGE_PATH = str(tmp_path / "audio")
+            result = self._invoke_finalize(episode_id, generation_result, mock_db)
+
+        assert result["status"] == "success"
+        assert episode.generation_status == "complete"
+        mock_retry.assert_not_called()
+
     def test_no_rss_refresh_when_generation_failed(self):
         """A failed generation never touches the feed (issue #382)."""
         episode_id = str(uuid.uuid4())

--- a/apps/api/tests/unit/test_celery_callbacks.py
+++ b/apps/api/tests/unit/test_celery_callbacks.py
@@ -10,6 +10,16 @@ All database interactions are mocked so no real database is required.
 import uuid
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_rss_refresh():
+	"""Keep the post-completion RSS refresh (issue #382) out of callback tests."""
+	with patch("src.tasks.callbacks.refresh_project_rss_feed") as mock:
+		mock.return_value = True
+		yield mock
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -19,6 +29,8 @@ def _mock_episode(episode_id: str) -> MagicMock:
 	"""Return a MagicMock that behaves like an Episode ORM object."""
 	ep = MagicMock()
 	ep.id = uuid.UUID(episode_id)
+	ep.project_id = uuid.uuid4()
+	ep.user_id = uuid.uuid4()
 	ep.generation_status = "generating"
 	ep.generation_progress = {}
 	ep.s3_url = None
@@ -466,6 +478,62 @@ class TestOnWorkflowComplete:
 			_invoke_task(on_workflow_complete, result={}, episode_id=episode_id)
 
 		mock_session.commit.assert_not_called()
+
+	def test_refreshes_rss_feed_on_complete(self, mock_rss_refresh):
+		"""A fully successful workflow triggers an RSS feed refresh (issue #382)."""
+		episode_id = str(uuid.uuid4())
+		episode = _mock_episode(episode_id)
+		mock_ctx, _ = _make_sync_session(episode)
+
+		from src.tasks.callbacks import on_workflow_complete
+
+		with patch("src.tasks.callbacks.SyncSessionLocal", return_value=mock_ctx):
+			_invoke_task(on_workflow_complete, result={}, episode_id=episode_id)
+
+		mock_rss_refresh.assert_called_once_with(episode.project_id, episode.user_id)
+
+	def test_no_rss_refresh_when_distribution_failed(self, mock_rss_refresh):
+		"""distribution_failed episodes are not 'complete', so no refresh (issue #382)."""
+		episode_id = str(uuid.uuid4())
+		episode = _mock_episode(episode_id)
+		episode.generation_progress = {
+			"distribution": {"spotify": {"status": "failed", "error": "auth failed"}}
+		}
+		mock_ctx, _ = _make_sync_session(episode)
+
+		from src.tasks.callbacks import on_workflow_complete
+
+		with patch("src.tasks.callbacks.SyncSessionLocal", return_value=mock_ctx):
+			_invoke_task(on_workflow_complete, result={}, episode_id=episode_id)
+
+		mock_rss_refresh.assert_not_called()
+
+	def test_no_rss_refresh_when_episode_missing(self, mock_rss_refresh):
+		"""No episode row means nothing completed — no refresh (issue #382)."""
+		episode_id = str(uuid.uuid4())
+		mock_ctx, _ = _make_sync_session(None)
+
+		from src.tasks.callbacks import on_workflow_complete
+
+		with patch("src.tasks.callbacks.SyncSessionLocal", return_value=mock_ctx):
+			_invoke_task(on_workflow_complete, result={}, episode_id=episode_id)
+
+		mock_rss_refresh.assert_not_called()
+
+	def test_rss_refresh_failure_keeps_episode_complete(self, mock_rss_refresh):
+		"""A refresh blow-up must not raise or unset the committed status (issue #382)."""
+		episode_id = str(uuid.uuid4())
+		episode = _mock_episode(episode_id)
+		mock_ctx, mock_session = _make_sync_session(episode)
+		mock_rss_refresh.side_effect = RuntimeError("S3 unreachable")
+
+		from src.tasks.callbacks import on_workflow_complete
+
+		with patch("src.tasks.callbacks.SyncSessionLocal", return_value=mock_ctx):
+			_invoke_task(on_workflow_complete, result={}, episode_id=episode_id)
+
+		assert episode.generation_status == "complete"
+		mock_session.commit.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/unit/test_extract_content_async.py
+++ b/apps/api/tests/unit/test_extract_content_async.py
@@ -3,7 +3,7 @@ Unit tests for _extract_content_async helper in content_extraction task.
 
 The existing test_content_extraction_task.py tests the Celery task surface by
 mocking asyncio.run, so _extract_content_async (lines 46-62) is never called.
-These tests call _extract_content_async directly with a mocked AsyncSessionLocal
+These tests call _extract_content_async directly with a mocked celery_async_session
 and mocked ContentExtractionService to cover those lines.
 
 Tests cover:
@@ -54,7 +54,7 @@ async def test_extract_async_url_calls_extract_from_url():
 	mock_db = AsyncMock()
 	service_result = _make_service_result(success=True, word_count=150)
 
-	with patch("src.database.AsyncSessionLocal", return_value=_make_async_context_manager(mock_db)), \
+	with patch("src.database.celery_async_session", return_value=_make_async_context_manager(mock_db)), \
 	     patch("src.services.content_extraction_service.ContentExtractionService") as MockSvc:
 		mock_instance = AsyncMock()
 		mock_instance.extract_from_url.return_value = service_result
@@ -75,7 +75,7 @@ async def test_extract_async_pdf_calls_extract_from_pdf():
 	mock_db = AsyncMock()
 	service_result = _make_service_result(success=True, word_count=300)
 
-	with patch("src.database.AsyncSessionLocal", return_value=_make_async_context_manager(mock_db)), \
+	with patch("src.database.celery_async_session", return_value=_make_async_context_manager(mock_db)), \
 	     patch("src.services.content_extraction_service.ContentExtractionService") as MockSvc:
 		mock_instance = AsyncMock()
 		mock_instance.extract_from_pdf.return_value = service_result
@@ -95,7 +95,7 @@ async def test_extract_async_text_calls_extract_from_text():
 	mock_db = AsyncMock()
 	service_result = _make_service_result(success=False, word_count=0, error="Too short")
 
-	with patch("src.database.AsyncSessionLocal", return_value=_make_async_context_manager(mock_db)), \
+	with patch("src.database.celery_async_session", return_value=_make_async_context_manager(mock_db)), \
 	     patch("src.services.content_extraction_service.ContentExtractionService") as MockSvc:
 		mock_instance = AsyncMock()
 		mock_instance.extract_from_text.return_value = service_result
@@ -114,7 +114,7 @@ async def test_extract_async_unsupported_type_raises_value_error():
 
 	mock_db = AsyncMock()
 
-	with patch("src.database.AsyncSessionLocal", return_value=_make_async_context_manager(mock_db)), \
+	with patch("src.database.celery_async_session", return_value=_make_async_context_manager(mock_db)), \
 	     patch("src.services.content_extraction_service.ContentExtractionService"):
 		with pytest.raises(ValueError, match="Unsupported source type"):
 			await _extract_content_async(str(uuid4()), "video")

--- a/apps/api/tests/unit/test_rss_refresh.py
+++ b/apps/api/tests/unit/test_rss_refresh.py
@@ -37,7 +37,7 @@ class TestRefreshProjectRssFeed:
         service = _mock_service(feed=MagicMock())
 
         with (
-            patch("src.tasks.rss_refresh.AsyncSessionLocal", return_value=ctx),
+            patch("src.tasks.rss_refresh.celery_async_session", return_value=ctx),
             patch("src.tasks.rss_refresh.RSSGenerationService", return_value=service),
         ):
             assert refresh_project_rss_feed(project_id, user_id) is True
@@ -53,7 +53,7 @@ class TestRefreshProjectRssFeed:
         service = _mock_service(feed=None)
 
         with (
-            patch("src.tasks.rss_refresh.AsyncSessionLocal", return_value=ctx),
+            patch("src.tasks.rss_refresh.celery_async_session", return_value=ctx),
             patch("src.tasks.rss_refresh.RSSGenerationService", return_value=service),
         ):
             assert refresh_project_rss_feed(uuid.uuid4(), uuid.uuid4()) is False
@@ -69,7 +69,7 @@ class TestRefreshProjectRssFeed:
         )
 
         with (
-            patch("src.tasks.rss_refresh.AsyncSessionLocal", return_value=ctx),
+            patch("src.tasks.rss_refresh.celery_async_session", return_value=ctx),
             patch("src.tasks.rss_refresh.RSSGenerationService", return_value=service),
         ):
             assert refresh_project_rss_feed(uuid.uuid4(), uuid.uuid4()) is False
@@ -77,7 +77,7 @@ class TestRefreshProjectRssFeed:
     def test_swallows_session_errors(self):
         """Even a broken DB session must not raise out of the helper."""
         with patch(
-            "src.tasks.rss_refresh.AsyncSessionLocal",
+            "src.tasks.rss_refresh.celery_async_session",
             side_effect=RuntimeError("pool gone"),
         ):
             assert refresh_project_rss_feed(uuid.uuid4(), uuid.uuid4()) is False
@@ -90,7 +90,7 @@ class TestRefreshProjectRssFeed:
         service = _mock_service(feed=MagicMock())
 
         with (
-            patch("src.tasks.rss_refresh.AsyncSessionLocal", return_value=ctx),
+            patch("src.tasks.rss_refresh.celery_async_session", return_value=ctx),
             patch("src.tasks.rss_refresh.RSSGenerationService", return_value=service),
         ):
             assert refresh_project_rss_feed(str(project_id), str(user_id)) is True

--- a/apps/api/tests/unit/test_rss_refresh.py
+++ b/apps/api/tests/unit/test_rss_refresh.py
@@ -1,0 +1,98 @@
+"""
+Unit tests for the post-completion RSS feed refresh helper (issue #382).
+
+refresh_project_rss_feed() bridges Celery's sync world into the async
+RSSGenerationService. It must regenerate the feed only when one already
+exists, and must never raise — a feed refresh failure must not fail the
+episode-completion path that invokes it.
+"""
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.tasks.rss_refresh import refresh_project_rss_feed
+
+
+def _mock_async_session():
+    """Return (ctx, session) mimicking AsyncSessionLocal() as an async CM."""
+    session = MagicMock()
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx, session
+
+
+def _mock_service(feed):
+    """Return an RSSGenerationService mock whose get_rss_feed returns *feed*."""
+    service = MagicMock()
+    service.get_rss_feed = AsyncMock(return_value=feed)
+    service.generate_rss_for_project = AsyncMock(return_value=feed)
+    return service
+
+
+class TestRefreshProjectRssFeed:
+    def test_regenerates_when_feed_exists(self):
+        project_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        ctx, session = _mock_async_session()
+        service = _mock_service(feed=MagicMock())
+
+        with (
+            patch("src.tasks.rss_refresh.AsyncSessionLocal", return_value=ctx),
+            patch("src.tasks.rss_refresh.RSSGenerationService", return_value=service),
+        ):
+            assert refresh_project_rss_feed(project_id, user_id) is True
+
+        service.get_rss_feed.assert_awaited_once_with(session, project_id)
+        service.generate_rss_for_project.assert_awaited_once_with(
+            session, project_id, user_id
+        )
+
+    def test_skips_when_no_feed_row(self):
+        """No RSSFeed row means no platform consumes the feed yet — do nothing."""
+        ctx, _session = _mock_async_session()
+        service = _mock_service(feed=None)
+
+        with (
+            patch("src.tasks.rss_refresh.AsyncSessionLocal", return_value=ctx),
+            patch("src.tasks.rss_refresh.RSSGenerationService", return_value=service),
+        ):
+            assert refresh_project_rss_feed(uuid.uuid4(), uuid.uuid4()) is False
+
+        service.generate_rss_for_project.assert_not_awaited()
+
+    def test_swallows_service_errors(self):
+        """A ValueError (e.g. incomplete podcast_metadata) must not propagate."""
+        ctx, _session = _mock_async_session()
+        service = _mock_service(feed=MagicMock())
+        service.generate_rss_for_project = AsyncMock(
+            side_effect=ValueError("Missing metadata")
+        )
+
+        with (
+            patch("src.tasks.rss_refresh.AsyncSessionLocal", return_value=ctx),
+            patch("src.tasks.rss_refresh.RSSGenerationService", return_value=service),
+        ):
+            assert refresh_project_rss_feed(uuid.uuid4(), uuid.uuid4()) is False
+
+    def test_swallows_session_errors(self):
+        """Even a broken DB session must not raise out of the helper."""
+        with patch(
+            "src.tasks.rss_refresh.AsyncSessionLocal",
+            side_effect=RuntimeError("pool gone"),
+        ):
+            assert refresh_project_rss_feed(uuid.uuid4(), uuid.uuid4()) is False
+
+    def test_accepts_string_ids(self):
+        """Celery callbacks hold string UUIDs; the helper normalizes them."""
+        project_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        ctx, session = _mock_async_session()
+        service = _mock_service(feed=MagicMock())
+
+        with (
+            patch("src.tasks.rss_refresh.AsyncSessionLocal", return_value=ctx),
+            patch("src.tasks.rss_refresh.RSSGenerationService", return_value=service),
+        ):
+            assert refresh_project_rss_feed(str(project_id), str(user_id)) is True
+
+        service.get_rss_feed.assert_awaited_once_with(session, project_id)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,7 +1,21 @@
 # Issue #382 — [P4.3.2] RSS feed is never regenerated when an episode completes
 
-Status: IN PROGRESS. Plan source: self-authored (no plan comment on issue).
+Status: IN PROGRESS — implementation + review fixes committed; quality gates green
+(1805 passed full suite pre-fix run; diff coverage 100%; 5/5 mutation checks killed;
+opencode APPROVE; internal Critical fixed). Awaiting final full-suite run, then PR.
 Branch: `feature/issue-382-rss-regen-on-complete`
+
+## Post-plan additions (review round)
+
+- **Critical (internal review, empirically confirmed)**: asyncio.run + shared pooled
+  async engine fails on the 2nd call per worker process ("Future attached to a different
+  loop"). Fixed with `celery_async_session()` in database.py — per-call NullPool engine,
+  disposed after use. Applied to rss_refresh AND content_extraction (same latent bug).
+- **Major**: finalize's refresh call sat inside the retry-bearing try; a refresh escape
+  would self.retry and eventually mark a completed episode failed. Now locally guarded +
+  regression test.
+- Skipped (nitpick, moot): finalize reads episode ids after commit — safe, both session
+  factories set expire_on_commit=False.
 
 ## Problem
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,61 +1,68 @@
-# Issue #378 — [P4.3.1] First Spotify/Apple distribution fails until the project RSS feed is generated
+# Issue #382 — [P4.3.2] RSS feed is never regenerated when an episode completes
 
-Status: SHIPPED — merged 2026-07-12 via PR #384 (squash); issue #378 closed. Follow-ups filed: #382 (feed regen on completion), #383 (UI enable_distribution), #385 (feed public-read policy).
+Status: IN PROGRESS. Plan source: self-authored (no plan comment on issue).
+Branch: `feature/issue-382-rss-regen-on-complete`
 
-Plan source: self-authored. Branch: `feature/issue-378-rss-preflight-distribution` (deleted).
+## Problem
 
-Post-plan addition (PR review round): the pre-flight runs under a SAVEPOINT (`begin_nested`) so DB failures (unique-RSSFeed race) degrade to skip+warning instead of poisoning the 'queued' commit.
+`RSSGenerationService.generate_rss_for_project` is only called from the RSS router and the
+#378 generation pre-flight. When an episode reaches `complete`, nothing regenerates the feed,
+so Spotify/Apple keep ingesting a stale (often empty) feed XML on S3.
 
-## Design decision (autonomous — no architectural fork)
+## Design decisions (made autonomously — no architectural fork)
 
-The issue offers Option 1 (auto-generate the feed before distribution; flagged as expensive because
-the Celery task is sync and `RSSGenerationService` is async) and Option 2 (pre-flight check/warn,
-recommended as cheaper). Key finding: the sync-bridge cost only exists inside the Celery task — the
-**generation router** (`apps/api/src/routers/generation.py`) is async and already resolves active
-distribution targets before dispatch. So the cheap path is a router pre-flight that:
-
-1. **Auto-generates** the feed when possible (project metadata valid) — one awaited service call,
-   no new infrastructure. Feed with zero complete episodes is valid RSS.
-2. **Skips Spotify/Apple + returns a clear warning** when auto-generation is impossible (missing
-   `show_title`/`author`/`description` → `ValueError`) or errors (S3 down) — mirroring the existing
-   graceful-skip precedents (no S3 bucket, no active targets), instead of a guaranteed
-   `distribution_failed`.
-
-This satisfies both halves of the acceptance criterion ("no guaranteed first-attempt failure, OR
-clearly told beforehand").
+- **Post-completion hook, not a chain stage.** The issue floats both. A feed-refresh chain
+  stage only covers the chain path (`build_generation_workflow`); the finalize path
+  (`finalize_episode_generation_task`, used when composition+distribution are both off)
+  never invokes the chain or `on_workflow_complete`. A shared hook called from **both**
+  completion sites covers everything; a chain stage cannot.
+- **Sync→async bridge**: `asyncio.run()` + `AsyncSessionLocal`, same pattern as
+  `content_extraction.py:101` / `maintenance.py:150`. Celery sessions don't arm the tenant
+  GUC; the service filters by explicit `project_id`, which is the existing task-side pattern.
+- **Gate on an existing RSSFeed row** (`get_rss_feed`). If no feed row exists, no platform is
+  consuming the feed yet — the #378 pre-flight creates it at distribution time. Regenerating
+  unconditionally would fail on projects with incomplete `podcast_metadata` for no benefit.
+- **Only on `complete`.** On `distribution_failed` the episode's `generation_status` is not
+  `complete`, so `_get_completed_episodes` wouldn't include it anyway — regeneration is a no-op.
+- **Never fail the completion callback.** The hook catches and logs all exceptions
+  (mirrors the #378 pre-flight's non-fatal handling). Regeneration is already idempotent:
+  single upsert per project, service commits internally.
 
 ## Steps
 
-1. **Backend pre-flight (TDD)** — `apps/api/src/routers/generation.py`
-   - After the `platforms` dict is built: if `spotify`/`apple_podcasts` present and
-     `not settings.ENABLE_DIRECT_PLATFORM_PUBLISH`, check `RSSGenerationService.get_rss_feed()`.
-   - No feed / no `public_url` → `await generate_rss_for_project(db, project_id, user.id)`.
-   - On any exception: log warning, drop spotify/apple from `platforms`, collect a warning string.
-   - Response: additive `warnings: [...]` key (only when non-empty) on the 202 payload.
-   - Tests: `apps/api/tests/test_distribution_wiring.py` (existing file covers router→platforms
-     wiring): (a) no feed + valid metadata → feed auto-created, spotify kept, no warnings;
-     (b) no feed + missing metadata → spotify dropped, warning returned, still 202;
-     (c) feed exists → no regeneration; (d) webhook-only → no pre-flight;
-     (e) `ENABLE_DIRECT_PLATFORM_PUBLISH=True` → no pre-flight.
-
-2. **Frontend warning surface (TDD)** — `apps/web/src/app/(auth)/episodes/[id]/page.tsx`
-   - Generate handler (~line 482): if the 202 response has `warnings`, show them (toast/notice).
-   - Test: extend `apps/web/__tests__` episode page test with a warnings-response case.
-
-3. **Follow-up issue** — the RSS feed is never regenerated when an episode completes, so
-   Spotify/Apple never see new episodes until a manual regenerate. Out of scope here; file as
-   `[P4.3.2]`.
+1. **Add `refresh_project_rss_feed(project_id, user_id)` helper** in
+   `apps/api/src/tasks/rss_refresh.py` (new small module; avoids callbacks↔podcast_generation
+   import tangle). Opens `AsyncSessionLocal` via `asyncio.run`, skips (log) if
+   `get_rss_feed` returns None, else `await generate_rss_for_project(db, project_id, user_id)`.
+   Swallows + logs every exception. Returns True/False (regenerated or not) for tests.
+2. **Call it from `on_workflow_complete`** (`src/tasks/callbacks.py:379` success branch only):
+   capture `episode.project_id` / `episode.user_id` inside the session
+   (expire_on_commit=False, but capture anyway before session close), invoke the helper after
+   `db.commit()` / session close.
+3. **Call it from `finalize_episode_generation_task`** (`src/tasks/podcast_generation.py:773`
+   path): after the successful `db.commit()` that marks `complete` (not on the StaleDataError
+   absorb branch — episode was deleted), using captured project/user ids.
+4. **Tests (TDD — write first)**:
+   - `tests/unit/test_rss_refresh.py`: helper regenerates when feed row exists; skips when
+     none; swallows service exceptions (ValueError on bad metadata) and returns False.
+   - `tests/unit/test_celery_callbacks.py`: on_workflow_complete triggers refresh on success;
+     does NOT trigger on distribution_failed; missing episode → no refresh; refresh error
+     doesn't break the callback.
+   - `tests/test_celery_workflow.py`: finalize task triggers refresh after marking complete;
+     no refresh on failed S3 upload.
+5. **CI fix (user-requested, same PR)**: `deploy-dev.yml:77` and `:87`
+   `JWT_SECRET_KEY: test-jwt-secret-for-ci` (22 bytes) → `test-jwt-secret-for-ci-0000000000`
+   (33 bytes, same value `test.yml:80` already uses). PyJWT emits InsecureKeyLengthWarning
+   below 32 bytes; the repo's `filterwarnings=error` turns every `jwt.encode` into a 500, which
+   is why "Deploy to Development" has failed on every recent main push (164 failed / 417 errors,
+   all rooted in `POST /auth/register` 500). Also align `playwright-tests.yml:151`/`:183`
+   for consistency (server-mode, warning-only today, but same latent trap).
 
 ## Acceptance criteria
 
-- [x] Project with valid podcast metadata: adding a Spotify/Apple target + generating an episode
-      does NOT produce a first-attempt `distribution_failed` (feed auto-generated at kickoff).
-- [x] Project without metadata: user is clearly told (API warning surfaced in UI; platforms
-      skipped, episode generation still proceeds).
-- [x] Existing feed / webhook-only / direct-publish-flag paths unchanged.
-
-## Known limitations (by design, noted for PR)
-
-- The warning is returned in the API response and shown as a toast; it is not persisted in
-  `generation_progress` (that dict is overwritten at dispatch and managed by worker callbacks).
-- Feed staleness (new episode not in the feed) is pre-existing and tracked by the follow-up issue.
+- [ ] Episode completing via the workflow chain regenerates the project RSS feed (feed XML on
+      S3 includes the new episode).
+- [ ] Episode completing via the finalize path (no composition/distribution) regenerates too.
+- [ ] Projects without an RSS feed row are untouched (no error, no feed created).
+- [ ] A regeneration failure never fails/marks-failed the episode completion.
+- [ ] Deploy to Development workflow's "Run API tests" step passes (JWT key fix).


### PR DESCRIPTION
## Summary
Implements #382: RSS feed is never regenerated when an episode completes — Spotify/Apple ingest a stale or empty feed.

- New `refresh_project_rss_feed()` (`apps/api/src/tasks/rss_refresh.py`): best-effort, never-raising bridge from sync Celery code into the async `RSSGenerationService`; regenerates the feed **only if an RSSFeed row already exists** (no feed row → no platform consumes it yet; the #378 pre-flight creates it at distribution time).
- Called from **both** episode-completion sites: `on_workflow_complete` (workflow-chain path, success branch only) and `finalize_episode_generation_task` (no-composition/no-distribution path). A chain stage alone would have missed the finalize path entirely.
- New `celery_async_session()` (`src/database.py`): per-call NullPool engine for `asyncio.run()` bridges. The shared pooled engine returns connections bound to a destroyed event loop, so the 2nd `asyncio.run()` per worker process fails with "got Future attached to a different loop" (reproduced empirically: every other call fails). Also applied to `content_extraction.py`, which had the same latent bug.
- **CI fix (user-requested)**: `deploy-dev.yml` (and `playwright-tests.yml`) used a 22-byte `JWT_SECRET_KEY`; PyJWT emits `InsecureKeyLengthWarning` below 32 bytes and the repo's `filterwarnings=error` escalates it, 500-ing every `jwt.encode` → `POST /auth/register` failed → 164 failed / 417 errors in every recent "Deploy to Development" run. Lengthened to the 33-byte value `test.yml` already uses.

## Acceptance Criteria
- [x] Episode completing via the workflow chain regenerates the project RSS feed
- [x] Episode completing via the finalize path regenerates too
- [x] Projects without an RSS feed row are untouched (no error, no feed created)
- [x] A regeneration failure never fails or marks-failed the episode completion (guarded at both call sites; the finalize guard prevents a spurious `self.retry`)
- [x] Deploy to Development "Run API tests" step passes (JWT key fix)

## Test Plan
- [x] Unit tests written first (TDD): helper (5), callbacks (4), finalize path (4), plus a real-DB regression test proving 3 sequential `asyncio.run()` sessions succeed
- [x] Full backend suite: 1807 passed, 7 skipped, coverage gate ≥85% green
- [x] Diff coverage on changed lines: 100%
- [x] Linting clean (ruff); mypy adds no new errors (16 pre-existing in imported modules, 24 on main)
- [x] Internal code review (advisory) completed — Critical + Major findings fixed (see notes)
- [x] Cross-family review pass: opencode (GLM) — **APPROVE**; its two Suggestions were already fixed from the internal review round
- [x] Mutation sanity check: 5 mutations, all killed their target tests

## Known Limitations / Intentionally Deferred
- `distribution_failed` episodes do not trigger a refresh — intentional: their `generation_status` isn't `complete`, so `_get_completed_episodes` wouldn't include them anyway (refresh would be a no-op). Retry-to-success later lands on the `complete` branch and refreshes.
- The refresh is fire-and-forget with log-only failure reporting; no user-visible surfacing of a failed refresh. Acceptable while feed regeneration is idempotent and re-triggerable via `POST /projects/{id}/rss-feed/generate`.
- RLS note: task-side sessions don't arm the tenant GUC (established task-layer property, cf. #211); isolation is via explicit `project_id` filters, same as `content_extraction`.

## Implementation Notes
- Self-authored plan (issue had no plan comment). The issue floated "chain stage vs post-completion hook" — hook chosen because the finalize path never enters the chain or `on_workflow_complete`.
- The cross-event-loop pool bug was found by internal review, confirmed empirically against a real DB before fixing (run 0 ok, run 1 fail, run 2 ok), and re-verified fixed after.

Closes #382