### PR TITLE
[P5.1] Parameterize nginx upstream ports in provision-ssl.sh (#317)

### DIFF
--- a/.github/DEPLOYMENT_SETUP.md
+++ b/.github/DEPLOYMENT_SETUP.md
@@ -142,11 +142,11 @@ pm2 logs podcaststudiohub-api --lines 50
 pm2 logs podcaststudiohub-frontend --lines 50
 pm2 logs podcaststudiohub-celery --lines 50
 
-# Check API health
-curl http://localhost:8001/health
+# Check API health (dev API_PORT — see deployment/README.md)
+curl http://localhost:8005/health
 
-# Check frontend
-curl http://localhost:3003
+# Check frontend (dev FRONTEND_PORT)
+curl http://localhost:3010
 ```
 
 ### Rollback Deployment

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -185,8 +185,8 @@ jobs:
             find . -type f -name '*.pyc' -delete 2>/dev/null || true
 
             # The API port is per-environment: this is a multi-tenant host, so the
-            # port that nginx proxies to differs per app (dev podcast = 8005, not the
-            # single-tenant 8001 in deployment/nginx/podcastfy.conf). The source of
+            # port that nginx proxies to differs per app (dev podcast = 8005, the
+            # committed default in deployment/nginx/podcastfy.conf). The source of
             # truth is the environment's API_PORT variable, which must match that
             # environment's nginx upstream. Require it to be set and numeric so a
             # missing/typo'd value fails fast BEFORE the running service is torn

--- a/apps/api/docs/demos/issue317-nginx-port-drift.md
+++ b/apps/api/docs/demos/issue317-nginx-port-drift.md
@@ -1,0 +1,105 @@
+# Issue #317: nginx upstream port drift — parameterized provisioning + drift gate
+
+*2026-07-14T05:17:25Z*
+
+Issue #317: provision-ssl.sh used to install the committed nginx conf with hardcoded upstreams (8001/3003) that did not match the deployed ports (8005/3010), causing 502s. AC1: the conf now commits the real dev defaults and provision-ssl.sh substitutes API_PORT/FRONTEND_PORT overrides the same way it substitutes DOMAIN. First, the committed defaults and the new override variables:
+
+```bash
+grep -nE '127\.0\.0\.1:[0-9]+' deployment/nginx/podcastfy.conf | head -4
+```
+
+```output
+19:	server 127.0.0.1:8005;
+87:		proxy_pass http://127.0.0.1:3010;
+130:		proxy_pass http://127.0.0.1:3010;
+140:		proxy_pass http://127.0.0.1:3010;
+```
+
+```bash
+grep -n 'PORT=' deployment/scripts/provision-ssl.sh | head -4
+```
+
+```output
+26:API_PORT="${API_PORT:-8005}"
+27:FRONTEND_PORT="${FRONTEND_PORT:-3010}"
+```
+
+The defaults match the deploy workflow ports (8005/3010) exactly. Now the override path — the script rewrites the installed copy with the same guarded sed pattern used for DOMAIN. Simulating an install with API_PORT=9001 FRONTEND_PORT=4000 by running the exact substitution lines from the script against a copy of the conf:
+
+```bash
+grep -A7 'Honour port overrides' deployment/scripts/provision-ssl.sh
+```
+
+```output
+# Honour port overrides the same way: rewrite the conf's committed dev
+# defaults (8005/3010) to this environment's upstream ports.
+if [ "${API_PORT}" != "8005" ]; then
+	sed -i "s/127\.0\.0\.1:8005/127.0.0.1:${API_PORT}/g" "${NGINX_SITE}"
+fi
+if [ "${FRONTEND_PORT}" != "3010" ]; then
+	sed -i "s/127\.0\.0\.1:3010/127.0.0.1:${FRONTEND_PORT}/g" "${NGINX_SITE}"
+fi
+```
+
+```bash
+export NGINX_SITE=$(mktemp) API_PORT=9001 FRONTEND_PORT=4000
+cp deployment/nginx/podcastfy.conf "$NGINX_SITE"
+eval "$(grep -A7 "Honour port overrides" deployment/scripts/provision-ssl.sh)"
+grep -nE "127\.0\.0\.1:[0-9]+" "$NGINX_SITE"; rm -f "$NGINX_SITE"
+```
+
+```output
+19:	server 127.0.0.1:9001;
+87:		proxy_pass http://127.0.0.1:4000;
+130:		proxy_pass http://127.0.0.1:4000;
+140:		proxy_pass http://127.0.0.1:4000;
+```
+
+AC2: a regression test pins the conf ports to the script defaults so drift is caught in CI. First, the gate passing on the fixed tree:
+
+```bash
+python -m pytest deployment/tests/test_port_alignment.py -q 2>&1 | tail -2
+```
+
+```output
+/home/frankbria/.local/share/uv/tools/showboat/bin/python: No module named pytest
+```
+
+Mutation check — reintroduce the original bug (upstream back to 8001) and the gate fails loudly, then restore:
+
+```bash
+/usr/bin/python -m pytest deployment/tests/test_port_alignment.py -q 2>&1 | tail -2
+```
+
+```output
+....                                                                     [100%]
+4 passed in 0.02s
+```
+
+Mutation check — reintroduce the original bug (upstream back to 8001) and the gate fails loudly, then restore:
+
+```bash
+sed -i "s/127\.0\.0\.1:8005/127.0.0.1:8001/" deployment/nginx/podcastfy.conf
+/usr/bin/python -m pytest deployment/tests/test_port_alignment.py -q 2>&1 | grep -E "^FAILED|assert .* == |failed" | head -3
+git checkout -- deployment/nginx/podcastfy.conf
+echo "--- restored ---"
+/usr/bin/python -m pytest deployment/tests/test_port_alignment.py -q 2>&1 | tail -1
+```
+
+```output
+>   	assert m.group(1) == _script_default("API_PORT"), (
+E    assert '8001' == '8005'
+FAILED deployment/tests/test_port_alignment.py::test_api_upstream_port_matches_script_default
+--- restored ---
+4 passed in 0.02s
+```
+
+The gate catches the exact bug from the issue (assert 8001 == 8005) and the stale-port check also guards the provisioning script itself. Full deployment suite, including real nginx -t in Docker:
+
+```bash
+/usr/bin/python -m pytest deployment/tests/ -q 2>&1 | tail -1
+```
+
+```output
+42 passed in 1.23s
+```

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -252,8 +252,12 @@ Configure in **Settings** → **Environments** → **development**:
 > The dev host is **multi-tenant** (several apps share it), so these ports are
 > per-environment, not repo-wide constants. `API_PORT`/`FRONTEND_PORT` are the
 > source of truth and **must match that host's nginx upstream**
-> (`/etc/nginx/sites-available/podcaststudiohub` on the server). The values in
-> `deployment/nginx/podcastfy.conf` (8001/3003) are a single-tenant example.
+> (`/etc/nginx/sites-available/podcastfy` on the server).
+> `deployment/nginx/podcastfy.conf` commits the dev defaults (8005/3010);
+> `provision-ssl.sh` substitutes `API_PORT`/`FRONTEND_PORT` overrides into the
+> installed copy the same way it substitutes `DOMAIN`, and
+> `deployment/tests/test_port_alignment.py` pins the conf and script defaults
+> together (issue #317).
 
 **Secrets:**
 - `SSH_PRIVATE_KEY`: SSH key for deployment

--- a/deployment/nginx/podcastfy.conf
+++ b/deployment/nginx/podcastfy.conf
@@ -10,9 +10,11 @@
 
 # API Backend (FastAPI)
 # This file is the DEV site config (server_name dev.podcaststudiohub.me).
-# The hardcoded ports are dev's: API 8005, web 3010 — they must match the
-# "development" GitHub environment's API_PORT / FRONTEND_PORT vars. Another
-# environment needs its own copy with its own server_name and ports.
+# The hardcoded ports are dev's defaults: API 8005, web 3010 — they must match
+# the "development" GitHub environment's API_PORT / FRONTEND_PORT vars
+# (deployment/tests/test_port_alignment.py enforces the pairing, issue #317).
+# provision-ssl.sh rewrites DOMAIN / API_PORT / FRONTEND_PORT overrides into
+# the installed copy, so other environments reuse this file as-is.
 upstream podcastfy_api {
 	server 127.0.0.1:8005;
 }

--- a/deployment/scripts/provision-ssl.sh
+++ b/deployment/scripts/provision-ssl.sh
@@ -9,8 +9,12 @@
 #   sudo DOMAIN=dev.podcaststudiohub.me deployment/scripts/provision-ssl.sh
 #
 # Optional env overrides:
-#   DOMAIN  — FQDN to issue the cert for (default: dev.podcaststudiohub.me)
-#   EMAIL   — Let's Encrypt recovery email        (default: admin@<DOMAIN>)
+#   DOMAIN        — FQDN to issue the cert for (default: dev.podcaststudiohub.me)
+#   EMAIL         — Let's Encrypt recovery email    (default: admin@<DOMAIN>)
+#   API_PORT      — FastAPI upstream port           (default: 8005)
+#   FRONTEND_PORT — Next.js upstream port           (default: 3010)
+# Port defaults must match the committed deployment/nginx/podcastfy.conf —
+# deployment/tests/test_port_alignment.py enforces this (issue #317).
 #
 # Prerequisites:
 #   - DNS for $DOMAIN points at this server
@@ -19,6 +23,8 @@
 set -euo pipefail
 
 DOMAIN="${DOMAIN:-dev.podcaststudiohub.me}"
+API_PORT="${API_PORT:-8005}"
+FRONTEND_PORT="${FRONTEND_PORT:-3010}"
 WEBROOT="/var/www/html"
 EMAIL="${EMAIL:-admin@${DOMAIN}}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -69,7 +75,6 @@ if [ ! -f "${CERT_DIR}/fullchain.pem" ] || [ ! -f "${CERT_DIR}/privkey.pem" ] ||
 
 	rm -f /etc/nginx/sites-enabled/default
 	cat > "${NGINX_SITE}" <<HTTP
-upstream podcastfy_api { server 127.0.0.1:8001; }
 server {
 	listen 80;
 	server_name ${DOMAIN};
@@ -104,6 +109,14 @@ cp -a "${SITE_CONF}" "${NGINX_SITE}"
 # copy so server_name + cert paths match the certificate that was issued.
 if [ "${DOMAIN}" != "dev.podcaststudiohub.me" ]; then
 	sed -i "s/dev\.podcaststudiohub\.me/${DOMAIN}/g" "${NGINX_SITE}"
+fi
+# Honour port overrides the same way: rewrite the conf's committed dev
+# defaults (8005/3010) to this environment's upstream ports.
+if [ "${API_PORT}" != "8005" ]; then
+	sed -i "s/127\.0\.0\.1:8005/127.0.0.1:${API_PORT}/g" "${NGINX_SITE}"
+fi
+if [ "${FRONTEND_PORT}" != "3010" ]; then
+	sed -i "s/127\.0\.0\.1:3010/127.0.0.1:${FRONTEND_PORT}/g" "${NGINX_SITE}"
 fi
 ln -sf "${NGINX_SITE}" "${NGINX_ENABLED}"
 rm -f /etc/nginx/sites-enabled/default

--- a/deployment/tests/test_port_alignment.py
+++ b/deployment/tests/test_port_alignment.py
@@ -1,0 +1,65 @@
+"""Guard against nginx upstream port drift (issue #317).
+
+The committed ``podcastfy.conf`` bakes the dev ports (API 8005, web 3010) and
+``provision-ssl.sh`` substitutes ``API_PORT``/``FRONTEND_PORT`` overrides into
+the installed copy. These tests pin the two sides together so the conf, the
+script defaults, and the substitution mechanism cannot silently diverge again
+(the original drift shipped 8001/3003 upstreams → 502s on the dev host).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "provision-ssl.sh"
+
+
+def _script_text() -> str:
+	return SCRIPT_PATH.read_text()
+
+
+def _script_default(var: str) -> str:
+	m = re.search(rf'{var}="\$\{{{var}:-(\d+)\}}"', _script_text())
+	assert m, f"provision-ssl.sh must define {var}=\"${{{var}:-<port>}}\""
+	return m.group(1)
+
+
+def test_api_upstream_port_matches_script_default(nginx_conf_raw: str):
+	m = re.search(
+		r"upstream\s+podcastfy_api\s*\{[^}]*?server\s+127\.0\.0\.1:(\d+)", nginx_conf_raw
+	)
+	assert m, "podcastfy.conf must define the podcastfy_api upstream"
+	assert m.group(1) == _script_default("API_PORT"), (
+		"API upstream port in podcastfy.conf must equal the API_PORT default in "
+		"provision-ssl.sh (drift here 502s the API — issue #317)"
+	)
+
+
+def test_frontend_proxy_ports_match_script_default(nginx_conf_raw: str):
+	# Set-equality is deliberate: every direct-IP proxy_pass must be the
+	# frontend — the API must go through the podcastfy_api upstream, so a new
+	# direct-IP API proxy_pass should fail here.
+	ports = set(re.findall(r"proxy_pass\s+http://127\.0\.0\.1:(\d+)", nginx_conf_raw))
+	assert ports, "podcastfy.conf must proxy_pass to the Next.js app"
+	assert ports == {_script_default("FRONTEND_PORT")}, (
+		"every direct proxy_pass port in podcastfy.conf must equal the "
+		"FRONTEND_PORT default in provision-ssl.sh (drift here 502s the frontend "
+		f"— issue #317); found ports: {sorted(ports)}"
+	)
+
+
+def test_script_substitutes_both_port_overrides():
+	text = _script_text()
+	for var in ("API_PORT", "FRONTEND_PORT"):
+		assert re.search(rf"sed .*\${{{var}}}", text), (
+			f"provision-ssl.sh must sed-substitute ${{{var}}} into the installed "
+			"nginx site (same contract as the DOMAIN override)"
+		)
+
+
+def test_no_stale_bootstrap_ports():
+	assert "8001" not in _script_text() and "3003" not in _script_text(), (
+		"provision-ssl.sh must not hardcode the retired 8001/3003 ports "
+		"(issue #317)"
+	)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,20 @@
 # Tasks
 
-_No active task._ Last shipped: #376 (composition downloads S3-backed snippets to the worker) via PR #396, merged 2026-07-13 (cba6c84).
+## Active: Issue #317 — nginx upstream port drift (provision-ssl.sh vs deploy ports)
+
+### Status of original CodeRabbit plan
+- Phase 1 Task 1 (fix podcastfy.conf to 8005/3010): **already done** on main (conf already 8005/3010 with explanatory comment).
+- Remaining work adapted below.
+
+### Plan (approved autonomously — no architectural fork)
+- [ ] RED: add `deployment/tests/test_port_alignment.py` asserting:
+  - conf API upstream port == `${API_PORT:-…}` default in provision-ssl.sh
+  - conf frontend proxy_pass port == `${FRONTEND_PORT:-…}` default in provision-ssl.sh
+  - provision-ssl.sh contains sed substitution for both ports
+  - bootstrap heredoc has no stale hardcoded 8001 upstream
+- [ ] GREEN: provision-ssl.sh — add `API_PORT="${API_PORT:-8005}"`, `FRONTEND_PORT="${FRONTEND_PORT:-3010}"`, guarded sed substitutions after `cp` (mirror DOMAIN pattern), remove unused `upstream podcastfy_api { server 127.0.0.1:8001; }` from bootstrap heredoc (dead: bootstrap block never proxies)
+- [ ] Docs: deployment/README.md ~252-256 — replace stale "(8001/3003) single-tenant example" caveat with the new default+override contract
+- [ ] Quality gate: pytest deployment/tests, bash -n, third-party review (opencode pre-PR)
+- [ ] PR → demo (Showboat, infra — no browser) → CI green → merge
+
+Last shipped: #376 (composition downloads S3-backed snippets to the worker) via PR #396, merged 2026-07-13 (cba6c84).


### PR DESCRIPTION
Closes #317.

## What

The committed `podcastfy.conf` was already corrected to the real dev ports (8005/3010) on main, so the live 502 half of the issue was fixed; this PR closes the remaining drift surface:

- **`deployment/scripts/provision-ssl.sh`**: new `API_PORT`/`FRONTEND_PORT` env overrides, sed-substituted into the installed site config exactly like the existing `DOMAIN` override (guarded, anchored on `127.0.0.1:<default>`). Removed the bootstrap heredoc's unused `upstream podcastfy_api { server 127.0.0.1:8001; }` (its server block only serves the ACME webroot — the upstream was dead code carrying a stale port).
- **`deployment/nginx/podcastfy.conf`**: header comment now documents the default+override contract.
- **`deployment/README.md`**: retired the stale "(8001/3003) single-tenant example" caveat; fixed the installed site path (`sites-available/podcastfy`, matching the script's `SITE_NAME`).
- **`deployment/tests/test_port_alignment.py`** (regression gate): conf upstream/proxy ports must equal the script's `${API_PORT:-…}`/`${FRONTEND_PORT:-…}` defaults; the substitution logic must exist; no stale 8001/3003 anywhere in the script.

## Verification

- 42/42 `deployment/tests/` pass locally, including real `nginx -t` in Docker (`nginx:stable`).
- Substitution exercised on a copy: `API_PORT=9001 FRONTEND_PORT=4000` rewrites the upstream and all three frontend `proxy_pass` lines, no leftovers outside comments.
- `bash -n` clean; pre-commit hooks passed.

## Third-party review

opencode (GLM, glm-5-turbo) pre-PR review: **no Critical/Major**; 3 minors triaged — heredoc verified proxy-free, set-assertion rationale comment added, numeric-guard skipped (see below).

## Known Limitations

- No numeric validation of `API_PORT`/`FRONTEND_PORT` in the script: a malformed value breaks the sed or fails the immediate `nginx -t`, and `set -euo pipefail` halts before anything deploys — the failure is loud, just not pre-validated. The deploy workflow separately enforces numeric `API_PORT`.
- The port substitution comes from this branch's script; the live dev host's installed conf is not touched by this PR (it already runs 8005/3010).