### PR TITLE
[P4.6] Download S3-backed snippets to the worker before composition merge (#376)

### DIFF
--- a/apps/api/docs/demos/issue376-s3-snippet-composition.md
+++ b/apps/api/docs/demos/issue376-s3-snippet-composition.md
@@ -1,0 +1,32 @@
+# Demo — #376: Composition downloads S3-backed snippets before merging
+
+**Date:** 2026-07-13 · **Branch:** `feat/376-composition-s3-snippet-download`
+
+Real services: real ffmpeg-generated tones, the real S3 bucket
+(`podcaststudiohub-audio`, demo prefix `audio-snippets/demo-376/`), and the
+actual `merge_audio_snippets_task` code path (`.apply()`, eager). Local snippet
+copies were deleted after upload so the snippets existed **only in S3**, exactly
+like production (`upload_audio_snippet` stores the S3 key and deletes its temp).
+
+## Acceptance criteria → evidence
+
+| Criterion | Evidence |
+|---|---|
+| Composed episode actually contains intro → main → outro, verified by duration | Tones: intro 3.03s, main 5.04s, outro 4.05s → composed output **12.04s** (`ffprobe`), status `success` |
+| Download failures degrade to main-only (log, don't fail the chain) | Timeline with a nonexistent S3 key → warning `Composition: skipping intro segment — download of s3://…/does-not-exist.mp3 failed: … 404 …`, status `success`, output **5.04s** (main only) |
+| Temp snippet files cleaned up after merge (success and failure paths) | `$TMPDIR/tmp*.mp3` diff before/after both cases: **0 leaked files** (includes the pre-created tempfile of the failed download) |
+| Unit tests for download/degrade/cleanup | `tests/unit/test_audio_composition_task.py::TestS3BackedSegments` (3 tests) + 3 resolver tests in `tests/unit/test_podcast_generation_task.py`; full suite 1828 passed / 7 skipped |
+
+## Transcript
+
+```text
+Composition: skipping intro segment — download of s3://podcaststudiohub-audio/audio-snippets/demo-376/does-not-exist.mp3 failed: An error occurred (404) when calling the HeadObject operation: Not Found
+tones: intro=3.03s main=5.04s outro=4.05s
+uploaded snippets to s3://podcaststudiohub-audio/audio-snippets/demo-376/ and removed local copies
+case1 composed: status=success duration=12.04s (expected ~12s)
+case2 degraded: status=success duration=5.04s (expected ~5s)
+tempfile cleanup: 0 leaked snippet tempfiles (expected 0)
+demo S3 objects deleted — ALL CHECKS PASSED
+```
+
+Demo S3 objects were deleted at the end of the run.

--- a/apps/api/src/tasks/audio_composition.py
+++ b/apps/api/src/tasks/audio_composition.py
@@ -2,13 +2,61 @@
 Celery tasks for audio snippet merging and composition
 """
 from celery import Task
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Tuple
 import logging
+import os
+import tempfile
+
+import boto3
 
 from src.worker import celery_app
+from src.config import settings
 from src.tasks.retry_utils import calculate_backoff
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_segment_files(
+    timeline: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Materialize S3-backed timeline segments as local tempfiles (issue #376).
+
+    Snippets uploaded with S3 configured exist only as S3 objects, so the
+    resolver emits ``{"s3_key": …}`` entries; download each to a tempfile with
+    sync boto3 (consistent with ``upload_to_s3_task``) so pydub can read it.
+    A failed download skips just that segment (log, don't fail the chain) —
+    worst case the merge degrades to the generated audio alone. Segments with
+    a ``file_path`` pass through untouched, including a missing main file,
+    which must still fail loudly in the merge loop.
+
+    Returns ``(segments, temp_paths)``; the caller must delete ``temp_paths``
+    after the merge (success and failure paths). Failed downloads' tempfiles
+    are also returned so one cleanup site covers everything.
+    """
+    resolved: List[Dict[str, Any]] = []
+    temp_paths: List[str] = []
+    s3_client = None
+    for segment in timeline:
+        s3_key = segment.get("s3_key")
+        if segment.get("file_path") or not s3_key:
+            resolved.append(segment)
+            continue
+        try:
+            fd, tmp = tempfile.mkstemp(suffix=os.path.splitext(s3_key)[1] or ".mp3")
+            os.close(fd)
+            temp_paths.append(tmp)
+            if s3_client is None:
+                s3_client = boto3.client("s3")
+            s3_client.download_file(settings.AWS_S3_BUCKET, s3_key, tmp)
+        except Exception as exc:
+            logger.warning(
+                "Composition: skipping %s segment — download of s3://%s/%s "
+                "failed: %s",
+                segment.get("segment_type"), settings.AWS_S3_BUCKET, s3_key, exc,
+            )
+            continue
+        resolved.append({**segment, "file_path": tmp})
+    return resolved, temp_paths
 
 
 @celery_app.task(bind=True, name="merge_audio_snippets", time_limit=300, max_retries=2)
@@ -45,6 +93,7 @@ def merge_audio_snippets_task(
             "at least one segment (the generated audio) is required"
         )
 
+    temp_paths: List[str] = []
     try:
         self.update_state(
             state='PROGRESS',
@@ -55,8 +104,10 @@ def merge_audio_snippets_task(
             }
         )
 
+        # Download S3-backed segments to worker tempfiles (issue #376).
+        timeline, temp_paths = _resolve_segment_files(timeline)
+
         from pydub import AudioSegment
-        import os
 
         # Initialize empty audio
         final_audio = AudioSegment.empty()
@@ -124,3 +175,11 @@ def merge_audio_snippets_task(
                 "file_size_bytes": 0,
                 "error": str(e)
             }
+    finally:
+        # Downloaded snippet tempfiles are per-attempt artifacts: remove them on
+        # success, failure, AND the retry path (the next attempt re-downloads).
+        for tmp in temp_paths:
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass

--- a/apps/api/src/tasks/podcast_generation.py
+++ b/apps/api/src/tasks/podcast_generation.py
@@ -137,28 +137,35 @@ def resolve_composition_timeline(
             )
             for snippet in snippets:
                 # AudioSnippet.file_path holds the S3 key when S3 is configured,
-                # so the file may not exist on this worker's disk.
-                # ponytail: S3-only snippets are skipped, not downloaded; add a
-                # download-to-tempfile step here if remote snippets are needed.
-                if not snippet.file_path or not os.path.isfile(snippet.file_path):
+                # so the file usually doesn't exist on this worker's disk.
+                if snippet.file_path and os.path.isfile(snippet.file_path):
+                    entry = {
+                        "file_path": snippet.file_path,
+                        "segment_type": snippet.snippet_type,
+                    }
+                elif snippet.s3_key and settings.AWS_S3_BUCKET:
+                    # S3-backed snippet: merge_audio_snippets_task downloads it
+                    # to a worker tempfile before merging (issue #376).
+                    entry = {
+                        "s3_key": snippet.s3_key,
+                        "segment_type": snippet.snippet_type,
+                    }
+                else:
                     logger.warning(
-                        "Composition: skipping snippet %s (%s) — file %r is not "
-                        "available on local disk",
+                        "Composition: skipping snippet %s (%s) — no local file "
+                        "%r and no downloadable S3 object",
                         snippet.id, snippet.snippet_type, snippet.file_path,
                     )
                     continue
-                entry = {
-                    "file_path": snippet.file_path,
-                    "segment_type": snippet.snippet_type,
-                }
                 if snippet.snippet_type in _PRE_MAIN_SNIPPET_TYPES:
                     pre.append(entry)
                 else:
                     post.append(entry)
             if snippets and not pre and not post:
                 logger.warning(
-                    "Composition: project %s has %d snippet(s) but none are on "
-                    "local disk — composing the generated audio only",
+                    "Composition: project %s has %d snippet(s) but none are "
+                    "usable (no local file or S3 object) — composing the "
+                    "generated audio only",
                     project_id, len(snippets),
                 )
     except Exception as exc:

--- a/apps/api/tests/unit/test_audio_composition_task.py
+++ b/apps/api/tests/unit/test_audio_composition_task.py
@@ -5,6 +5,7 @@ Covers issue #116: happy path merging, normalize/fade flags,
 empty timeline edge case, and error-path return shape.
 """
 
+import os
 import types
 from unittest.mock import MagicMock, patch
 
@@ -172,3 +173,143 @@ class TestMergeAudioSnippetsTask:
 		assert result["duration_seconds"] == 0
 		assert result["file_size_bytes"] == 0
 		assert "FFmpeg not found" in result["error"]
+
+
+class TestS3BackedSegments:
+	"""S3-backed timeline entries are downloaded to tempfiles, merged, and
+	cleaned up; download failures degrade instead of failing the chain (#376)."""
+
+	def _pydub(self, from_file_side_effect=None):
+		mock_cls, mock_modules = _mock_pydub_modules()
+		seg = _make_mock_audio_segment(duration_ms=8000)
+		mock_cls.empty.return_value = seg
+		if from_file_side_effect is not None:
+			mock_cls.from_file.side_effect = from_file_side_effect
+		else:
+			mock_cls.from_file.return_value = seg
+		return mock_cls, mock_modules, seg
+
+	def test_s3_segment_downloaded_merged_and_temp_removed(self, tmp_path):
+		"""An s3_key segment is downloaded via boto3, merged, and its tempfile
+		is deleted after a successful merge."""
+		mock_cls, mock_modules, seg = self._pydub()
+		main = tmp_path / "gen.mp3"
+		main.write_bytes(b"m")
+		timeline = [
+			{"s3_key": "audio-snippets/u1/intro.mp3", "segment_type": "intro"},
+			{"file_path": str(main), "segment_type": "main_content"},
+		]
+
+		downloaded = []
+		def fake_download(bucket, key, dest):
+			downloaded.append((bucket, key, dest))
+			with open(dest, "wb") as f:
+				f.write(b"audio")
+
+		mock_s3 = MagicMock()
+		mock_s3.download_file.side_effect = fake_download
+
+		with patch.object(merge_audio_snippets_task, "update_state"), \
+			 patch_modules(mock_modules), \
+			 patch("src.tasks.audio_composition.boto3") as mock_boto3, \
+			 patch("src.tasks.audio_composition.settings") as mock_settings, \
+			 patch("os.path.getsize", return_value=4096):
+			mock_boto3.client.return_value = mock_s3
+			mock_settings.AWS_S3_BUCKET = "test-bucket"
+
+			result = merge_audio_snippets_task.run(
+				episode_id="ep-376a",
+				timeline=timeline,
+				output_path=str(tmp_path / "out.mp3"),
+			)
+
+		assert result["status"] == "success"
+		assert len(downloaded) == 1
+		bucket, key, dest = downloaded[0]
+		assert bucket == "test-bucket"
+		assert key == "audio-snippets/u1/intro.mp3"
+		# Both segments were merged: the downloaded tempfile, then the main file.
+		loaded = [c.args[0] for c in mock_cls.from_file.call_args_list]
+		assert loaded == [dest, str(main)]
+		# Tempfile cleaned up after the merge.
+		assert not os.path.exists(dest)
+
+	def test_s3_download_failure_skips_segment_and_merge_succeeds(self, tmp_path):
+		"""A failed snippet download degrades (segment skipped, warning) — the
+		merge still succeeds with the remaining segments and cleans its temp."""
+		mock_cls, mock_modules, seg = self._pydub()
+		main = tmp_path / "gen.mp3"
+		main.write_bytes(b"m")
+		timeline = [
+			{"s3_key": "audio-snippets/u1/intro.mp3", "segment_type": "intro"},
+			{"file_path": str(main), "segment_type": "main_content"},
+		]
+
+		attempted = []
+		def failing_download(bucket, key, dest):
+			attempted.append(dest)
+			raise RuntimeError("S3 unavailable")
+
+		mock_s3 = MagicMock()
+		mock_s3.download_file.side_effect = failing_download
+
+		with patch.object(merge_audio_snippets_task, "update_state"), \
+			 patch_modules(mock_modules), \
+			 patch("src.tasks.audio_composition.boto3") as mock_boto3, \
+			 patch("src.tasks.audio_composition.settings") as mock_settings, \
+			 patch("os.path.getsize", return_value=4096):
+			mock_boto3.client.return_value = mock_s3
+			mock_settings.AWS_S3_BUCKET = "test-bucket"
+
+			result = merge_audio_snippets_task.run(
+				episode_id="ep-376b",
+				timeline=timeline,
+				output_path=str(tmp_path / "out.mp3"),
+			)
+
+		assert result["status"] == "success"
+		# Only the main segment was merged.
+		loaded = [c.args[0] for c in mock_cls.from_file.call_args_list]
+		assert loaded == [str(main)]
+		# The pre-created tempfile for the failed download was cleaned up.
+		assert attempted and not os.path.exists(attempted[0])
+
+	def test_temps_cleaned_when_merge_fails(self, tmp_path):
+		"""Downloaded tempfiles are removed even when the merge itself fails."""
+		mock_cls, mock_modules, _ = self._pydub(
+			from_file_side_effect=RuntimeError("corrupt audio")
+		)
+		timeline = [
+			{"s3_key": "audio-snippets/u1/intro.mp3", "segment_type": "intro"},
+			{"file_path": str(tmp_path / "gen.mp3"), "segment_type": "main_content"},
+		]
+
+		downloaded = []
+		def fake_download(bucket, key, dest):
+			downloaded.append(dest)
+			with open(dest, "wb") as f:
+				f.write(b"audio")
+
+		mock_s3 = MagicMock()
+		mock_s3.download_file.side_effect = fake_download
+
+		with patch.object(merge_audio_snippets_task, "update_state"), \
+			 patch_modules(mock_modules), \
+			 patch("src.tasks.audio_composition.boto3") as mock_boto3, \
+			 patch("src.tasks.audio_composition.settings") as mock_settings, \
+			 patch.object(
+				merge_audio_snippets_task,
+				"retry",
+				side_effect=merge_audio_snippets_task.MaxRetriesExceededError(),
+			 ):
+			mock_boto3.client.return_value = mock_s3
+			mock_settings.AWS_S3_BUCKET = "test-bucket"
+
+			result = merge_audio_snippets_task.run(
+				episode_id="ep-376c",
+				timeline=timeline,
+				output_path=str(tmp_path / "out.mp3"),
+			)
+
+		assert result["status"] == "failed"
+		assert downloaded and not os.path.exists(downloaded[0])

--- a/apps/api/tests/unit/test_podcast_generation_task.py
+++ b/apps/api/tests/unit/test_podcast_generation_task.py
@@ -452,9 +452,11 @@ class TestResolveCompositionTimeline:
 		session.__exit__ = MagicMock(return_value=False)
 		return session
 
-	def _snippet(self, snippet_type: str, file_path: str) -> types.SimpleNamespace:
+	def _snippet(
+		self, snippet_type: str, file_path: str, s3_key: str = None
+	) -> types.SimpleNamespace:
 		return types.SimpleNamespace(
-			id=uuid4(), snippet_type=snippet_type, file_path=file_path
+			id=uuid4(), snippet_type=snippet_type, file_path=file_path, s3_key=s3_key
 		)
 
 	def test_no_snippets_yields_main_segment_only(self) -> None:
@@ -490,15 +492,15 @@ class TestResolveCompositionTimeline:
 		assert segment_types == ["intro", "music", "main_content", "outro", "ad"]
 		assert timeline[2]["file_path"] == "/tmp/gen.mp3"
 
-	def test_skips_snippets_without_local_file(self, tmp_path) -> None:
-		"""Snippets whose file_path is not on local disk (S3-only) are skipped."""
+	def test_skips_snippets_without_local_file_or_s3_key(self, tmp_path) -> None:
+		"""Snippets with no local file and no S3 object are skipped."""
 		from src.tasks import podcast_generation as pg
 
 		local = tmp_path / "intro.mp3"
 		local.write_bytes(b"x")
 		snippets = [
 			self._snippet("intro", str(local)),
-			self._snippet("outro", "audio-snippets/only-in-s3.mp3"),
+			self._snippet("outro", "audio-snippets/gone.mp3", s3_key=None),
 		]
 
 		with patch.object(pg, "SyncSessionLocal", return_value=self._mock_session(snippets)):
@@ -506,17 +508,38 @@ class TestResolveCompositionTimeline:
 
 		assert [seg["segment_type"] for seg in timeline] == ["intro", "main_content"]
 
-	def test_all_snippets_s3_only_yields_main_segment_only(self) -> None:
-		"""Current production shape: file_path always holds the S3 key, so every
-		snippet is skipped and composition passes the generated audio through."""
+	def test_s3_backed_snippets_included_as_s3_entries(self) -> None:
+		"""Production shape (#376): file_path holds the S3 key, s3_key is set, and
+		S3 is configured — snippets are included as s3_key entries for the merge
+		task to download, ordered around the main segment."""
 		from src.tasks import podcast_generation as pg
 
 		snippets = [
-			self._snippet("intro", "audio-snippets/u1/s1.mp3"),
-			self._snippet("outro", "audio-snippets/u1/s2.mp3"),
+			self._snippet("outro", "audio-snippets/u1/s2.mp3", s3_key="audio-snippets/u1/s2.mp3"),
+			self._snippet("intro", "audio-snippets/u1/s1.mp3", s3_key="audio-snippets/u1/s1.mp3"),
 		]
 
-		with patch.object(pg, "SyncSessionLocal", return_value=self._mock_session(snippets)):
+		with patch.object(pg, "SyncSessionLocal", return_value=self._mock_session(snippets)), \
+			 patch.object(pg.settings, "AWS_S3_BUCKET", "test-bucket"):
+			timeline = pg.resolve_composition_timeline(uuid4(), "/tmp/gen.mp3")
+
+		assert timeline == [
+			{"s3_key": "audio-snippets/u1/s1.mp3", "segment_type": "intro"},
+			{"file_path": "/tmp/gen.mp3", "segment_type": "main_content"},
+			{"s3_key": "audio-snippets/u1/s2.mp3", "segment_type": "outro"},
+		]
+
+	def test_s3_backed_snippets_skipped_when_s3_not_configured(self) -> None:
+		"""Without AWS_S3_BUCKET the merge task cannot download, so s3_key-only
+		snippets stay skipped and the timeline degrades to main-only."""
+		from src.tasks import podcast_generation as pg
+
+		snippets = [
+			self._snippet("intro", "audio-snippets/u1/s1.mp3", s3_key="audio-snippets/u1/s1.mp3"),
+		]
+
+		with patch.object(pg, "SyncSessionLocal", return_value=self._mock_session(snippets)), \
+			 patch.object(pg.settings, "AWS_S3_BUCKET", None):
 			timeline = pg.resolve_composition_timeline(uuid4(), "/tmp/gen.mp3")
 
 		assert timeline == [{"file_path": "/tmp/gen.mp3", "segment_type": "main_content"}]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,23 +1,44 @@
-# #363 [P4.5] Evaluate podcastfy 0.4.1 → 0.4.3 upgrade
+# #376 — Composition: download S3-backed snippets to the worker before merging
 
-## Findings so far (Phase 2)
-- Upstream repo has no 0.4.1+ tags; evaluated via PyPI sdist diff 0.4.1 → 0.4.3.
-- `podcastfy/client.py` (our `generate_podcast` entrypoint, #204 coupling): **byte-identical**. No signature risk.
-- `ContentGenerator`: only default `model_name` changed (`gemini-1.5-pro-latest` → `gemini-2.5-flash`); we pass it explicitly (env `GEMINI_MODEL_NAME`). `generate_qa_content` unchanged.
-- `PDFExtractor`: unchanged. `WebsiteExtractor` helpers we use (normalize_url, remove_unwanted_elements, clean_content, user_agent, timeout): unchanged.
-- **Breaking**: 0.4.3 `website_extractor.py` imports `playwright.sync_api` at module top but playwright is NOT a declared dependency (upstream packaging bug). Our `main.py` import guard + `content_extraction_service.py` import `WebsiteExtractor` → app import fails unless WE add playwright (+ chromium binaries in CI/VPS).
-- `content_extractor.py` now imports `google.genai` top-level; declared (`google-genai ^1.46`) — our lock has 1.2.0, would bump.
-- Dep bumps: openai ^1.56 (still <2), httpx ^0.28.1 (we lock 0.27.2), edge-tts 6→7 (major).
-- langchain still `<0.4` → PYSEC-2026-2193 / PYSEC-2026-2562 NOT cleared by 0.4.3 (as predicted in issue comments).
-- Functional gains for US: ~none. Topic-grounding fix (google-genai/gemini-2.5) only helps `topic=` path — not wired from our router. Playwright fetching only helps `extract_content`, which we deliberately bypass (SSRF #206/#234). Gemini TTS language-code fix only for google-cloud TTS voices.
+**Plan source**: self-authored (no plan comment on the issue). **Approved autonomously** — no architectural fork: the issue sanctions doing the download in `resolve_composition_timeline` *or* the merge task; the merge task is chosen so download, use, and cleanup live in one task with a `finally` (no tempfile lifetime across Celery task boundaries).
 
-## Plan
-1. [x] Upstream changelog/diff review (above)
-2. [x] Empirical spike on feature branch: bump pin → `uv lock` → `uv sync` → run test_imports + signature-guard tests. Record exact failure/success.
-3. [x] Verdict (DEFER — evidence: playwright ModuleNotFoundError on import, zero gain, CVEs uncleared) from evidence:
-   - If upgrade is drop-in + low cost → complete checklist (caps, CLAUDE.md, full suite, e2e generation).
-   - If upgrade costs (playwright+chromium in prod, dep churn) exceed ~zero benefit → **defer**: write evaluation doc (`apps/api/docs/`), update CLAUDE.md pin note + security-audit.sh comment if needed, PR the docs, comment verdict on issue, close.
-4. [x] Quality gates, PR #395, showboat demo, merged 2026-07-13. Issue #363 closed.
+## Current behavior (verified in code)
 
-## Review
-SHIPPED via PR #395 (squash 74f9073). Verdict: defer upgrade. Deliverables: apps/api/docs/podcastfy-0.4.3-evaluation.md, CLAUDE.md engine note, security-audit.sh comment fix. Spike reverted; 0.4.1 env verified green (32 guard tests).
+- `upload_audio_snippet` stores the S3 key in `AudioSnippet.file_path` (and in `s3_key`) and deletes the upload tempfile → snippets are never on worker disk (`audio_snippet_service.py:142`).
+- `resolve_composition_timeline` (`podcast_generation.py:107`) skips any snippet whose `file_path` isn't a local file → timeline degrades to main-only; snippets never play.
+- `merge_audio_snippets_task` (`audio_composition.py`) consumes `segment["file_path"]` blindly.
+
+## Changes
+
+### 1. `src/tasks/podcast_generation.py` — `resolve_composition_timeline`
+- For a snippet whose `file_path` is a local file: unchanged (local entry).
+- Else, if `snippet.s3_key` and `settings.AWS_S3_BUCKET` are set: emit `{"s3_key": ..., "segment_type": ...}` instead of skipping.
+- Else: skip with warning (unchanged).
+- Update the "none are on local disk" summary log / ponytail comment accordingly.
+
+### 2. `src/tasks/audio_composition.py` — `merge_audio_snippets_task`
+- Before the merge loop, resolve each segment to a local path:
+  - `file_path` exists on disk → use it.
+  - has `s3_key` → download via sync `boto3.client("s3").download_file(settings.AWS_S3_BUCKET, key, tmp)` to a `NamedTemporaryFile` (consistent with `upload_to_s3_task`); on any download failure, log a warning and **skip the segment** (degrade — never fail the chain; worst case timeline is main-only).
+  - neither usable → current behavior (unchanged for plain-file segments: missing main content still fails/retries).
+- Track downloaded temp paths; delete them in `finally` (covers success, failure, and retry paths).
+
+### 3. Tests (TDD — write first)
+- `tests/unit/test_podcast_generation_task.py::TestResolveCompositionTimeline`:
+  - S3-backed snippet (s3_key set, bucket configured) → included as `s3_key` entry, ordered correctly.
+  - s3_key set but no bucket → skipped.
+  - no local file and no s3_key → skipped (update existing `_snippet` helper with `s3_key`).
+- `tests/unit/test_audio_composition_task.py`:
+  - s3 segment downloaded (mock boto3), merged, tempfile removed on success.
+  - download failure → segment skipped, merge still succeeds with remaining segments (main-only worst case), no chain failure.
+  - tempfiles removed on merge failure path.
+
+## Acceptance criteria mapping
+- Composed episode contains intro → main → outro (duration-verified) → demo in Phase 11.
+- Download failure degrades, doesn't fail the chain → per-segment skip (strictly gentler than full main-only degrade).
+- Temp cleanup success + failure paths → `finally` block + tests.
+- Unit tests for download/degrade/cleanup → above.
+
+## Out of scope
+- No change to snippet upload, callbacks, or chain structure.
+- Router-supplied timelines (file_path-only entries) behave exactly as before.


### PR DESCRIPTION
Closes #376.

## Problem
Since #313/#375 the composition timeline is resolved on the worker, but project snippets were only included when `AudioSnippet.file_path` was a local file — which it never is in production: `upload_audio_snippet` stores the **S3 key** in `file_path` and deletes the upload temp. Every snippet was skipped, so intro/outro/music never actually played.

## Changes
- `resolve_composition_timeline` now emits `{"s3_key": …}` entries for snippets that have an S3 object (and S3 is configured); local-file snippets and router-supplied timelines are unchanged.
- `merge_audio_snippets_task` materializes `s3_key` entries as worker tempfiles via sync boto3 (consistent with `upload_to_s3_task`). Any per-segment failure (tempfile creation or download) logs a warning and skips just that segment — worst case the merge degrades to the generated audio alone; the chain never fails because of a snippet.
- Downloaded tempfiles are removed in a `finally` covering success, failure, and the retry path (each retry re-downloads).

## Testing
- TDD: 6 new unit tests (resolver s3-entry emission / no-bucket skip / no-key skip; merge download+cleanup, download-failure degrade, cleanup-on-merge-failure). Full backend suite: **1828 passed, 7 skipped**. ruff clean.
- **Demo (real S3, real ffmpeg)** — `apps/api/docs/demos/issue376-s3-snippet-composition.md`: S3-only intro (3.03s) + main (5.04s) + outro (4.05s) → composed **12.04s**; bogus key → degraded main-only 5.04s with warning; **0 leaked tempfiles**.

## Review
Pre-PR third-party review: opencode (GLM) — 1 finding applied (`mkstemp` moved inside the per-segment try so tempfile-creation failure also degrades instead of failing the chain); 1 finding verified already-handled (retry wrapper).

## Known Limitations
- Snippets are re-downloaded on each merge attempt (retries re-download); no snippet cache. Fine at current snippet sizes (≤50 MB upload cap).
- Download failure skips only the failed segment (strictly gentler than the issue's "main-only" degrade); a partial composition (e.g. intro without outro) is possible when S3 fails mid-set.