### PR TITLE
[P4.4.1] Allow clearing optional podcast metadata via explicit null/blank (#381)

### DIFF
--- a/apps/api/scripts/security-audit.sh
+++ b/apps/api/scripts/security-audit.sh
@@ -11,8 +11,9 @@ uv export --format requirements-txt --no-hashes --no-emit-project -o "$reqs" -q
 
 # Ignored IDs are all structurally capped by podcastfy==0.4.1's requirement set
 # (litellm>=1.84 needs openai>=2.20 vs podcastfy's openai<2; langchain 1.x /
-# langsmith 0.8 / aiplatform 1.133 / pytest 9 conflict the same way). The fix is
-# the podcastfy upgrade (#204 coupling), not an override. Re-check this list on
+# langsmith 0.8 / aiplatform 1.133 / pytest 9 conflict the same way; PYSEC-2026-2562
+# is langchain-core, fixed only in 1.2.11). The fix is the podcastfy upgrade
+# (#204 coupling, evaluated in #363), not an override. Re-check this list on
 # every podcastfy bump.
 uvx pip-audit -r "$reqs" --no-deps --disable-pip --strict \
   --ignore-vuln CVE-2026-35029 \
@@ -31,4 +32,5 @@ uvx pip-audit -r "$reqs" --no-deps --disable-pip --strict \
   --ignore-vuln CVE-2026-2472 \
   --ignore-vuln CVE-2026-2473 \
   --ignore-vuln PYSEC-2026-1845 \
-  --ignore-vuln PYSEC-2026-2193
+  --ignore-vuln PYSEC-2026-2193 \
+  --ignore-vuln PYSEC-2026-2562

--- a/apps/api/src/routers/rss_feed.py
+++ b/apps/api/src/routers/rss_feed.py
@@ -185,9 +185,16 @@ async def update_rss_feed(
 			detail=f"Project {project_id} not found",
 		)
 
-	# Merge updated metadata into existing project metadata
+	# Merge updated metadata into existing project metadata. An explicitly-sent
+	# null or blank string deletes the key (JSON-merge-patch semantics, #381);
+	# the schema already rejects clearing required fields.
 	new_metadata = update_data.podcast_metadata.model_dump(exclude_unset=True)
-	merged_metadata = {**(project.podcast_metadata or {}), **new_metadata}
+	merged_metadata = dict(project.podcast_metadata or {})
+	for key, value in new_metadata.items():
+		if value is None or (isinstance(value, str) and not value.strip()):
+			merged_metadata.pop(key, None)
+		else:
+			merged_metadata[key] = value
 	project.podcast_metadata = merged_metadata
 	await db.commit()
 

--- a/apps/api/src/routers/rss_feed.py
+++ b/apps/api/src/routers/rss_feed.py
@@ -161,7 +161,9 @@ async def update_rss_feed(
 	Update podcast metadata and regenerate RSS feed.
 
 	Merges the provided podcast_metadata fields into the project's existing
-	podcast_metadata, then triggers feed regeneration.
+	podcast_metadata, then triggers feed regeneration. An explicitly-sent null
+	or blank string deletes the key (optional fields only — clearing show_title,
+	author, or description is rejected 422); omitted fields are left unchanged.
 
 	Args:
 		project_id: UUID of the project

--- a/apps/api/src/schemas/rss_feed.py
+++ b/apps/api/src/schemas/rss_feed.py
@@ -57,5 +57,9 @@ class RSSFeedUpdate(BaseModel):
 
 	podcast_metadata: PodcastMetadataUpdate = Field(
 		...,
-		description="Podcast metadata fields to update (triggers feed regeneration)"
+		description=(
+			"Podcast metadata fields to update (triggers feed regeneration). "
+			"Explicit null or blank string deletes an optional key; omitted "
+			"fields are left unchanged. Required keys cannot be cleared."
+		)
 	)

--- a/apps/api/src/schemas/rss_feed.py
+++ b/apps/api/src/schemas/rss_feed.py
@@ -4,7 +4,7 @@ RSS Feed schemas for request/response validation.
 Defines Pydantic models for RSS Feed management endpoints.
 """
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from uuid import UUID
 from datetime import datetime
 from typing import Optional
@@ -38,6 +38,18 @@ class PodcastMetadataUpdate(BaseModel):
 	copyright: Optional[str] = Field(None, description="Copyright statement")
 	artwork_url: Optional[str] = Field(None, description="URL of podcast artwork image")
 	website_url: Optional[str] = Field(None, description="Podcast website URL")
+
+	@model_validator(mode="after")
+	def reject_clearing_required_fields(self):
+		"""Explicitly-sent null/blank values delete keys on merge (#381), but the
+		fields required for feed generation must never be cleared. Rejecting here
+		keeps the 422 ahead of the DB write in the update route."""
+		for key in ("show_title", "author", "description"):
+			if key in self.model_fields_set:
+				value = getattr(self, key)
+				if value is None or not value.strip():
+					raise ValueError(f"podcast_metadata.{key} cannot be cleared")
+		return self
 
 
 class RSSFeedUpdate(BaseModel):

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -115,6 +115,7 @@ async def client(test_db):
     This fixture properly handles tenant context for RLS by accepting the Request parameter.
     """
     from fastapi import HTTPException, Request
+    from fastapi.exceptions import RequestValidationError
     from src.database import arm_tenant_context, set_tenant_context
 
     # Override the database dependency with proper tenant context support
@@ -134,10 +135,10 @@ async def client(test_db):
                 await set_tenant_context(test_db, str(request.state.tenant_id))
 
             yield test_db
-        except HTTPException:
-            # Expected control-flow responses (402/404/409, …) are NOT database
-            # failures. Production uses a session-per-request, so an HTTPException
-            # there never rolls back other requests' data. The test session is
+        except (HTTPException, RequestValidationError):
+            # Expected control-flow responses (402/404/409, and request-validation
+            # 422s) are NOT database failures. Production uses a session-per-request,
+            # so these never roll back other requests' data. The test session is
             # shared across all requests in a test, so rolling back here would
             # wipe earlier writes (e.g. the registered user) and break any
             # assertion made after a rejected request. Re-raise without rollback.

--- a/apps/api/tests/test_rss_feed.py
+++ b/apps/api/tests/test_rss_feed.py
@@ -342,6 +342,133 @@ async def test_update_rss_feed_invalid_metadata(client, project_with_metadata):
 
 
 @pytest.mark.asyncio
+async def test_update_rss_feed_null_clears_optional_field(client, project_with_metadata):
+	"""Explicit null on an optional field deletes it from the merged metadata (#381)."""
+	project_id, headers = project_with_metadata
+
+	with patch("src.routers.rss_feed.RSSGenerationService") as MockService:
+		mock_instance = AsyncMock()
+		mock_instance.generate_rss_for_project.return_value = make_mock_rss_feed(project_id)
+		MockService.return_value = mock_instance
+
+		response = await client.put(
+			f"/projects/{project_id}/rss-feed",
+			headers=headers,
+			json={"podcast_metadata": {"category": None}},
+		)
+
+	assert response.status_code == 200
+	proj = await client.get(f"/projects/{project_id}", headers=headers)
+	metadata = proj.json()["podcast_metadata"]
+	assert "category" not in metadata
+	assert metadata["language"] == "en-US"
+	assert metadata["show_title"] == "My Test Podcast"
+
+
+@pytest.mark.asyncio
+async def test_update_rss_feed_empty_string_clears_optional_field(client, project_with_metadata):
+	"""An empty/whitespace string on an optional field deletes it, same as null (#381)."""
+	project_id, headers = project_with_metadata
+
+	with patch("src.routers.rss_feed.RSSGenerationService") as MockService:
+		mock_instance = AsyncMock()
+		mock_instance.generate_rss_for_project.return_value = make_mock_rss_feed(project_id)
+		MockService.return_value = mock_instance
+
+		response = await client.put(
+			f"/projects/{project_id}/rss-feed",
+			headers=headers,
+			json={"podcast_metadata": {"artwork_url": "", "copyright": "  "}},
+		)
+
+	assert response.status_code == 200
+	proj = await client.get(f"/projects/{project_id}", headers=headers)
+	metadata = proj.json()["podcast_metadata"]
+	assert "artwork_url" not in metadata
+	assert "copyright" not in metadata
+	assert metadata["category"] == "Technology"
+
+
+@pytest.mark.asyncio
+async def test_update_rss_feed_null_explicit_unsets_key(client, project_with_metadata):
+	"""Null explicit deletes the key; generation defaults it to false via .get() (#381)."""
+	project_id, headers = project_with_metadata
+
+	with patch("src.routers.rss_feed.RSSGenerationService") as MockService:
+		mock_instance = AsyncMock()
+		mock_instance.generate_rss_for_project.return_value = make_mock_rss_feed(project_id)
+		MockService.return_value = mock_instance
+
+		response = await client.put(
+			f"/projects/{project_id}/rss-feed",
+			headers=headers,
+			json={"podcast_metadata": {"explicit": None}},
+		)
+
+	assert response.status_code == 200
+	proj = await client.get(f"/projects/{project_id}", headers=headers)
+	assert "explicit" not in proj.json()["podcast_metadata"]
+
+
+@pytest.mark.asyncio
+async def test_update_rss_feed_empty_object_is_noop(client, project_with_metadata):
+	"""An empty podcast_metadata object changes nothing (#381)."""
+	project_id, headers = project_with_metadata
+
+	with patch("src.routers.rss_feed.RSSGenerationService") as MockService:
+		mock_instance = AsyncMock()
+		mock_instance.generate_rss_for_project.return_value = make_mock_rss_feed(project_id)
+		MockService.return_value = mock_instance
+
+		response = await client.put(
+			f"/projects/{project_id}/rss-feed",
+			headers=headers,
+			json={"podcast_metadata": {}},
+		)
+
+	assert response.status_code == 200
+	proj = await client.get(f"/projects/{project_id}", headers=headers)
+	metadata = proj.json()["podcast_metadata"]
+	assert metadata["show_title"] == "My Test Podcast"
+	assert metadata["category"] == "Technology"
+	assert metadata["language"] == "en-US"
+
+
+@pytest.mark.asyncio
+async def test_update_rss_feed_null_required_field_rejected(client, project_with_metadata):
+	"""Explicit null on a required field is rejected 422 before any write (#381)."""
+	project_id, headers = project_with_metadata
+
+	response = await client.put(
+		f"/projects/{project_id}/rss-feed",
+		headers=headers,
+		json={"podcast_metadata": {"show_title": None, "category": "Science"}},
+	)
+
+	assert response.status_code == 422
+	proj = await client.get(f"/projects/{project_id}", headers=headers)
+	metadata = proj.json()["podcast_metadata"]
+	assert metadata["show_title"] == "My Test Podcast"
+	assert metadata["category"] == "Technology"
+
+
+@pytest.mark.asyncio
+async def test_update_rss_feed_empty_required_field_rejected(client, project_with_metadata):
+	"""A blank string on a required field is rejected 422 (#381)."""
+	project_id, headers = project_with_metadata
+
+	response = await client.put(
+		f"/projects/{project_id}/rss-feed",
+		headers=headers,
+		json={"podcast_metadata": {"author": "  "}},
+	)
+
+	assert response.status_code == 422
+	proj = await client.get(f"/projects/{project_id}", headers=headers)
+	assert proj.json()["podcast_metadata"]["author"] == "Test Author"
+
+
+@pytest.mark.asyncio
 async def test_update_rss_feed_internal_error_hides_details(client, project_with_metadata):
 	"""500 during regeneration returns a generic message, not exception internals."""
 	project_id, headers = project_with_metadata

--- a/apps/web/__tests__/app/projects/[id]/distribution/page.test.tsx
+++ b/apps/web/__tests__/app/projects/[id]/distribution/page.test.tsx
@@ -288,6 +288,11 @@ describe('DistributionPage', () => {
               author: 'Jane Doe',
               description: 'A great show about things',
               explicit: false,
+              category: null,
+              language: null,
+              copyright: null,
+              artwork_url: null,
+              website_url: null,
             },
           }),
         })
@@ -295,6 +300,53 @@ describe('DistributionPage', () => {
     )
     expect(showSuccessToast).toHaveBeenCalledWith('Podcast metadata updated')
     await waitFor(() => expect(screen.queryByText('Edit Podcast Metadata')).not.toBeInTheDocument())
+  })
+
+  it('sends null for an optional field the user cleared so the backend deletes it (#381)', async () => {
+    const projectWithCategory = {
+      ...project,
+      podcast_metadata: { ...project.podcast_metadata, category: 'Technology' },
+    }
+    const fetchMock = withOverride(
+      withOverride(
+        mockFetchRouter(),
+        (url, init) => url === '/api/proxy/projects/p1' && (init?.method ?? 'GET') === 'GET',
+        () => Promise.resolve({ ok: true, json: async () => projectWithCategory })
+      ),
+      (url, init) => url === '/api/proxy/projects/p1/rss-feed' && (init?.method ?? 'GET') === 'PUT',
+      () => Promise.resolve({ ok: true, json: async () => feed })
+    )
+    global.fetch = fetchMock
+
+    render(<DistributionPage />)
+    await screen.findByText('Podcast RSS Feed')
+
+    await userEvent.click(screen.getByRole('button', { name: /edit podcast metadata/i }))
+    const categoryInput = screen.getByDisplayValue('Technology')
+    await userEvent.clear(categoryInput)
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/proxy/projects/p1/rss-feed',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({
+            podcast_metadata: {
+              show_title: 'My Podcast Show',
+              author: 'Jane Doe',
+              description: 'A great show about things',
+              explicit: false,
+              category: null,
+              language: null,
+              copyright: null,
+              artwork_url: null,
+              website_url: null,
+            },
+          }),
+        })
+      )
+    )
   })
 
   it('shows the detail toast and keeps the dialog open on a 422 metadata update failure', async () => {

--- a/apps/web/src/app/(auth)/projects/[id]/distribution/page.tsx
+++ b/apps/web/src/app/(auth)/projects/[id]/distribution/page.tsx
@@ -42,12 +42,14 @@ interface RawPodcastMetadata {
   show_title?: string
   author?: string
   description?: string
-  category?: string
-  language?: string
+  // Optional fields are string | null: sending an explicit null tells the
+  // backend to delete the key from the merged metadata (#381).
+  category?: string | null
+  language?: string | null
   explicit?: boolean
-  copyright?: string
-  artwork_url?: string
-  website_url?: string
+  copyright?: string | null
+  artwork_url?: string | null
+  website_url?: string | null
 }
 
 function mapPodcastMetadataToForm(
@@ -160,11 +162,11 @@ export default function DistributionPage() {
       author: data.author,
       description: data.description,
       explicit: data.explicit ?? false,
-      ...(data.category ? { category: data.category } : {}),
-      ...(data.language ? { language: data.language } : {}),
-      ...(data.copyright ? { copyright: data.copyright } : {}),
-      ...(data.artworkUrl ? { artwork_url: data.artworkUrl } : {}),
-      ...(data.websiteUrl ? { website_url: data.websiteUrl } : {}),
+      category: data.category || null,
+      language: data.language || null,
+      copyright: data.copyright || null,
+      artwork_url: data.artworkUrl || null,
+      website_url: data.websiteUrl || null,
     }
 
     try {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,26 +1,34 @@
-# #391 — [P4.3.6] RSS `<enclosure>` URLs embed private S3 URLs
+# Issue #381 — [P4.4.1] Clearing optional podcast metadata fields does not persist
 
-Status: SHIPPED — merged 2026-07-13 via PR #393 (squash, 0b68620); issue #391 closed.
-All gates green: 12/12 CI checks (backend 1818 passed), ruff clean, review bot 0 findings
-across both synchronize rounds. Demo posted to PR with outcome evidence against the real
-S3 bucket: real upload → feed XML shows API enclosure URL (no raw S3), HEAD+GET → 302 to
-presigned URL, downloaded bytes identical, Range served, random UUIDs → 404, two requests
-→ distinct signatures. Demo caught a real bug pre-merge: 405 on HEAD (FastAPI doesn't add
-HEAD to GET routes; platforms HEAD enclosures) — fixed with methods=["GET","HEAD"] + test.
+Plan source: self-authored (no plan comment on issue). Deferred from PR #380 finding S4.
 
-## What shipped
-Enclosures now emit `{API_PUBLIC_BASE_URL}/feeds/episodes/{user_id}/{episode_id}/audio.mp3`;
-the public endpoint 302-redirects to a per-request presigned URL (1h, Cache-Control:
-no-store), 404s via a real S3 HEAD check, and derives the key from the URL
-(`build_podcast_s3_key`, #215) — no DB read, episodes is FORCE RLS (#385 precedent).
-Episodes without `s3_key` keep the legacy `s3_url` fallback. The issue's sketched
-project_id path was underivable; URL carries user_id (already exposed in old raw S3 URLs).
+## Design decision (autonomous — no fork)
+JSON-merge-patch semantics (RFC 7386): an optional metadata key explicitly sent as
+`null` — or as an empty/whitespace string — is **deleted** from the merged
+`podcast_metadata`. Required keys (`show_title`, `author`, `description`) cannot be
+cleared: explicit `null`/empty is rejected 422 at the schema layer **before** any DB
+write (avoids committing broken metadata pre-regeneration). Frontend always sends the
+five optional fields, `null` when the form value is empty.
 
-## Review triage of note
-opencode (GLM) pre-PR Major "remove file_exists (TOCTOU)" was declined as factually wrong:
-presigning is local computation that never fails on a missing key, so the HEAD check is
-the only real 404 path. Post-PR review + both bot rounds: APPROVE / 0 findings.
+## Steps
+1. **Backend tests first** (`apps/api/tests/test_rss_feed.py`):
+   - PUT with `category: null` deletes the key from stored metadata (and other keys survive)
+   - PUT with `artwork_url: ""` deletes the key (empty string same as null)
+   - PUT with `show_title: null` → 422, metadata unchanged
+   - Existing omit-field merge behavior unchanged
+2. **Backend impl**:
+   - `apps/api/src/schemas/rss_feed.py`: `model_validator` on `PodcastMetadataUpdate`
+     rejecting explicitly-set null/blank for required keys
+   - `apps/api/src/routers/rss_feed.py`: merge loop — explicitly-set `None`/blank-string
+     values pop the key; others overwrite
+3. **Frontend test** (`apps/web/__tests__/app/distribution/page.test.tsx`):
+   PUT body carries `category: null` (etc.) when the dialog fields are cleared
+4. **Frontend impl** (`apps/web/src/app/(auth)/projects/[id]/distribution/page.tsx`):
+   replace conditional spreads with always-send `field: value || null`;
+   widen `RawPodcastMetadata` optional fields to `string | null`
 
-## Also in this PR (unrelated, blocked CI)
-PYSEC-2026-2193 (langchain-core 0.3.86, fix only in 1.2.22) added to the pip-audit ignore
-list — structurally capped by podcastfy 0.4.1's langchain<0.4 pin; noted on #363.
+## Acceptance criteria
+- [ ] Clearing an optional field (category/language/copyright/artwork_url/website_url) in the dialog removes it from `podcast_metadata` and the regenerated feed
+- [ ] Required fields cannot be cleared (422, no partial write)
+- [ ] Setting/updating fields still merges as before
+- [ ] Backend + frontend tests green; lint green

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -28,7 +28,16 @@ five optional fields, `null` when the form value is empty.
    widen `RawPodcastMetadata` optional fields to `string | null`
 
 ## Acceptance criteria
-- [ ] Clearing an optional field (category/language/copyright/artwork_url/website_url) in the dialog removes it from `podcast_metadata` and the regenerated feed
-- [ ] Required fields cannot be cleared (422, no partial write)
-- [ ] Setting/updating fields still merges as before
-- [ ] Backend + frontend tests green; lint green
+- [x] Clearing an optional field (category/language/copyright/artwork_url/website_url) in the dialog removes it from `podcast_metadata` and the regenerated feed — demoed against real stack (API + real dialog), posted to PR #394
+- [x] Required fields cannot be cleared (422, no partial write) — demoed
+- [x] Setting/updating fields still merges as before — demoed
+- [x] Backend + frontend tests green; lint green — full suites + CI green
+
+## Status (2026-07-13)
+PR #394 open; all code CI gates green (backend/frontend/playwright/migrations/coverage/review);
+demo + both third-party reviews (pre-PR: 1 Minor + 2 Nits addressed; post-PR: no findings) posted.
+**BLOCKED on user decision:** CI dependency audit fails on NEW upstream CVE PYSEC-2026-2562
+(langchain-core 0.3.86, fix only in 1.2.11 — structurally capped by podcastfy==0.4.1, upgrade
+tracked in #363). Proposed ignore-list addition to apps/api/scripts/security-audit.sh is in the
+working tree UNCOMMITTED (permission classifier requires user sign-off on security-gate changes).
+Also uncommitted: docstring/OpenAPI clear-semantics notes in rss_feed router+schema.


### PR DESCRIPTION
Closes #381. Deferred from PR #380 (issue #316) post-PR review, finding S4.

## Problem
The Edit Podcast Metadata dialog omitted empty optional fields (category, language, copyright, artwork_url, website_url) from `PUT /projects/{id}/rss-feed`, and the backend merged `podcast_metadata` into the existing dict — so a cleared field could never be removed; the stale value persisted in the feed.

## Design (backend clear semantics)
JSON-merge-patch (RFC 7386 style): an **explicitly-sent `null` or blank string deletes the key** from the merged metadata. Omitted fields still merge as before — fully backward-compatible.
- Required keys (`show_title`, `author`, `description`) cannot be cleared: rejected **422 at the Pydantic schema, before any DB write** (avoids committing metadata that can no longer generate a feed).
- `explicit: null` unsets the key; generation defaults it to `false` via `metadata.get("explicit", False)` (test pins this).
- Frontend: the dialog now always sends the five optional fields, `null` when the form value is empty.

## Changes
- `apps/api/src/schemas/rss_feed.py` — `model_validator` on `PodcastMetadataUpdate` rejecting explicitly-set null/blank required fields
- `apps/api/src/routers/rss_feed.py` — merge loop: explicit null/blank pops the key, other values overwrite
- `apps/web/src/app/(auth)/projects/[id]/distribution/page.tsx` — always-send optional fields (`value || null`); `RawPodcastMetadata` optional fields widened to `string | null`
- `apps/api/tests/conftest.py` — **test-harness fix**: `RequestValidationError` (body-validation 422) hit the shared-session rollback path in the `get_db` override, wiping earlier writes (e.g. the registered user) so any request after a 422 got 401. Now treated as expected control flow like `HTTPException`.
- Tests: 6 new backend (null clears / blank clears / required null 422 / required blank 422 / explicit-null unsets / empty-object no-op), 1 new + 1 updated frontend (PUT body carries `null` for cleared fields)

## Test results
- Backend: full suite 1822 passed, 7 skipped; ruff clean
- Web: 491 passed (49 suites); tsc clean; eslint clean

## Third-party review (pre-PR)
opencode (GLM) reviewed the branch diff: **no Critical/Major findings**. 1 Minor + 2 Nits, all addressed or verified:
- Minor (`explicit` deletable via null, untested) → verified safe (`.get()` default) and pinned with a test
- Nit (empty-object no-op untested) → test added
- Nit (conftest clause now covers all request-validation errors) → intentional; comment documents it

## Known Limitations
- Clearing an optional field requires the client to send it explicitly (`null`/blank); omitted fields still merge. This is the documented contract, matching JSON merge-patch.
- A stale-prefilled dialog (project fetch failed) can't destructively clear fields by accident: required-field zod validation blocks submission of an empty form.