### PR TITLE
[P4.3.5] Accept enable_composition/enable_distribution on /regenerate (#389)

### DIFF
--- a/apps/api/src/routers/generation.py
+++ b/apps/api/src/routers/generation.py
@@ -510,6 +510,14 @@ async def get_generation_progress_stream(
 @router.post("/episodes/{episode_id}/regenerate", status_code=status.HTTP_202_ACCEPTED)
 async def regenerate_podcast(
     episode_id: UUID,
+    enable_composition: bool = Query(
+        default=False,
+        description="Merge audio snippets after generation (requires ENABLE_AUDIO_COMPOSITION)",
+    ),
+    enable_distribution: bool = Query(
+        default=False,
+        description="Distribute to platforms after generation (requires ENABLE_PLATFORM_DISTRIBUTION)",
+    ),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -532,8 +540,8 @@ async def regenerate_podcast(
     # arguments and pass the Depends() sentinels as ``current_user`` / ``db``.
     return await generate_podcast(
         episode_id=episode_id,
-        enable_composition=False,
-        enable_distribution=False,
+        enable_composition=enable_composition,
+        enable_distribution=enable_distribution,
         current_user=current_user,
         db=db,
     )

--- a/apps/api/tests/test_distribution_wiring.py
+++ b/apps/api/tests/test_distribution_wiring.py
@@ -214,6 +214,64 @@ async def test_generate_forwards_platforms_when_distribution_enabled(client):
 
 
 @pytest.mark.asyncio
+async def test_regenerate_forwards_platforms_when_distribution_enabled(client):
+    """/regenerate accepts enable_distribution and forwards it like /generate.
+
+    Issue #389: regenerate previously hardcoded enable_distribution=False, so a
+    re-generated episode could never distribute even with active targets.
+    """
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    episode_id = await _create_episode(client, headers, project_id)
+    await _create_text_source(client, episode_id, headers)
+    await _create_webhook_target(
+        client, headers, project_id, "https://hook.example.com/republish"
+    )
+
+    with patch.object(generation_router.settings, "ENABLE_PLATFORM_DISTRIBUTION", True), \
+         patch.object(generation_router.settings, "AWS_S3_BUCKET", "test-bucket"), \
+         patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
+        mock_delay.return_value = MagicMock(id="task-redist")
+        resp = await client.post(
+            f"/generation/episodes/{episode_id}/regenerate?enable_distribution=true",
+            headers=headers,
+        )
+
+    assert resp.status_code == 202, resp.text
+    mock_delay.assert_called_once()
+    kwargs = mock_delay.call_args.kwargs["kwargs"]
+    assert kwargs["enable_distribution"] is True
+    platforms = kwargs["platforms"]
+    assert "webhook" in platforms
+    assert platforms["webhook"]["url"] == "https://hook.example.com/republish"
+
+
+@pytest.mark.asyncio
+async def test_regenerate_distribution_gated_by_feature_flag(client):
+    """?enable_distribution=true on /regenerate is a no-op when the flag is off."""
+    headers = await _register(client)
+    project_id = await _create_project(client, headers)
+    episode_id = await _create_episode(client, headers, project_id)
+    await _create_text_source(client, episode_id, headers)
+    await _create_webhook_target(
+        client, headers, project_id, "https://hook.example.com/gated"
+    )
+
+    with patch.object(generation_router.settings, "ENABLE_PLATFORM_DISTRIBUTION", False), \
+         patch("src.routers.generation.generate_podcast_task.apply_async") as mock_delay:
+        mock_delay.return_value = MagicMock(id="task-gated")
+        resp = await client.post(
+            f"/generation/episodes/{episode_id}/regenerate?enable_distribution=true",
+            headers=headers,
+        )
+
+    assert resp.status_code == 202, resp.text
+    kwargs = mock_delay.call_args.kwargs["kwargs"]
+    assert kwargs["enable_distribution"] is False
+    assert "platforms" not in kwargs
+
+
+@pytest.mark.asyncio
 async def test_generate_keeps_one_target_per_type(client):
     """Multiple active targets of the same type collapse to one platforms entry.
 

--- a/apps/api/tests/test_regenerate_endpoint.py
+++ b/apps/api/tests/test_regenerate_endpoint.py
@@ -92,6 +92,11 @@ async def test_regenerate_happy_path(client, episode_with_content):
     assert body["status"] == "queued"
     assert body["episode_id"] == episode_id
     mock_delay.assert_called_once()
+    # #389: flags are opt-in Query params; without them regenerate stays off,
+    # matching /generate's defaults.
+    task_kwargs = mock_delay.call_args.kwargs["kwargs"]
+    assert task_kwargs["enable_composition"] is False
+    assert task_kwargs["enable_distribution"] is False
 
 
 @pytest.mark.asyncio

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,82 +1,30 @@
-# Issue #385 — [P4.3.4] RSS feed public_url returns S3 AccessDenied
+# #389 — [P4.3.5] Regenerate endpoint hardcodes enable_distribution=False
 
-Status: SHIPPED — merged 2026-07-13 via PR #390 (squash, a25b5a2); issue #385 closed.
-All gates green: backend 1810/1810 (+7 skip), coverage 94.52% (diff 100%), ruff clean,
-full CI 12/12 incl. review bot (no defects). Demo 4/4 criteria with outcome evidence
-against real Postgres (FORCE RLS) + real S3, incl. 403 AccessDenied contrast on the old
-S3 URL. Reviews: opencode (GLM) APPROVE pre-PR and post-PR (posted to PR), internal
-APPROVE. Follow-up filed: #391 (P4.3.6, episode enclosure URLs are private S3 URLs).
-Plan was self-authored (no plan comment on the issue).
+**Plan (approved autonomously — no architectural fork).**
 
-**DEPLOY ACTION REQUIRED**: staging's hand-managed apps/api `.env` must set
-`API_PUBLIC_BASE_URL=https://dev.podcaststudiohub.me/api` or regenerated feeds will
-store `http://localhost:8000/...` URLs. Existing rows keep the stale S3 URL until
-regenerated (generate/PUT/#382 auto-refresh).
+## Context
+- `regenerate_podcast` (`apps/api/src/routers/generation.py:510-539`) delegates to
+  `generate_podcast` with hardcoded `enable_composition=False, enable_distribution=False`.
+- After #388 the web generate action requests distribution, but regenerate (API-only,
+  no web caller) can never distribute.
 
-## Problem
+## Decision
+Mirror `generate_podcast` exactly: same two Query params, same `default=False`.
+The issue floated defaulting `enable_distribution=true` on regenerate; rejected —
+the generate endpoint defaults to False, and an asymmetric default across the two
+endpoints is the exact class of confusion this issue fixes. Callers (web, when it
+grows a regenerate button) opt in explicitly, as #388 did for generate.
 
-`RSSFeed.public_url` stores the raw S3 URL
-(`https://{bucket}.s3.{region}.amazonaws.com/rss-feeds/{project_id}/feed.xml`).
-The bucket is ACL-disabled with no public-read policy, so the URL returns
-AccessDenied — the whole RSS distribution model (#315) is dead end-to-end.
-
-**Worse (found in exploration):** the existing public endpoint
-`GET /feeds/{project_id}/podcast.xml` (`src/routers/rss_feed.py:219`) is itself
-broken for real unauthenticated callers: it reads `rss_feeds` via `get_db` with
-no tenant context, and FORCE RLS (`tenant_id = current_setting('app.tenant_id',
-true)::uuid`, migration 003/014) yields zero rows → 404 for everyone. Existing
-tests mock `RSSGenerationService`, so they never caught it.
-
-## Decision (autonomous, per issue's own recommendation)
-
-**Option B** — serve feeds through the API's public endpoint and store that URL
-as `public_url`. No AWS bucket-policy change (Option A rejected: infra change
-outside the repo, and it would make private-bucket posture inconsistent).
-
-Sub-decisions:
-- New setting `API_PUBLIC_BASE_URL` (no existing API-base setting; `FRONTEND_URL`
-  is the Next.js app). Default `http://localhost:8000`.
-- Fix the public endpoint's RLS problem by **removing the tenant-scoped DB read**:
-  the s3_key is deterministic (`rss-feeds/{project_id}/feed.xml`), so download
-  straight from S3 and 404 when the object doesn't exist. Lazy + correct; avoids
-  a SECURITY DEFINER migration. UUIDs are unguessable; feeds are public by design.
-- Keep the S3 upload + refresh hook (#382) as the content store. NOT switching the
-  endpoint to render fresh XML from DB — that would need RLS-bypassing reads of
-  episodes/projects (scope creep; freshness is already handled by rss_refresh).
-
-## Steps
-
-1. **Config**: add `API_PUBLIC_BASE_URL: str = "http://localhost:8000"` to
-   `src/config.py`; add to `apps/api/.env.example` and root `.env.example`.
-2. **StorageService.download_file** (`src/services/storage_service.py:96`):
-   raise `FileNotFoundError` on ClientError 404/NoSuchKey instead of generic
-   `Exception`, so callers can distinguish missing objects.
-3. **Public endpoint** (`src/routers/rss_feed.py:219-297`): drop the
-   `get_rss_feed` DB read; build `s3_key` deterministically; return 404 on
-   `FileNotFoundError`, 500 on other storage errors. Remove now-unused `db` /
-   `rss_service.get_rss_feed` usage (keep service dep for `.storage`).
-4. **public_url construction** (`src/services/rss_generation_service.py`
-   `_upload_rss_to_s3`/`_update_rss_feed` ~357/421): set
-   `public_url = f"{settings.API_PUBLIC_BASE_URL.rstrip('/')}/feeds/{project_id}/podcast.xml"`.
-   Refresh task (#382) and distribution metadata pick this up automatically.
-5. **Tests (TDD — write first)**:
-   - `tests/test_rss_feed.py`: public endpoint 200 serves S3 bytes without any
-     DB row (proves the RLS fix); 404 when S3 object missing; fixture
-     `make_mock_rss_feed` URL updated; generate-endpoint asserts new
-     `public_url` format.
-   - `tests/unit/test_rss_generation_service.py`: `public_url` = API URL, not
-     the `upload_file` return; s3_key unchanged.
-   - storage unit test: download 404 → `FileNotFoundError`.
-6. **Docs/env**: `deployment/README.md` note — staging must set
-   `API_PUBLIC_BASE_URL` to the nginx-exposed API origin.
-
-## Acceptance criteria
-
-- [x] `public_url` stored for new/regenerated feeds is the API endpoint URL,
-      not the S3 URL.
-- [x] `GET /feeds/{project_id}/podcast.xml` returns the feed XML with
-      `application/rss+xml` to a fully unauthenticated client, with a real
-      RLS-enabled DB (no mocked service on the success path).
-- [x] Missing feed → 404 (not 500, not AccessDenied).
-- [x] Distribution metadata (`rss_feed_url`) carries the fetchable API URL.
-- [x] Backend suite green, coverage gate (85%) green, lint green.
+## Steps (TDD)
+1. **RED** — tests:
+   - `tests/test_distribution_wiring.py`: `test_regenerate_forwards_platforms_when_distribution_enabled`
+     — webhook target + settings patched, POST `/regenerate?enable_distribution=true`,
+     assert task kwargs `enable_distribution is True` and platforms mapping present
+     (mirrors the existing generate test).
+   - `tests/test_regenerate_endpoint.py`: happy path additionally asserts task kwargs
+     `enable_distribution is False` by default.
+2. **GREEN** — `regenerate_podcast`: add `enable_composition` / `enable_distribution`
+   Query params (defaults False, same descriptions), pass through as keyword args
+   (keep the keyword-arg delegation comment re: positional misalignment, #213).
+3. Quality gate: pytest, ruff, third-party review (opencode/GLM pre-PR + post-PR).
+4. PR → demo (Showboat, API-only) → CI gate → docs sync → merge.


### PR DESCRIPTION
Closes #389.

## Problem
`regenerate_podcast` delegated to `generate_podcast` with `enable_composition=False, enable_distribution=False` hardcoded. After #388, first-time generation from the web UI requests distribution, but a regenerate (API-only today) silently dropped it — regenerated episodes never distributed even with active targets and `ENABLE_PLATFORM_DISTRIBUTION` on.

## Fix
Mirror the `/generate` Query params on `/regenerate` (`enable_composition`, `enable_distribution`, both `default=False`) and pass them through, keeping the explicit keyword-arg delegation (#213 positional-misalignment guard).

**Default choice:** the issue floated defaulting `enable_distribution=true` on regenerate; kept `False` instead for symmetry with `/generate` — callers opt in explicitly, as the web generate action does since #388.

## Tests (TDD, RED→GREEN)
- `test_regenerate_forwards_platforms_when_distribution_enabled` — `?enable_distribution=true` + active webhook target + flag on → task kwargs `enable_distribution=True` with platforms mapping (mirrors the generate test).
- `test_regenerate_distribution_gated_by_feature_flag` — `?enable_distribution=true` with `ENABLE_PLATFORM_DISTRIBUTION=False` → task kwargs `enable_distribution=False`, no platforms (added from opencode review feedback).
- Regenerate happy path now asserts both flags default to `False` in task kwargs.

Full backend suite: 1811 passed, 7 skipped. Ruff clean.

## Reviews
- Pre-PR third-party review: opencode (GLM) — **APPROVE**, two minor test-gap notes; the feature-flag negative test was added, the symmetric `enable_composition=true` test skipped (identical delegation path already asserted by the pass-through and default tests).

## Known Limitations
- The web UI still has no regenerate call; this makes distribution *callable* on regenerate via the API, matching the issue's minimum bar.

https://claude.ai/code/session_01VSo6gvnhGkrvk8S1XxtWkh