### PR TITLE
[P4.5] Evaluate podcastfy 0.4.1→0.4.3: defer upgrade, document evaluation (#363)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,11 @@ The pin is intentional: task kwargs are coupled to the upstream call signature (
 bump the version in `apps/api/pyproject.toml`, run `uv sync`, and re-check the call signatures in
 `src/services/` and `src/tasks/` before relying on it.
 
+**0.4.2/0.4.3 were evaluated 2026-07-13 and deferred** (#363): 0.4.2+ imports `playwright` at module
+top without declaring it (breaks app startup), offers no benefit to our call paths, and does not clear
+the langchain CVEs on the pip-audit ignore list. See `apps/api/docs/podcastfy-0.4.3-evaluation.md` for
+the full evaluation and re-evaluation triggers (chiefly: upstream langchain 1.x support).
+
 Engine capabilities (provided by the dependency): multi-modal input (websites, YouTube, PDFs, images,
 text, topics); 100+ LLMs via LiteLLM + Gemini; TTS via OpenAI, ElevenLabs, Gemini multi-speaker, and
 Edge TTS; short-form and long-form ("content chunking with contextual linking") generation.

--- a/apps/api/docs/demos/363-podcastfy-043-evaluation-demo.md
+++ b/apps/api/docs/demos/363-podcastfy-043-evaluation-demo.md
@@ -1,0 +1,87 @@
+# Demo: #363 podcastfy 0.4.1→0.4.3 evaluation (verdict: defer)
+
+*2026-07-13T19:44:05Z*
+
+Issue #363 asked for a deliberate evaluation of upgrading the podcastfy engine 0.4.1→0.4.3. Each checklist item below is mapped to executable evidence. Verdict: DEFER — full rationale in apps/api/docs/podcastfy-0.4.3-evaluation.md. The upstream sdists used for the diff are re-downloaded here so evidence is reproducible.
+
+```bash
+cd /tmp && rm -rf pf-demo && mkdir pf-demo && cd pf-demo && for v in 0.4.1 0.4.3; do curl -s https://pypi.org/pypi/podcastfy/$v/json | python3 -c "import json,sys; d=json.load(sys.stdin); print([u[\"url\"] for u in d[\"urls\"] if u[\"packagetype\"]==\"sdist\"][0])" | xargs curl -sL -o pf-$v.tar.gz && tar xzf pf-$v.tar.gz; done && ls -d podcastfy-*/
+```
+
+```output
+podcastfy-0.4.1/
+podcastfy-0.4.3/
+```
+
+**Checklist 1 — upstream diff review.** The generation entrypoint we're coupled to (#204), `client.py`, is byte-identical between 0.4.1 and 0.4.3 — no signature risk:
+
+```bash
+cmp /tmp/pf-demo/podcastfy-0.4.1/podcastfy/client.py /tmp/pf-demo/podcastfy-0.4.3/podcastfy/client.py && echo "client.py IDENTICAL 0.4.1 vs 0.4.3"
+```
+
+```output
+client.py IDENTICAL 0.4.1 vs 0.4.3
+```
+
+**The blocker**: 0.4.3 imports playwright at module top of website_extractor.py — a module our app imports at startup — yet declares no playwright dependency:
+
+```bash
+grep -n "from playwright" /tmp/pf-demo/podcastfy-0.4.3/podcastfy/content_parser/website_extractor.py; echo "--- playwright in 0.4.3 declared deps?"; grep -c playwright /tmp/pf-demo/podcastfy-0.4.3/pyproject.toml || echo "NOT DECLARED (0 matches) -> ModuleNotFoundError at import; app cannot boot"
+```
+
+```output
+16:from playwright.sync_api import sync_playwright
+--- playwright in 0.4.3 declared deps?
+0
+NOT DECLARED (0 matches) -> ModuleNotFoundError at import; app cannot boot
+```
+
+**Checklist 2+3 — bump + uv sync + call-site recheck.** The spike was executed live on this branch (pin→0.4.3, `uv lock` resolved, `uv sync` installed, then the #204 signature-guard suite failed collection with `ModuleNotFoundError: No module named 'playwright'` via the exact import chain main.py guards). Spike transcript is in the evaluation doc. The spike was then reverted; proof the repo remains pinned and green on 0.4.1:
+
+```bash
+grep -n "podcastfy==" apps/api/pyproject.toml | head -1
+```
+
+```output
+26:    "podcastfy==0.4.1",  # pinned: task kwargs are coupled to this signature (see #204); bumping needs a signature recheck
+```
+
+```bash
+cd apps/api && uv run pytest tests/test_imports.py tests/unit/test_podcast_generation_task.py -q 2>&1 | tail -1 | sed 's/in [0-9.]*s/in <time>/'
+```
+
+```output
+============================== 32 passed in <time> ==============================
+```
+
+**Checklist 4 — pip-audit ignore list.** Staying on 0.4.1 means the capped ignore list is unchanged; the script comment no longer implies a 0.4.x bump clears the langchain CVEs (0.4.3 still pins langchain <0.4):
+
+```bash
+grep -n "langchain <0.4\|langchain>=0.3.3,<0.4.0" /tmp/pf-demo/podcastfy-0.4.3/pyproject.toml; grep -n "langchain" /tmp/pf-demo/podcastfy-0.4.3/pyproject.toml | head -2; sed -n "15,18p" apps/api/scripts/security-audit.sh
+```
+
+```output
+33:langchain = "^0.3.3"
+34:langchain-google-vertexai = "^2.0.4"
+# is langchain-core, fixed only in 1.2.11). The fix is a podcastfy release that
+# supports langchain 1.x — 0.4.2/0.4.3 do NOT (evaluated & deferred in #363, see
+# docs/podcastfy-0.4.3-evaluation.md) — not an override. Re-check this list on
+# every podcastfy bump.
+```
+
+**Checklist 5 — full suite + e2e generation:** N/A under the defer verdict — no dependency or code changed on main; the branch diff is docs/comments only (CI runs the full suite on the PR regardless).
+
+**Checklist 6 — CLAUDE.md pin note updated** with the verdict and a pointer to the evaluation doc:
+
+```bash
+grep -n -A3 "0.4.2/0.4.3 were evaluated" CLAUDE.md
+```
+
+```output
+60:**0.4.2/0.4.3 were evaluated 2026-07-13 and deferred** (#363): 0.4.2+ imports `playwright` at module
+61-top without declaring it (breaks app startup), offers no benefit to our call paths, and does not clear
+62-the langchain CVEs on the pip-audit ignore list. See `apps/api/docs/podcastfy-0.4.3-evaluation.md` for
+63-the full evaluation and re-evaluation triggers (chiefly: upstream langchain 1.x support).
+```
+
+**Outcome**: evaluation complete, verdict DEFER, re-evaluation triggers documented (upstream langchain 1.x support chief among them). Dependabot's podcastfy ignore stays in place.

--- a/apps/api/docs/podcastfy-0.4.3-evaluation.md
+++ b/apps/api/docs/podcastfy-0.4.3-evaluation.md
@@ -1,0 +1,77 @@
+# Podcastfy 0.4.1 → 0.4.3 upgrade evaluation (issue #363)
+
+**Date**: 2026-07-13
+**Verdict**: **Defer.** Stay pinned on `podcastfy==0.4.1`. The upgrade breaks app
+startup out of the box (undeclared `playwright` import), delivers no functional
+benefit to any code path this product uses, and does not clear the two CVEs riding
+on the langchain pin.
+
+## Method
+
+Upstream publishes no git tags past `v0.4.0`, so the evaluation diffed the PyPI
+sdists (`podcastfy-0.4.1` / `0.4.2` / `0.4.3`), then ran an empirical spike on a
+branch: bump the pin, `uv lock && uv sync --all-extras`, run
+`tests/test_imports.py` + `tests/unit/test_podcast_generation_task.py`
+(the #204 signature guards).
+
+## What changed upstream
+
+All substantive changes are in **0.4.2**; 0.4.3 only bumps `httpx ^0.27.2 → ^0.28.1`
+in its own pyproject. (`podcastfy.__version__` still reports `"0.4.2"` in the 0.4.3
+sdist — upstream release hygiene is loose.)
+
+| Area | Change | Impact on us |
+|---|---|---|
+| `client.py` (`generate_podcast`) | **Byte-identical** to 0.4.1 | None — the #204 Celery kwarg coupling is signature-safe |
+| `content_generator.py` | Default `model_name` `gemini-1.5-pro-latest` → `gemini-2.5-flash` (only hunk) | None — we pass `model_name` explicitly (`GEMINI_MODEL_NAME` env) in `script_generation_service.py` |
+| `content_parser/website_extractor.py` | `extract_content` now fetches via Playwright headless Chromium; **imports `playwright.sync_api` at module top** | **Breaks import.** We import `WebsiteExtractor` in `content_extraction_service.py` and the `main.py` startup guard. We never call `extract_content` (bypassed for SSRF safety, #206/#234); the helpers we do use (`normalize_url`, `remove_unwanted_elements`, `clean_content`, `user_agent`, `timeout`) are unchanged |
+| `content_parser/content_extractor.py` | Topic grounding rewritten on `google-genai` / `gemini-2.5-flash` (old path used retired `gemini-1.5-flash-002`) | None — the `topic=` path is not wired from our router |
+| `tts/providers/gemini.py` | Parses `language_code` from voice name; drops hardcoded `en-US` + `FEMALE` gender | None for our current providers (`openai`, `gemini_multi`→`geminimulti`) |
+| `pyproject` deps | `openai ^1.56` (still <2), `httpx ^0.28.1`, `edge-tts 6→7` (major), `google-genai ^1.46` added | Lock churn (see spike); **`playwright` NOT declared** despite the top-level import — upstream packaging bug |
+| Misc | New `podcastfy/api/fast_app.py` (unused), default LLM config → gemini-2.5-flash, ending message text | None |
+
+## Spike results
+
+`uv lock` resolves cleanly: `edge-tts 6.1.19→7.2.8`, `google-genai 1.2.0→1.75.0`,
+`httpx 0.27.2→0.28.1`, `langchain-google-vertexai 2.0.7→2.1.2`, plus new transitives
+`bottleneck`, `numexpr`, `pyarrow 21`, `tabulate`, `validators`.
+
+But the import guard fails immediately:
+
+```
+tests/unit/test_podcast_generation_task.py:27: from podcastfy.client import generate_podcast
+  → podcastfy/content_parser/website_extractor.py:16: from playwright.sync_api import sync_playwright
+  → ModuleNotFoundError: No module named 'playwright'
+```
+
+Every import of `podcastfy.client` or the content parsers fails, so the API won't
+start. This is exactly why Dependabot #356 failed backend tests, coverage, and e2e.
+Working around it means adding `playwright` (plus Chromium binaries on CI + VPS if
+the code path ever runs) as our own dependency to patch an upstream packaging bug.
+
+## CVE position (unchanged by the upgrade)
+
+0.4.3 still pins `langchain >=0.3.3,<0.4.0`, so:
+
+- **PYSEC-2026-2193** (langchain-core, fixed only in 1.2.22) — still unreachable
+- **PYSEC-2026-2562 / CVE-2026-26013** (SSRF in `ChatOpenAI.get_num_tokens_from_messages`,
+  fixed only in langchain-core 1.2.11; method not called by podcastfy or us) — still unreachable
+
+The pip-audit ignore list in `scripts/security-audit.sh` is capped to podcastfy's
+requirement set and stays exactly as-is while we remain on 0.4.1.
+
+## Decision
+
+Cost (new prod dependency to work around an upstream bug, a major edge-tts bump,
+five new transitives, re-verification of the full generation chain) buys **zero**
+user-visible or security benefit. Defer.
+
+**Re-evaluate when upstream ships a release that either:**
+1. supports **langchain 1.x** — this is the real payoff: it would clear
+   PYSEC-2026-2193 / PYSEC-2026-2562 and let the pip-audit ignore list shrink, or
+2. declares its imports correctly (playwright) so the upgrade is at least drop-in, or
+3. changes `generate_podcast` / `ContentGenerator` signatures we depend on
+   (would show up in `test_podcast_generation_task.py` guards on any future spike).
+
+Dependabot keeps ignoring `podcastfy` (per #363). When re-evaluating, run
+`@dependabot unignore dependency` on a podcastfy PR or repeat the spike above.

--- a/apps/api/scripts/security-audit.sh
+++ b/apps/api/scripts/security-audit.sh
@@ -12,8 +12,9 @@ uv export --format requirements-txt --no-hashes --no-emit-project -o "$reqs" -q
 # Ignored IDs are all structurally capped by podcastfy==0.4.1's requirement set
 # (litellm>=1.84 needs openai>=2.20 vs podcastfy's openai<2; langchain 1.x /
 # langsmith 0.8 / aiplatform 1.133 / pytest 9 conflict the same way; PYSEC-2026-2562
-# is langchain-core, fixed only in 1.2.11). The fix is the podcastfy upgrade
-# (#204 coupling, evaluated in #363), not an override. Re-check this list on
+# is langchain-core, fixed only in 1.2.11). The fix is a podcastfy release that
+# supports langchain 1.x — 0.4.2/0.4.3 do NOT (evaluated & deferred in #363, see
+# docs/podcastfy-0.4.3-evaluation.md) — not an override. Re-check this list on
 # every podcastfy bump.
 uvx pip-audit -r "$reqs" --no-deps --disable-pip --strict \
   --ignore-vuln CVE-2026-35029 \


### PR DESCRIPTION
Closes #363

## Summary
Issue #363 asked for a deliberate evaluation of the podcastfy 0.4.1 → 0.4.3 engine upgrade. The evaluation ran (PyPI sdist diff + empirical spike on this branch) and the verdict is **defer** — stay pinned on 0.4.1. This PR ships the evaluation record, not the upgrade.

## Evidence
- **Upstream diff** (no git tags past v0.4.0; diffed sdists): all substantive changes are in 0.4.2; 0.4.3 only bumps `httpx` in its own pyproject.
- **`client.py` is byte-identical** 0.4.1↔0.4.3 → the #204 Celery kwarg coupling carries zero signature risk.
- **Hard break**: 0.4.2+ `website_extractor.py` does `from playwright.sync_api import sync_playwright` at module top but **playwright is not a declared dependency** (upstream packaging bug). Spike result: `uv lock` resolves, but `pytest tests/unit/test_podcast_generation_task.py` fails collection with `ModuleNotFoundError: No module named 'playwright'` — the same chain `main.py`'s startup import guard uses, so the API won't boot. This explains Dependabot #356's CI failures.
- **No CVE relief**: 0.4.3 still pins `langchain <0.4`, so PYSEC-2026-2193 and PYSEC-2026-2562 stay on the pip-audit ignore list either way.
- **No functional gain for our call paths**: topic grounding (`topic=`) isn't wired from our router; Playwright fetching only affects `WebsiteExtractor.extract_content`, which we deliberately bypass for SSRF safety (#206/#234); the Gemini TTS language-code fix doesn't touch our providers.

## Changes
- `apps/api/docs/podcastfy-0.4.3-evaluation.md` — full evaluation, spike transcript, decision, and re-evaluation triggers (chiefly upstream langchain-1.x support)
- `CLAUDE.md` — engine section notes 0.4.2/0.4.3 evaluated & deferred, with pointer to the doc
- `apps/api/scripts/security-audit.sh` — comment no longer implies "the podcastfy upgrade" clears the ignored CVEs (0.4.2/0.4.3 don't)

The spike itself (pin bump + lock churn) was reverted; the 0.4.1 environment was re-verified green (32 signature-guard/import tests pass).

## Known Limitations
- Dependabot keeps ignoring `podcastfy` per #363; re-enabling bump PRs is deliberate future work when a re-evaluation trigger fires.
- The evaluation is against 0.4.3 (latest on PyPI today); a future 0.4.4+ needs the spike repeated (steps in the doc).

## Review
- Pre-PR third-party review: `codex review --base main` — no actionable findings (opencode/GLM stalled and timed out; codex fallback used per review invariants).