### PR TITLE
Deploy: pm2-managed uv run --no-sync to prevent venv tear races

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -213,7 +213,7 @@ jobs:
             pm2 start uv \
               --name podcaststudiohub-api \
               --cwd $SERVER_PATH/api \
-              -- run uvicorn src.main:app --host 127.0.0.1 --port "\$API_EFFECTIVE_PORT"
+              -- run --no-sync uvicorn src.main:app --host 127.0.0.1 --port "\$API_EFFECTIVE_PORT"
 
             pm2 save
 
@@ -318,7 +318,7 @@ jobs:
             pm2 start uv \
               --name podcaststudiohub-celery \
               --cwd $SERVER_PATH/api \
-              -- run celery -A src.worker:celery_app worker -B --loglevel=info
+              -- run --no-sync celery -A src.worker:celery_app worker -B --loglevel=info
 
             pm2 save
 


### PR DESCRIPTION
## Summary
Follow-up to the Deploy to Development incident behind PR #386's Health Check failure.

Every pm2 (re)start of `uv run uvicorn` / `uv run celery` performs an **implicit `uv sync`**. A crash-looping API therefore re-syncs the shared venv every ~3 seconds, racing the deploy's own `uv sync` and the Celery restart's sync. On the 2026-07-13 deploy (first to reach the VPS since 07-09, with a 124-uninstall/122-install dependency churn) this tore `typer` out of the venv — `typer-0.12.5.dist-info` intact, `typer/` package directory gone — so `uv sync` reported "no changes" while `from podcastfy.client import …` failed, and the startup lifespan check crash-looped the API (nginx 502, 1000+ pm2 restarts).

Fix: start both pm2 processes with `uv run --no-sync` so only the deploy step's explicit `uv sync` ever mutates the venv.

The torn venv itself was repaired manually (`uv sync --reinstall`); dev API/frontend are healthy again (`/api/health` 200).

## Known Limitations / Intentionally Deferred
- None — two-flag workflow change; no app code touched.

## Test Plan
- [x] YAML untouched apart from the two flags; workflow-file change only, exercised by the next main deploy
- [x] Live verification of the failure/repair on the VPS documented above