### PR TITLE
[P4.3.4] Serve RSS feeds via the public API endpoint; stop storing the AccessDenied S3 URL as public_url (#385)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -84,6 +84,12 @@ EMAIL_FROM_NAME=Podcastfy
 FRONTEND_URL=http://localhost:3000
 EMAIL_VERIFICATION_TOKEN_EXPIRE_HOURS=24
 
+# Public origin of this API, no trailing slash (issue #385). Used to build
+# externally fetchable URLs: RSS feed public_url =
+# {API_PUBLIC_BASE_URL}/feeds/{project_id}/podcast.xml. In prod set it to the
+# nginx-exposed API origin (e.g. https://dev.podcaststudiohub.me/api).
+API_PUBLIC_BASE_URL=http://localhost:8000
+
 # Application Settings
 LOG_LEVEL=INFO
 

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -133,6 +133,10 @@ class Settings(BaseSettings):
     EMAIL_FROM: str = "noreply@podcaststudiohub.com"
     EMAIL_FROM_NAME: str = "Podcastfy"
     FRONTEND_URL: str = "http://localhost:3000"
+    # Public origin of this API, used to build externally fetchable URLs
+    # (e.g. RSSFeed.public_url -> {API_PUBLIC_BASE_URL}/feeds/{id}/podcast.xml).
+    # The raw S3 URL is AccessDenied — the bucket has no public-read policy (#385).
+    API_PUBLIC_BASE_URL: str = "http://localhost:8000"
     EMAIL_VERIFICATION_TOKEN_EXPIRE_HOURS: int = 24
 
     # Logging

--- a/apps/api/src/routers/rss_feed.py
+++ b/apps/api/src/routers/rss_feed.py
@@ -17,7 +17,7 @@ from ..database import get_db
 from ..middleware.auth import get_current_user
 from ..models import User
 from ..schemas.rss_feed import RSSFeedResponse, RSSFeedUpdate
-from ..services.rss_generation_service import RSSGenerationService
+from ..services.rss_generation_service import RSSGenerationService, rss_feed_s3_key
 from ..services.project_service import get_project_by_id
 
 logger = logging.getLogger(__name__)
@@ -222,7 +222,6 @@ async def update_rss_feed(
 )
 async def get_public_rss_feed(
 	project_id: UUID,
-	db: AsyncSession = Depends(get_db),
 	rss_service: RSSGenerationService = Depends(get_rss_service),
 ):
 	"""
@@ -231,29 +230,30 @@ async def get_public_rss_feed(
 	No authentication required. Returns the RSS 2.0 feed XML with
 	appropriate Content-Type and caching headers.
 
-	Fetches feed XML from S3 if available, otherwise returns 404.
+	Deliberately no database read: an unauthenticated request carries no
+	tenant context, so FORCE RLS on rss_feeds would return zero rows and
+	404 every real platform fetch (#385). The S3 key is deterministic, so
+	the object's existence is the "feed was generated" check.
 
 	Args:
 		project_id: UUID of the project
-		db: Database session
-		rss_service: RSS generation service
+		rss_service: RSS generation service (for S3 access)
 
 	Returns:
 		RSS 2.0 XML response with Content-Type: application/rss+xml
 
 	Raises:
-		HTTPException 404: If project or feed not found
+		HTTPException 404: If the feed has not been generated
 	"""
-	rss_feed = await rss_service.get_rss_feed(db, project_id)
-	if rss_feed is None or not rss_feed.public_url:
+	s3_key = rss_feed_s3_key(project_id)
+
+	try:
+		xml_content = await _fetch_rss_from_s3(rss_service, s3_key)
+	except FileNotFoundError:
 		raise HTTPException(
 			status_code=status.HTTP_404_NOT_FOUND,
 			detail="Podcast feed not found",
 		)
-
-	# Fetch XML from S3
-	try:
-		xml_content = await _fetch_rss_from_s3(rss_service, rss_feed.s3_key)
 	except Exception:
 		logger.exception("Failed to fetch RSS feed for project %s", project_id)
 		raise HTTPException(

--- a/apps/api/src/services/rss_generation_service.py
+++ b/apps/api/src/services/rss_generation_service.py
@@ -13,9 +13,19 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from ..config import settings
 from ..models import Episode, Project, RSSFeed
 from .storage_service import StorageService
 from ..utils.datetime_utils import utcnow
+
+
+def rss_feed_s3_key(project_id: UUID) -> str:
+	"""Deterministic S3 key for a project's RSS feed.
+
+	Shared with the public feed endpoint, which derives the key from the URL
+	instead of reading the RLS-protected rss_feeds table (#385).
+	"""
+	return f"rss-feeds/{project_id}/feed.xml"
 
 
 class RSSGenerationService:
@@ -329,7 +339,12 @@ class RSSGenerationService:
 
 	async def _upload_rss_to_s3(self, project_id: UUID, xml_content: str) -> tuple[str, str]:
 		"""
-		Upload RSS XML content to S3 with public-read ACL.
+		Upload RSS XML content to S3 and build the public feed URL.
+
+		The returned public_url is the API's public endpoint, NOT the S3
+		object URL: the bucket has no public-read policy, so the raw S3 URL
+		returns AccessDenied to podcast platforms (#385). The endpoint
+		(GET /feeds/{project_id}/podcast.xml) serves the stored object.
 
 		Args:
 			project_id: Project UUID (used in S3 key path)
@@ -341,7 +356,7 @@ class RSSGenerationService:
 		import tempfile
 		import os
 
-		s3_key = f"rss-feeds/{project_id}/feed.xml"
+		s3_key = rss_feed_s3_key(project_id)
 
 		# Write to temp file for upload
 		with tempfile.NamedTemporaryFile(
@@ -354,7 +369,7 @@ class RSSGenerationService:
 			tmp_path = tmp.name
 
 		try:
-			public_url = await self.storage.upload_file(
+			await self.storage.upload_file(
 				file_path=tmp_path,
 				s3_key=s3_key,
 				content_type="application/rss+xml",
@@ -363,6 +378,9 @@ class RSSGenerationService:
 		finally:
 			os.unlink(tmp_path)
 
+		public_url = (
+			f"{settings.API_PUBLIC_BASE_URL.rstrip('/')}/feeds/{project_id}/podcast.xml"
+		)
 		return s3_key, public_url
 
 	async def _get_or_create_rss_feed(

--- a/apps/api/src/services/rss_generation_service.py
+++ b/apps/api/src/services/rss_generation_service.py
@@ -373,7 +373,6 @@ class RSSGenerationService:
 				file_path=tmp_path,
 				s3_key=s3_key,
 				content_type="application/rss+xml",
-				public=True,
 			)
 		finally:
 			os.unlink(tmp_path)

--- a/apps/api/src/services/storage_service.py
+++ b/apps/api/src/services/storage_service.py
@@ -62,7 +62,11 @@ class StorageService:
             public: Make file publicly accessible
 
         Returns:
-            Public URL of the uploaded file
+            The S3 object URL. NOT publicly fetchable — the bucket has no
+            public-read policy, so this URL returns AccessDenied to
+            unauthenticated clients (#385). Serve objects through an API
+            endpoint or a presigned URL instead of storing this value as a
+            user-facing link.
         """
         extra_args = {}
 

--- a/apps/api/src/services/storage_service.py
+++ b/apps/api/src/services/storage_service.py
@@ -103,6 +103,9 @@ class StorageService:
 
         Returns:
             Local file path
+
+        Raises:
+            FileNotFoundError: If the object does not exist in the bucket.
         """
         try:
             # boto3 is synchronous; run it off the event loop so concurrent
@@ -116,6 +119,10 @@ class StorageService:
             return local_path
 
         except ClientError as e:
+            # download_file surfaces a missing key as HeadObject "404";
+            # direct GetObject calls report "NoSuchKey".
+            if e.response.get("Error", {}).get("Code") in ("404", "NoSuchKey", "NotFound"):
+                raise FileNotFoundError(f"S3 object not found: {s3_key}") from e
             raise Exception(f"Failed to download file from S3: {str(e)}")
 
     async def delete_file(self, s3_key: str) -> None:

--- a/apps/api/tests/test_rss_feed.py
+++ b/apps/api/tests/test_rss_feed.py
@@ -69,7 +69,7 @@ def make_mock_rss_feed(project_id):
 	feed.project_id = project_id
 	feed.tenant_id = uuid4()
 	feed.s3_key = f"rss-feeds/{project_id}/feed.xml"
-	feed.public_url = f"https://bucket.s3.amazonaws.com/rss-feeds/{project_id}/feed.xml"
+	feed.public_url = f"http://localhost:8000/feeds/{project_id}/podcast.xml"
 	feed.validation_status = {}
 	feed.last_generated = utcnow()
 	feed.created_at = utcnow()
@@ -365,27 +365,45 @@ async def test_update_rss_feed_internal_error_hides_details(client, project_with
 
 # ============================================================================
 # GET /feeds/{project_id}/podcast.xml (public endpoint)
+#
+# The endpoint must not read the rss_feeds table: an unauthenticated request
+# has no tenant context, so FORCE RLS returns zero rows and the feed would
+# 404 for every real caller (#385). Only S3 access is patched here — any
+# reintroduced DB dependency makes these tests fail.
 # ============================================================================
 
 @pytest.mark.asyncio
 async def test_public_feed_success(client, project_with_metadata):
-	"""Test public RSS feed returns valid XML without authentication."""
+	"""Public RSS feed returns valid XML without authentication or a DB read."""
 	project_id, _ = project_with_metadata
 
 	sample_xml = b'<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title>Test</title></channel></rss>'
-	mock_feed = make_mock_rss_feed(project_id)
 
-	with patch("src.routers.rss_feed.RSSGenerationService") as MockService, \
-	     patch("src.routers.rss_feed._fetch_rss_from_s3", new=AsyncMock(return_value=sample_xml)):
-		mock_instance = AsyncMock()
-		mock_instance.get_rss_feed.return_value = mock_feed
-		MockService.return_value = mock_instance
-
+	with patch("src.routers.rss_feed._fetch_rss_from_s3", new=AsyncMock(return_value=sample_xml)) as mock_fetch:
 		# No auth headers — public endpoint
 		response = await client.get(f"/feeds/{project_id}/podcast.xml")
 
 	assert response.status_code == 200
 	assert "application/rss+xml" in response.headers["content-type"]
+	assert b"<rss" in response.content
+	# s3_key is derived from the URL, not from a tenant-scoped DB row
+	assert mock_fetch.await_args.args[1] == f"rss-feeds/{project_id}/feed.xml"
+
+
+@pytest.mark.asyncio
+async def test_public_feed_success_without_any_db_row(client):
+	"""The feed serves even when no rss_feeds row is visible (FORCE RLS path).
+
+	No project, no feed row, no mocked service — only S3 is patched. This is
+	the exact situation of a real unauthenticated platform fetch (#385).
+	"""
+	project_id = uuid4()
+	sample_xml = b'<?xml version="1.0"?><rss version="2.0"><channel><title>T</title></channel></rss>'
+
+	with patch("src.routers.rss_feed._fetch_rss_from_s3", new=AsyncMock(return_value=sample_xml)):
+		response = await client.get(f"/feeds/{project_id}/podcast.xml")
+
+	assert response.status_code == 200
 	assert b"<rss" in response.content
 
 
@@ -395,14 +413,8 @@ async def test_public_feed_cache_headers(client, project_with_metadata):
 	project_id, _ = project_with_metadata
 
 	sample_xml = b'<?xml version="1.0"?><rss version="2.0"><channel><title>T</title></channel></rss>'
-	mock_feed = make_mock_rss_feed(project_id)
 
-	with patch("src.routers.rss_feed.RSSGenerationService") as MockService, \
-	     patch("src.routers.rss_feed._fetch_rss_from_s3", new=AsyncMock(return_value=sample_xml)):
-		mock_instance = AsyncMock()
-		mock_instance.get_rss_feed.return_value = mock_feed
-		MockService.return_value = mock_instance
-
+	with patch("src.routers.rss_feed._fetch_rss_from_s3", new=AsyncMock(return_value=sample_xml)):
 		response = await client.get(f"/feeds/{project_id}/podcast.xml")
 
 	assert response.status_code == 200
@@ -412,14 +424,10 @@ async def test_public_feed_cache_headers(client, project_with_metadata):
 
 @pytest.mark.asyncio
 async def test_public_feed_not_found_when_no_feed(client, project_with_metadata):
-	"""Test 404 when RSS feed has not been generated."""
+	"""404 when the feed object does not exist in S3 (never generated)."""
 	project_id, _ = project_with_metadata
 
-	with patch("src.routers.rss_feed.RSSGenerationService") as MockService:
-		mock_instance = AsyncMock()
-		mock_instance.get_rss_feed.return_value = None
-		MockService.return_value = mock_instance
-
+	with patch("src.routers.rss_feed._fetch_rss_from_s3", new=AsyncMock(side_effect=FileNotFoundError())):
 		response = await client.get(f"/feeds/{project_id}/podcast.xml")
 
 	assert response.status_code == 404
@@ -430,15 +438,9 @@ async def test_public_feed_not_found_when_no_feed(client, project_with_metadata)
 async def test_public_feed_internal_error_hides_details(client, project_with_metadata):
 	"""500 while fetching from S3 returns a generic message, not exception internals."""
 	project_id, _ = project_with_metadata
-	secret = "S3 NoSuchKey rss-feeds/internal/path.xml"
-	mock_feed = make_mock_rss_feed(project_id)
+	secret = "S3 throttled rss-feeds/internal/path.xml"
 
-	with patch("src.routers.rss_feed.RSSGenerationService") as MockService, \
-	     patch("src.routers.rss_feed._fetch_rss_from_s3", new=AsyncMock(side_effect=RuntimeError(secret))):
-		mock_instance = AsyncMock()
-		mock_instance.get_rss_feed.return_value = mock_feed
-		MockService.return_value = mock_instance
-
+	with patch("src.routers.rss_feed._fetch_rss_from_s3", new=AsyncMock(side_effect=RuntimeError(secret))):
 		response = await client.get(f"/feeds/{project_id}/podcast.xml")
 
 	assert response.status_code == 500
@@ -451,11 +453,7 @@ async def test_public_feed_not_found_for_missing_project(client):
 	"""Test 404 for completely non-existent project."""
 	nonexistent_id = uuid4()
 
-	with patch("src.routers.rss_feed.RSSGenerationService") as MockService:
-		mock_instance = AsyncMock()
-		mock_instance.get_rss_feed.return_value = None
-		MockService.return_value = mock_instance
-
+	with patch("src.routers.rss_feed._fetch_rss_from_s3", new=AsyncMock(side_effect=FileNotFoundError())):
 		response = await client.get(f"/feeds/{nonexistent_id}/podcast.xml")
 
 	assert response.status_code == 404
@@ -467,14 +465,8 @@ async def test_public_feed_accessible_without_jwt(client, project_with_metadata)
 	project_id, _ = project_with_metadata
 
 	sample_xml = b'<?xml version="1.0"?><rss version="2.0"><channel><title>Test</title></channel></rss>'
-	mock_feed = make_mock_rss_feed(project_id)
 
-	with patch("src.routers.rss_feed.RSSGenerationService") as MockService, \
-	     patch("src.routers.rss_feed._fetch_rss_from_s3", new=AsyncMock(return_value=sample_xml)):
-		mock_instance = AsyncMock()
-		mock_instance.get_rss_feed.return_value = mock_feed
-		MockService.return_value = mock_instance
-
+	with patch("src.routers.rss_feed._fetch_rss_from_s3", new=AsyncMock(return_value=sample_xml)):
 		# Explicitly no headers
 		response = await client.get(
 			f"/feeds/{project_id}/podcast.xml",

--- a/apps/api/tests/test_rss_feed.py
+++ b/apps/api/tests/test_rss_feed.py
@@ -394,8 +394,9 @@ async def test_public_feed_success(client, project_with_metadata):
 async def test_public_feed_success_without_any_db_row(client):
 	"""The feed serves even when no rss_feeds row is visible (FORCE RLS path).
 
-	No project, no feed row, no mocked service — only S3 is patched. This is
-	the exact situation of a real unauthenticated platform fetch (#385).
+	No project, no feed row, no mocked DB service — only the S3 fetch is
+	patched. This is the exact situation of a real unauthenticated platform
+	fetch (#385).
 	"""
 	project_id = uuid4()
 	sample_xml = b'<?xml version="1.0"?><rss version="2.0"><channel><title>T</title></channel></rss>'

--- a/apps/api/tests/unit/test_rss_generation_service.py
+++ b/apps/api/tests/unit/test_rss_generation_service.py
@@ -446,16 +446,25 @@ class TestUploadToS3:
 	"""Tests for S3 upload functionality."""
 
 	@pytest.mark.asyncio
-	async def test_upload_uses_correct_s3_key(self, rss_service, valid_project):
-		"""Test that upload uses correct S3 key pattern."""
+	async def test_upload_uses_correct_s3_key_and_api_public_url(self, rss_service, valid_project):
+		"""public_url must be the API feed endpoint, never the raw S3 URL.
+
+		The bucket has no public-read policy, so the S3 URL returns
+		AccessDenied to podcast platforms (#385). The XML is still uploaded
+		to S3 (the endpoint serves the stored object).
+		"""
+		from src.config import settings
+
 		project_id = valid_project.id
-		xml_content = "<rss>test</rss>"
+		rss_service.storage.upload_file = AsyncMock(
+			return_value=f"https://bucket.s3.us-east-1.amazonaws.com/rss-feeds/{project_id}/feed.xml"
+		)
 
-		with patch.object(rss_service, '_upload_rss_to_s3', return_value=(
-			f"rss-feeds/{project_id}/feed.xml",
-			f"https://bucket.s3.us-east-1.amazonaws.com/rss-feeds/{project_id}/feed.xml"
-		)):
-			s3_key, public_url = await rss_service._upload_rss_to_s3(project_id, xml_content)
+		s3_key, public_url = await rss_service._upload_rss_to_s3(project_id, "<rss>test</rss>")
 
-		assert str(project_id) in s3_key
-		assert "feed.xml" in s3_key
+		assert s3_key == f"rss-feeds/{project_id}/feed.xml"
+		assert public_url == (
+			f"{settings.API_PUBLIC_BASE_URL.rstrip('/')}/feeds/{project_id}/podcast.xml"
+		)
+		assert ".s3." not in public_url
+		rss_service.storage.upload_file.assert_awaited_once()

--- a/apps/api/tests/unit/test_storage_service.py
+++ b/apps/api/tests/unit/test_storage_service.py
@@ -153,8 +153,24 @@ async def test_download_file_success_returns_local_path(service, mock_boto3_clie
 
 @pytest.mark.asyncio
 async def test_download_file_client_error_raises(service, mock_boto3_client):
-	mock_boto3_client.download_file.side_effect = _make_client_error()
+	mock_boto3_client.download_file.side_effect = _make_client_error("AccessDenied")
 	with pytest.raises(Exception, match="Failed to download"):
+		await service.download_file("key.mp3", "/tmp/local.mp3")
+
+
+@pytest.mark.asyncio
+async def test_download_file_404_raises_file_not_found(service, mock_boto3_client):
+	# boto3 surfaces a missing key from download_file as ClientError code "404"
+	# (HeadObject); callers need to distinguish it from real failures (#385).
+	mock_boto3_client.download_file.side_effect = _make_client_error("404")
+	with pytest.raises(FileNotFoundError):
+		await service.download_file("key.mp3", "/tmp/local.mp3")
+
+
+@pytest.mark.asyncio
+async def test_download_file_no_such_key_raises_file_not_found(service, mock_boto3_client):
+	mock_boto3_client.download_file.side_effect = _make_client_error("NoSuchKey")
+	with pytest.raises(FileNotFoundError):
 		await service.download_file("key.mp3", "/tmp/local.mp3")
 
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -282,6 +282,10 @@ JWT_ALGORITHM=HS256
 ENCRYPTION_KEY=<generate-with-openssl-rand-hex-32>
 DEBUG=False
 LOG_LEVEL=INFO
+# Public origin of this API, no trailing slash (issue #385): RSS feed
+# public_url is built as {API_PUBLIC_BASE_URL}/feeds/{project_id}/podcast.xml,
+# so it must be the nginx-exposed API origin platforms can reach.
+API_PUBLIC_BASE_URL=https://dev.podcaststudiohub.me/api
 
 # Optional - users can provide their own
 OPENAI_API_KEY=

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,58 +1,71 @@
-# Issue #383 — [P4.3.3] Web UI never enables distribution
+# Issue #385 — [P4.3.4] RSS feed public_url returns S3 AccessDenied
 
-Status: SHIPPED — merged 2026-07-13 via PR #388 (squash, 28833a8); issue #383 closed.
-All gates green: web 490/490 tests, lint + tsc clean, full CI (backend 15m39s incl.
-coverage + quality gate) green. Demo 4/4 criteria verified with outcome evidence
-(real next dev + real /api/proxy against a logging stub backend; stub log shows
-`POST /generation/episodes/ep-demo/generate?enable_distribution=true`; warning- and
-error-toast screenshots). Reviews: codex pre-PR approve (opencode timed out that
-round), opencode post-PR APPROVE posted to the PR. Follow-up filed: #389 (P4.3.5,
-regenerate endpoint hardcodes enable_distribution=False). Branch deleted.
+Status: IN PROGRESS. Plan self-authored (no plan comment on the issue).
 
 ## Problem
 
-`generatePodcast` in `apps/web/src/app/(auth)/episodes/[id]/page.tsx:481-484` POSTs
-`/api/proxy/generation/episodes/{id}/generate` with no query params. The backend defaults
-`enable_distribution=false`, so platform distribution (#316's purpose) is unreachable from
-the web UI.
+`RSSFeed.public_url` stores the raw S3 URL
+(`https://{bucket}.s3.{region}.amazonaws.com/rss-feeds/{project_id}/feed.xml`).
+The bucket is ACL-disabled with no public-read policy, so the URL returns
+AccessDenied — the whole RSS distribution model (#315) is dead end-to-end.
 
-## Key codebase facts (verified by exploration)
+**Worse (found in exploration):** the existing public endpoint
+`GET /feeds/{project_id}/podcast.xml` (`src/routers/rss_feed.py:219`) is itself
+broken for real unauthenticated callers: it reads `rss_feeds` via `get_db` with
+no tenant context, and FORCE RLS (`tenant_id = current_setting('app.tenant_id',
+true)::uuid`, migration 003/014) yields zero rows → 404 for everyone. Existing
+tests mock `RSSGenerationService`, so they never caught it.
 
-- Backend `generate_podcast` (`apps/api/src/routers/generation.py:81-94`) takes
-  `enable_distribution: bool = Query(default=False)`. It is honored **only** when ALL of:
-  `settings.ENABLE_PLATFORM_DISTRIBUTION` is on (line ~200), `AWS_S3_BUCKET` set (~245),
-  and the project has active targets (`is_active`, project- or account-scoped;
-  no targets → chain falls through to the normal path, logged, no error).
-- `enable_composition` is NOT required for distribution (chain is upload → distribute).
-- #378 pre-flight warnings already flow back on the 202 (`warnings: string[]`) and the
-  page already toasts them (page.tsx:485-493).
-- `/api/proxy/[...path]/route.ts:71-73` forwards query strings verbatim.
-- The frontend has NO way to read `ENABLE_PLATFORM_DISTRIBUTION` (no feature-flag
-  endpoint exists) and no distribution-target fetch on the episode page.
+## Decision (autonomous, per issue's own recommendation)
 
-## Decision (auto-approved, not an architectural fork)
+**Option B** — serve feeds through the API's public endpoint and store that URL
+as `public_url`. No AWS bucket-policy change (Option A rejected: infra change
+outside the repo, and it would make private-bucket posture inconsistent).
 
-**Always pass `enable_distribution=true` from the generate action.** The issue offers
-"automatically or via a checkbox"; automatic is the sanctioned safe default because the
-server already performs the exact conditional the issue asks for (flag on + active
-targets), and no-ops safely otherwise. A client-side targets fetch would duplicate that
-check; a checkbox is unneeded UI (users opt in/out by activating/deactivating targets in
-the #316 UI) — YAGNI. Documented as a Known Limitation in the PR (no per-episode opt-out).
+Sub-decisions:
+- New setting `API_PUBLIC_BASE_URL` (no existing API-base setting; `FRONTEND_URL`
+  is the Next.js app). Default `http://localhost:8000`.
+- Fix the public endpoint's RLS problem by **removing the tenant-scoped DB read**:
+  the s3_key is deterministic (`rss-feeds/{project_id}/feed.xml`), so download
+  straight from S3 and 404 when the object doesn't exist. Lazy + correct; avoids
+  a SECURITY DEFINER migration. UUIDs are unguessable; feeds are public by design.
+- Keep the S3 upload + refresh hook (#382) as the content store. NOT switching the
+  endpoint to render fresh XML from DB — that would need RLS-bypassing reads of
+  episodes/projects (scope creep; freshness is already handled by rss_refresh).
 
-## Steps (TDD)
+## Steps
 
-1. Branch `fix/383-web-generate-enable-distribution` off main.
-2. RED — `apps/web/__tests__/app/episodes/[id]/page.test.tsx`:
-   - Update exact-match assertion (lines ~204-222) to expect
-     `/api/proxy/generation/episodes/ep1/generate?enable_distribution=true`.
-3. GREEN — page.tsx:482: append `?enable_distribution=true`; update the adjacent comment.
-4. Gates: jest (web), lint, tsc; deslop scan; opencode pre-PR review; PR with Known
-   Limitations; post-PR opencode review comment; demo (hard gate — outcome evidence that
-   the request carries the param); CI green + feedback triage; docs sync; merge.
+1. **Config**: add `API_PUBLIC_BASE_URL: str = "http://localhost:8000"` to
+   `src/config.py`; add to `apps/api/.env.example` and root `.env.example`.
+2. **StorageService.download_file** (`src/services/storage_service.py:96`):
+   raise `FileNotFoundError` on ClientError 404/NoSuchKey instead of generic
+   `Exception`, so callers can distinguish missing objects.
+3. **Public endpoint** (`src/routers/rss_feed.py:219-297`): drop the
+   `get_rss_feed` DB read; build `s3_key` deterministically; return 404 on
+   `FileNotFoundError`, 500 on other storage errors. Remove now-unused `db` /
+   `rss_service.get_rss_feed` usage (keep service dep for `.storage`).
+4. **public_url construction** (`src/services/rss_generation_service.py`
+   `_upload_rss_to_s3`/`_update_rss_feed` ~357/421): set
+   `public_url = f"{settings.API_PUBLIC_BASE_URL.rstrip('/')}/feeds/{project_id}/podcast.xml"`.
+   Refresh task (#382) and distribution metadata pick this up automatically.
+5. **Tests (TDD — write first)**:
+   - `tests/test_rss_feed.py`: public endpoint 200 serves S3 bytes without any
+     DB row (proves the RLS fix); 404 when S3 object missing; fixture
+     `make_mock_rss_feed` URL updated; generate-endpoint asserts new
+     `public_url` format.
+   - `tests/unit/test_rss_generation_service.py`: `public_url` = API URL, not
+     the `upload_file` return; s3_key unchanged.
+   - storage unit test: download 404 → `FileNotFoundError`.
+6. **Docs/env**: `deployment/README.md` note — staging must set
+   `API_PUBLIC_BASE_URL` to the nginx-exposed API origin.
 
 ## Acceptance criteria
 
-- A1: Clicking Generate issues POST `...?enable_distribution=true` through the proxy.
-- A2: Backend receives `enable_distribution=true` (proxy forwards query string).
-- A3: Warning-toast path (#378) still works unchanged.
-- A4: Error paths (non-ok, network) unchanged.
+- [ ] `public_url` stored for new/regenerated feeds is the API endpoint URL,
+      not the S3 URL.
+- [ ] `GET /feeds/{project_id}/podcast.xml` returns the feed XML with
+      `application/rss+xml` to a fully unauthenticated client, with a real
+      RLS-enabled DB (no mocked service on the success path).
+- [ ] Missing feed → 404 (not 500, not AccessDenied).
+- [ ] Distribution metadata (`rss_feed_url`) carries the fetchable API URL.
+- [ ] Backend suite green, coverage gate (85%) green, lint green.


### PR DESCRIPTION
## Summary
Implements #385: `RSSFeed.public_url` returned S3 AccessDenied — the bucket has no public-read policy for `rss-feeds/*`, so platforms could not ingest the feed.

- `public_url` is now built as `{API_PUBLIC_BASE_URL}/feeds/{project_id}/podcast.xml` (new `API_PUBLIC_BASE_URL` setting, default `http://localhost:8000`). Single construction site (`_upload_rss_to_s3`), so the generate endpoint, PUT update, and the #382 post-completion refresh all pick it up.
- **Second bug fixed along the way**: the public endpoint `GET /feeds/{project_id}/podcast.xml` was itself broken for real callers — it read `rss_feeds` through a tenant-less session, and FORCE RLS (`current_setting('app.tenant_id', true)`) returned zero rows → 404 for every unauthenticated fetch. Existing tests mocked the service and never caught it. The endpoint now derives the deterministic `s3_key` (`rss_feed_s3_key()`, shared helper) and serves the stored S3 object with **no DB read**.
- `StorageService.download_file` now raises `FileNotFoundError` on S3 `404`/`NoSuchKey` so the endpoint can return 404 for never-generated feeds instead of 500. The other caller (`content_extraction_service`) already had a `FileNotFoundError` branch with the right message.
- nginx routing verified: `location /api/` strips the prefix, so `https://…/api/feeds/{id}/podcast.xml` reaches the backend route.

## Acceptance Criteria
- [x] `public_url` stored for new/regenerated feeds is the API endpoint URL, not the S3 URL
- [x] `GET /feeds/{project_id}/podcast.xml` returns `application/rss+xml` to a fully unauthenticated client despite FORCE RLS (no DB read on that path; regression-guarded by tests that patch only S3)
- [x] Missing feed → 404 (not 500, not AccessDenied)
- [x] Distribution metadata `rss_feed_url` (reads `feed.public_url`) carries the fetchable API URL

## Test Plan
- [x] Unit tests written first (TDD; RED confirmed before implementation)
- [x] Full backend suite: 1810 passed, 7 skipped; total coverage 94.52% (gate 85%)
- [x] Diff coverage 100% on changed lines (diff-cover vs main)
- [x] ruff clean; mypy 269 errors vs 270 on main (one fewer; pre-existing noise, not a gate)
- [x] Internal code review (advisory): APPROVE, no findings
- [x] Cross-family review pass: opencode (GLM) — APPROVE; suggestions triaged below
- [x] Mutation sanity check: 3 mutations (URL path, 404-code mapping, s3_key format) — all killed by tests

## Known Limitations / Intentionally Deferred
- **Existing `rss_feeds` rows keep the old S3 `public_url` until regenerated** (POST `/projects/{id}/rss-feed/generate`, PUT update, or the #382 auto-refresh on next episode completion). No data migration — regeneration is the supported path and rewrites the URL.
- **Episode `<enclosure>` URLs inside the feed XML still embed raw S3 episode URLs** (`episode.s3_url`), which are also private. Platforms could fetch the feed but not the audio. Separate follow-up issue (filed alongside this PR) — out of scope for #385, which is about the feed URL itself.
- Archived (soft-deleted) projects keep serving their feed — pre-existing behavior; hard-delete offboarding already GCs `rss-feeds/*` objects via the deletion outbox.
- Review suggestion "drop `NotFound` from the S3 error-code tuple" rebutted: botocore surfaces HeadObject misses inconsistently across versions/paths (`404` vs `NotFound`); keeping both is zero-risk defense.

## Implementation Notes
Plan was self-authored (no plan comment on the issue). Option B from the issue (API-served feed URL) chosen over an S3 bucket policy: code-only, keeps the private-bucket posture, no AWS console dependency. The endpoint deliberately does **not** render fresh XML from the DB — that would need RLS-bypassing reads of episodes/projects; freshness is already handled by the #382 refresh hook.

Closes #385

https://claude.ai/code/session_01VSo6gvnhGkrvk8S1XxtWkh