### PR TITLE
[P5.2] Migration safety: dedupe-safe 006, lock-safe DDL, complete env.py metadata (#318)

### DIFF
--- a/apps/api/alembic/env.py
+++ b/apps/api/alembic/env.py
@@ -1,5 +1,4 @@
 from logging.config import fileConfig
-import os
 import sys
 from pathlib import Path
 
@@ -11,14 +10,12 @@ from alembic import context
 # Add parent directory to path for imports (so we can import from src package)
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-# Import database and models for metadata discovery
+# Import database and the WHOLE model package for metadata discovery.
+# Do not regress to a hand-maintained model list: an incomplete list makes
+# `--autogenerate` emit DROP TABLE for any live table whose model it can't
+# see (issue #318). tests/test_migration_metadata.py enforces completeness.
 from src.database import Base
-from src.models import (
-    User, Project, Episode, ContentSource,
-    ConversationTemplate, TTSConfiguration,
-    DistributionTarget, RSSFeed, AudioSnippet,
-    EpisodeLayout, EpisodeComposition
-)
+import src.models  # noqa: F401
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/apps/api/alembic/versions/004_add_missing_discriminator_indexes.py
+++ b/apps/api/alembic/versions/004_add_missing_discriminator_indexes.py
@@ -27,42 +27,35 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
-def upgrade() -> None:
+INDEXES = [
 	# ContentSource: extraction-router discriminator
-	op.create_index(
-		'idx_content_sources_source_type',
-		'content_sources',
-		['source_type'],
-		postgresql_using='btree',
-	)
-
+	('idx_content_sources_source_type', 'content_sources', 'source_type'),
 	# ContentSource: background-job status filter
-	op.create_index(
-		'idx_content_sources_extraction_status',
-		'content_sources',
-		['extraction_status'],
-		postgresql_using='btree',
-	)
-
+	('idx_content_sources_extraction_status', 'content_sources', 'extraction_status'),
 	# DistributionTarget: platform-routing discriminator
-	op.create_index(
-		'idx_distribution_targets_target_type',
-		'distribution_targets',
-		['target_type'],
-		postgresql_using='btree',
-	)
-
+	('idx_distribution_targets_target_type', 'distribution_targets', 'target_type'),
 	# TTSConfiguration: provider-selection lookup
-	op.create_index(
-		'idx_tts_configurations_provider',
-		'tts_configurations',
-		['provider'],
-		postgresql_using='btree',
-	)
+	('idx_tts_configurations_provider', 'tts_configurations', 'provider'),
+]
+
+
+def upgrade() -> None:
+	# These tables pre-exist and may hold data: build CONCURRENTLY so the
+	# index build never blocks writes (issue #318). CONCURRENTLY cannot run
+	# inside a transaction, hence the autocommit block. The DROP guards make
+	# reruns safe — a failed CONCURRENTLY build leaves an INVALID index.
+	with op.get_context().autocommit_block():
+		for name, table, column in INDEXES:
+			op.execute(f"DROP INDEX IF EXISTS {name}")
+			op.create_index(
+				name,
+				table,
+				[column],
+				postgresql_using='btree',
+				postgresql_concurrently=True,
+			)
 
 
 def downgrade() -> None:
-	op.drop_index('idx_content_sources_source_type', table_name='content_sources')
-	op.drop_index('idx_content_sources_extraction_status', table_name='content_sources')
-	op.drop_index('idx_distribution_targets_target_type', table_name='distribution_targets')
-	op.drop_index('idx_tts_configurations_provider', table_name='tts_configurations')
+	for name, table, _column in INDEXES:
+		op.drop_index(name, table_name=table)

--- a/apps/api/alembic/versions/005_add_fk_indexes.py
+++ b/apps/api/alembic/versions/005_add_fk_indexes.py
@@ -31,12 +31,20 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
 	# EpisodeComposition.layout_id - foreign key to episode_layouts
 	# Used when: JOIN episode_layouts ON composition.layout_id = layout.id
-	op.create_index(
-		'idx_episode_compositions_layout_id',
-		'episode_compositions',
-		['layout_id'],
-		postgresql_using='btree',
-	)
+	#
+	# episode_compositions pre-exists and may hold data: build CONCURRENTLY
+	# in an autocommit block so the build never blocks writes (issue #318).
+	# The DROP guard makes reruns safe after a failed CONCURRENTLY build
+	# (which leaves an INVALID index behind).
+	with op.get_context().autocommit_block():
+		op.execute("DROP INDEX IF EXISTS idx_episode_compositions_layout_id")
+		op.create_index(
+			'idx_episode_compositions_layout_id',
+			'episode_compositions',
+			['layout_id'],
+			postgresql_using='btree',
+			postgresql_concurrently=True,
+		)
 
 
 def downgrade() -> None:

--- a/apps/api/alembic/versions/006_make_episode_number_not_null.py
+++ b/apps/api/alembic/versions/006_make_episode_number_not_null.py
@@ -1,8 +1,15 @@
 """Make episode_number NOT NULL with auto-increment per project
 
-Backfills NULL episode_number values with sequential numbers per project
-(ordered by created_at ASC), then enforces NOT NULL and adds a unique
-constraint on (project_id, episode_number) to guarantee ordering integrity.
+Renumbers any pre-existing duplicate (project_id, episode_number) rows (keeps
+the earliest by created_at, moves later rows above the project max), backfills
+NULL episode_number values with sequential numbers per project (ordered by
+created_at ASC), then enforces NOT NULL and a unique constraint on
+(project_id, episode_number) to guarantee ordering integrity.
+
+Lock-safety (issue #318): NOT NULL is applied via CHECK ... NOT VALID ->
+VALIDATE -> SET NOT NULL (PostgreSQL 12+ uses the validated check to skip the
+full-table scan under ACCESS EXCLUSIVE), and both indexes build CONCURRENTLY
+in an autocommit block so writes are never blocked on large tables.
 
 Revision ID: 006
 Revises: 005
@@ -27,13 +34,57 @@ def upgrade() -> None:
 
 	# Step 0: Fail loudly if this migration is run under a role subject to RLS
 	# (issue #301). 003 applies FORCE ROW LEVEL SECURITY to episodes; under an
-	# RLS-subject role the backfill below silently matches zero rows, then the
-	# NOT NULL / unique constraints build over un-backfilled data. With
+	# RLS-subject role the data repair below silently matches zero rows, then
+	# the NOT NULL / unique constraints build over un-repaired data. With
 	# row_security=off, a no-bypass role errors here instead of corrupting data;
 	# for a superuser/BYPASSRLS migration role this is a harmless no-op.
 	connection.execute(text("SET LOCAL row_security = off"))
 
-	# Step 1: Backfill NULL episode_numbers.
+	# Step 1: Renumber pre-existing duplicate (project_id, episode_number)
+	# rows so the unique constraint below can never abort (issue #318).
+	# Within each duplicate group the earliest row (created_at, id) keeps its
+	# number; later rows move to sequential numbers above the project's
+	# current max. (CTEs are evaluated against the pre-UPDATE snapshot, so
+	# project_max reads the pre-dedupe max — renumbered values land strictly
+	# above every pre-existing number and cannot collide.)
+	dedupe_sql = text("""
+	WITH ranked AS (
+		SELECT
+			id,
+			project_id,
+			created_at,
+			ROW_NUMBER() OVER (
+				PARTITION BY project_id, episode_number
+				ORDER BY created_at ASC, id ASC
+			) AS dup_rank
+		FROM episodes
+		WHERE episode_number IS NOT NULL
+	),
+	to_renumber AS (
+		SELECT
+			id,
+			project_id,
+			ROW_NUMBER() OVER (
+				PARTITION BY project_id ORDER BY created_at ASC, id ASC
+			) AS seq
+		FROM ranked
+		WHERE dup_rank > 1
+	),
+	project_max AS (
+		SELECT project_id, MAX(episode_number) AS max_num
+		FROM episodes
+		WHERE episode_number IS NOT NULL
+		GROUP BY project_id
+	)
+	UPDATE episodes e
+	SET episode_number = pm.max_num + tr.seq
+	FROM to_renumber tr
+	JOIN project_max pm ON pm.project_id = tr.project_id
+	WHERE e.id = tr.id
+	""")
+	connection.execute(dedupe_sql)
+
+	# Step 2: Backfill NULL episode_numbers.
 	# For each project, assign sequential numbers starting from
 	# MAX(existing episode_number) + 1 for NULL rows, ordered by created_at.
 	# Projects with no existing non-NULL values start from 1.
@@ -62,27 +113,60 @@ def upgrade() -> None:
 	""")
 	connection.execute(backfill_sql)
 
-	# Step 2: Enforce NOT NULL on episode_number.
-	op.alter_column(
-		'episodes',
-		'episode_number',
-		existing_type=sa.Integer(),
-		nullable=False,
+	# Step 3: Enforce NOT NULL without a full-table scan under ACCESS
+	# EXCLUSIVE. The NOT VALID add is a brief lock; the scan happens in
+	# VALIDATE (SHARE UPDATE EXCLUSIVE — writes continue); SET NOT NULL then
+	# reuses the validated check (PostgreSQL 12+) instead of rescanning.
+	# The DROP guard makes reruns safe: everything up to here commits when
+	# the autocommit block below opens, so a failure later in this migration
+	# would otherwise leave the check constraint behind and abort the re-add.
+	op.execute(
+		"ALTER TABLE episodes DROP CONSTRAINT IF EXISTS "
+		"ck_episodes_episode_number_not_null"
+	)
+	op.execute(
+		"ALTER TABLE episodes ADD CONSTRAINT ck_episodes_episode_number_not_null "
+		"CHECK (episode_number IS NOT NULL) NOT VALID"
 	)
 
-	# Step 3: Add unique constraint per project.
-	op.create_unique_constraint(
-		'uq_episodes_project_number',
-		'episodes',
-		['project_id', 'episode_number'],
-	)
+	# Steps 4-5 run outside the migration transaction: VALIDATE only avoids
+	# blocking writes when the NOT VALID add has already committed, and
+	# CREATE INDEX CONCURRENTLY refuses to run inside a transaction at all.
+	with op.get_context().autocommit_block():
+		op.execute(
+			"ALTER TABLE episodes VALIDATE CONSTRAINT "
+			"ck_episodes_episode_number_not_null"
+		)
+		op.execute(
+			"ALTER TABLE episodes ALTER COLUMN episode_number SET NOT NULL"
+		)
+		op.execute(
+			"ALTER TABLE episodes DROP CONSTRAINT "
+			"ck_episodes_episode_number_not_null"
+		)
 
-	# Step 4: Add composite index for efficient ordering queries.
-	op.create_index(
-		'idx_episodes_project_number',
-		'episodes',
-		['project_id', 'episode_number'],
-	)
+		# Step 4: Unique constraint per project, built without blocking
+		# writes: CONCURRENTLY index first, then attach it as the constraint.
+		# The DROP guards make reruns safe — a failed CONCURRENTLY build
+		# leaves an INVALID index behind.
+		op.execute("DROP INDEX IF EXISTS uq_episodes_project_number")
+		op.execute(
+			"CREATE UNIQUE INDEX CONCURRENTLY uq_episodes_project_number "
+			"ON episodes (project_id, episode_number)"
+		)
+		op.execute(
+			"ALTER TABLE episodes ADD CONSTRAINT uq_episodes_project_number "
+			"UNIQUE USING INDEX uq_episodes_project_number"
+		)
+
+		# Step 5: Composite index for efficient ordering queries.
+		op.execute("DROP INDEX IF EXISTS idx_episodes_project_number")
+		op.create_index(
+			'idx_episodes_project_number',
+			'episodes',
+			['project_id', 'episode_number'],
+			postgresql_concurrently=True,
+		)
 
 
 def downgrade() -> None:

--- a/apps/api/alembic/versions/006_make_episode_number_not_null.py
+++ b/apps/api/alembic/versions/006_make_episode_number_not_null.py
@@ -147,8 +147,14 @@ def upgrade() -> None:
 
 		# Step 4: Unique constraint per project, built without blocking
 		# writes: CONCURRENTLY index first, then attach it as the constraint.
-		# The DROP guards make reruns safe — a failed CONCURRENTLY build
-		# leaves an INVALID index behind.
+		# The DROP guards make reruns safe across BOTH failure windows: the
+		# constraint drop (which takes its owned index with it) covers a
+		# failure after ADD CONSTRAINT committed, and the index drop covers
+		# the INVALID index a failed CONCURRENTLY build leaves behind.
+		op.execute(
+			"ALTER TABLE episodes DROP CONSTRAINT IF EXISTS "
+			"uq_episodes_project_number"
+		)
 		op.execute("DROP INDEX IF EXISTS uq_episodes_project_number")
 		op.execute(
 			"CREATE UNIQUE INDEX CONCURRENTLY uq_episodes_project_number "

--- a/apps/api/alembic/versions/008_add_celery_task_tracking.py
+++ b/apps/api/alembic/versions/008_add_celery_task_tracking.py
@@ -31,30 +31,42 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+	# Nullable adds are metadata-only (no table rewrite). if_not_exists makes
+	# reruns safe: the adds commit when the autocommit block below opens, so
+	# a failed CONCURRENTLY build would otherwise wedge the re-run (#318).
+
 	# Add task_id column for Celery task UUID
 	op.add_column(
 		'episodes',
 		sa.Column('task_id', sa.Text(), nullable=True),
+		if_not_exists=True,
 	)
 
 	# Add task_started_at column
 	op.add_column(
 		'episodes',
 		sa.Column('task_started_at', sa.DateTime(timezone=True), nullable=True),
+		if_not_exists=True,
 	)
 
 	# Add task_completed_at column
 	op.add_column(
 		'episodes',
 		sa.Column('task_completed_at', sa.DateTime(timezone=True), nullable=True),
+		if_not_exists=True,
 	)
 
-	# Create index on task_id for fast lookups by Celery task UUID
-	op.create_index(
-		'idx_episodes_task_id',
-		'episodes',
-		['task_id'],
-	)
+	# Create index on task_id for fast lookups by Celery task UUID.
+	# episodes pre-exists and may be large: build CONCURRENTLY in an
+	# autocommit block so the build never blocks writes (issue #318).
+	with op.get_context().autocommit_block():
+		op.execute("DROP INDEX IF EXISTS idx_episodes_task_id")
+		op.create_index(
+			'idx_episodes_task_id',
+			'episodes',
+			['task_id'],
+			postgresql_concurrently=True,
+		)
 
 
 def downgrade() -> None:

--- a/apps/api/alembic/versions/011_add_analytics_events.py
+++ b/apps/api/alembic/versions/011_add_analytics_events.py
@@ -40,7 +40,11 @@ def upgrade() -> None:
 		sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
 	)
 
-	# Indexes for common query patterns
+	# Indexes for common query patterns.
+	# Deliberately NOT CONCURRENTLY (issue #318): analytics_events is created
+	# in this same migration, so it is empty and invisible to any other
+	# transaction — a plain CREATE INDEX blocks nothing, while CONCURRENTLY
+	# would force an autocommit block and add partial-failure modes.
 	op.create_index("ix_analytics_events_tenant_id", "analytics_events", ["tenant_id"])
 	op.create_index("ix_analytics_events_episode_id", "analytics_events", ["episode_id"])
 	op.create_index("ix_analytics_events_project_id", "analytics_events", ["project_id"])

--- a/apps/api/alembic/versions/012_canonicalize_user_emails.py
+++ b/apps/api/alembic/versions/012_canonicalize_user_emails.py
@@ -51,12 +51,22 @@ def upgrade() -> None:
 		)
 
 	op.execute("UPDATE users SET email = lower(email) WHERE email <> lower(email)")
-	op.create_index(
-		"uq_users_email_lower",
-		"users",
-		[sa.text("lower(email)")],
-		unique=True,
-	)
+
+	# users pre-exists and may be large: build the unique index CONCURRENTLY
+	# in an autocommit block so the build never blocks writes (issue #318).
+	# The guard/collision-check/UPDATE above stay inside the migration
+	# transaction (SET LOCAL is transaction-scoped) and commit when the
+	# autocommit block opens. The DROP guard makes reruns safe after a failed
+	# CONCURRENTLY build (which leaves an INVALID index behind).
+	with op.get_context().autocommit_block():
+		op.execute("DROP INDEX IF EXISTS uq_users_email_lower")
+		op.create_index(
+			"uq_users_email_lower",
+			"users",
+			[sa.text("lower(email)")],
+			unique=True,
+			postgresql_concurrently=True,
+		)
 
 
 def downgrade() -> None:

--- a/apps/api/docs/demos/issue318-migration-safety.md
+++ b/apps/api/docs/demos/issue318-migration-safety.md
@@ -1,0 +1,164 @@
+# Issue #318 — Migration safety: dedupe-safe 006, lock-safe DDL, complete env.py metadata
+
+*2026-07-14T20:40:47Z*
+
+Acceptance criteria from #318: (1) detect/renumber duplicate (project_id, episode_number) rows before adding the unique constraint; (2) build large-table indexes CONCURRENTLY in autocommit blocks and use NOT VALID → VALIDATE for NOT NULL; (3) import all current models into alembic target_metadata and assert metadata == model set in a test. This demo exercises each criterion against real PostgreSQL scratch databases. First: create a fresh DB and migrate to revision 005 (just before the hardened 006).
+
+```bash
+docker exec api-postgres-1 psql -U lull -d podcastfy -q -c "DROP DATABASE IF EXISTS mig318_demo;" -c "CREATE DATABASE mig318_demo OWNER podcastfy;"
+PW=$(grep "^DATABASE_URL=" .env | sed -E "s|.*//podcastfy:([^@]*)@.*|\1|")
+DATABASE_URL="postgresql+asyncpg://podcastfy:${PW}@localhost:5432/mig318_demo" uv run alembic upgrade 005 2>&1 | tail -2
+```
+
+```output
+NOTICE:  database "mig318_demo" does not exist, skipping
+INFO  [alembic.runtime.migration] Running upgrade 003 -> 004, Add missing indexes for discriminator and status columns
+INFO  [alembic.runtime.migration] Running upgrade 004 -> 005, Add missing index on episode_compositions.layout_id foreign key
+```
+
+**Criterion 1 — duplicates are renumbered, not fatal.** Seed the exact data shape that aborted the old 006: project A has a triplicate episode_number (2,2,2) plus numbers 1 and 7 and two NULLs; project B has a duplicate pair (1,1) plus a NULL.
+
+```bash
+docker exec -i api-postgres-1 psql -U podcastfy -d mig318_demo -v ON_ERROR_STOP=1 -q <<SQL
+INSERT INTO users (id, tenant_id, email, password_hash) VALUES
+ ('00000000-0000-0000-0000-000000000001','00000000-0000-0000-0000-0000000000aa','demo@example.com','x');
+INSERT INTO projects (id, tenant_id, user_id, name)
+SELECT gen, '00000000-0000-0000-0000-0000000000aa', '00000000-0000-0000-0000-000000000001', n FROM (VALUES
+ ('00000000-0000-0000-0000-000000000010'::uuid,'Project A'),
+ ('00000000-0000-0000-0000-000000000020'::uuid,'Project B')) v(gen,n);
+INSERT INTO episodes (id, tenant_id, user_id, project_id, episode_number, created_at)
+SELECT gen_random_uuid(), '00000000-0000-0000-0000-0000000000aa', '00000000-0000-0000-0000-000000000001',
+       '00000000-0000-0000-0000-000000000010', n, ts::timestamptz
+FROM (VALUES (1,'2026-01-01'),(2,'2026-01-02'),(2,'2026-01-03'),(2,'2026-01-04'),(7,'2026-01-05'),(NULL,'2026-01-06'),(NULL,'2026-01-07')) v(n,ts);
+INSERT INTO episodes (id, tenant_id, user_id, project_id, episode_number, created_at)
+SELECT gen_random_uuid(), '00000000-0000-0000-0000-0000000000aa', '00000000-0000-0000-0000-000000000001',
+       '00000000-0000-0000-0000-000000000020', n, ts::timestamptz
+FROM (VALUES (1,'2026-02-01'),(1,'2026-02-02'),(NULL,'2026-02-03')) v(n,ts);
+SQL
+docker exec api-postgres-1 psql -U podcastfy -d mig318_demo -c "SELECT left(project_id::text,13) AS project, episode_number, created_at::date FROM episodes ORDER BY project_id, created_at;"
+```
+
+```output
+    project    | episode_number | created_at
+---------------+----------------+------------
+ 00000000-0000 |              1 | 2026-01-01
+ 00000000-0000 |              2 | 2026-01-02
+ 00000000-0000 |              2 | 2026-01-03
+ 00000000-0000 |              2 | 2026-01-04
+ 00000000-0000 |              7 | 2026-01-05
+ 00000000-0000 |                | 2026-01-06
+ 00000000-0000 |                | 2026-01-07
+ 00000000-0000 |              1 | 2026-02-01
+ 00000000-0000 |              1 | 2026-02-02
+ 00000000-0000 |                | 2026-02-03
+(10 rows)
+
+```
+
+Now run `alembic upgrade head` over this dirty data. The old 006 aborted here with a unique-constraint violation; the hardened 006 renumbers duplicates first (earliest created_at keeps its number, later rows move above the project max), then backfills NULLs, then applies NOT NULL via CHECK NOT VALID → VALIDATE → SET NOT NULL and builds the unique index CONCURRENTLY (criterion 2).
+
+```bash
+PW=$(grep "^DATABASE_URL=" .env | sed -E "s|.*//podcastfy:([^@]*)@.*|\1|")
+DATABASE_URL="postgresql+asyncpg://podcastfy:${PW}@localhost:5432/mig318_demo" uv run alembic upgrade head 2>&1 | grep -E "005 -> 006|016 -> 017"
+```
+
+```output
+INFO  [alembic.runtime.migration] Running upgrade 005 -> 006, Make episode_number NOT NULL with auto-increment per project
+INFO  [alembic.runtime.migration] Running upgrade 016 -> 017, Add storage_deletion_outbox table for durable storage erasure (issue #366)
+```
+
+The full chain reached 017 with no abort. Outcome: project A (…10) kept 1, 2 (earliest of the triplicate), 7; the two later duplicates were renumbered to 8 and 9 (above the old max 7); NULLs backfilled to 10, 11. Project B (…20) kept the earlier 1, renumbered the other to 2, backfilled the NULL to 3.
+
+```bash
+docker exec api-postgres-1 psql -U podcastfy -d mig318_demo -c "SELECT right(project_id::text,2) AS proj, episode_number, created_at::date FROM episodes ORDER BY project_id, episode_number;"
+```
+
+```output
+ proj | episode_number | created_at
+------+----------------+------------
+ 10   |              1 | 2026-01-01
+ 10   |              2 | 2026-01-02
+ 10   |              7 | 2026-01-05
+ 10   |              8 | 2026-01-03
+ 10   |              9 | 2026-01-04
+ 10   |             10 | 2026-01-06
+ 10   |             11 | 2026-01-07
+ 20   |              1 | 2026-02-01
+ 20   |              2 | 2026-02-02
+ 20   |              3 | 2026-02-03
+(10 rows)
+
+```
+
+Verify the constraints landed: the unique constraint exists (contype u), episode_number is NOT NULL, and both indexes are present. The transient NOT-VALID check constraint was cleaned up.
+
+```bash
+docker exec api-postgres-1 psql -U podcastfy -d mig318_demo -c "SELECT conname, contype FROM pg_constraint WHERE conrelid = 'episodes'::regclass AND conname LIKE '%episode_number%' OR conname = 'uq_episodes_project_number';" -c "SELECT attname, attnotnull FROM pg_attribute WHERE attrelid = 'episodes'::regclass AND attname = 'episode_number';" -c "SELECT indexname FROM pg_indexes WHERE tablename = 'episodes' AND indexname LIKE '%project_number%';"
+```
+
+```output
+          conname           | contype
+----------------------------+---------
+ uq_episodes_project_number | u
+(1 row)
+
+    attname     | attnotnull
+----------------+------------
+ episode_number | t
+(1 row)
+
+          indexname
+-----------------------------
+ uq_episodes_project_number
+ idx_episodes_project_number
+(2 rows)
+
+```
+
+**Criterion 2 — CONCURRENTLY in the migration source.** The index builds in 004/005/006/008/012 use postgresql_concurrently inside autocommit blocks, and 006 uses the NOT VALID → VALIDATE sequence. (011 is deliberately non-concurrent: analytics_events is created in that same migration, so it is empty and invisible to other transactions.)
+
+```bash
+grep -c "postgresql_concurrently=True\|CONCURRENTLY" alembic/versions/004_add_missing_discriminator_indexes.py alembic/versions/005_add_fk_indexes.py alembic/versions/006_make_episode_number_not_null.py alembic/versions/008_add_celery_task_tracking.py alembic/versions/012_canonicalize_user_emails.py
+grep -n "NOT VALID\|VALIDATE CONSTRAINT\|SET NOT NULL" alembic/versions/006_make_episode_number_not_null.py | head -5
+```
+
+```output
+alembic/versions/004_add_missing_discriminator_indexes.py:4
+alembic/versions/005_add_fk_indexes.py:3
+alembic/versions/006_make_episode_number_not_null.py:6
+alembic/versions/008_add_celery_task_tracking.py:3
+alembic/versions/012_canonicalize_user_emails.py:3
+9:Lock-safety (issue #318): NOT NULL is applied via CHECK ... NOT VALID ->
+10:VALIDATE -> SET NOT NULL (PostgreSQL 12+ uses the validated check to skip the
+117:	# EXCLUSIVE. The NOT VALID add is a brief lock; the scan happens in
+118:	# VALIDATE (SHARE UPDATE EXCLUSIVE — writes continue); SET NOT NULL then
+129:		"CHECK (episode_number IS NOT NULL) NOT VALID"
+```
+
+**Criterion 3 — env.py metadata completeness.** env.py now imports the whole src.models package (no hand-maintained list), and a new test asserts the Base.metadata table set equals the migrated schema — it fails in both drift directions. Run it against the migrated dev DB, plus the full migration unit-test set.
+
+```bash
+grep -n "import src.models" alembic/env.py
+uv run pytest tests/test_migration_metadata.py tests/unit/test_migration_004_discriminator_indexes.py tests/unit/test_migration_005_fk_indexes.py tests/unit/test_migration_006_episode_number_not_null.py tests/unit/test_migration_012_canonicalize_user_emails.py -q --no-cov 2>&1 | tail -1
+```
+
+```output
+18:import src.models  # noqa: F401
+============================== 48 passed in 0.23s ==============================
+```
+
+Finally, CI parity: a pure fresh single-shot upgrade to head (what CI runs on every PR) still works with the CONCURRENTLY/autocommit changes, and scratch databases are cleaned up.
+
+```bash
+docker exec api-postgres-1 psql -U lull -d podcastfy -q -c "DROP DATABASE IF EXISTS mig318_fresh;" -c "CREATE DATABASE mig318_fresh OWNER podcastfy;" 2>/dev/null
+PW=$(grep "^DATABASE_URL=" .env | sed -E "s|.*//podcastfy:([^@]*)@.*|\1|")
+DATABASE_URL="postgresql+asyncpg://podcastfy:${PW}@localhost:5432/mig318_fresh" uv run alembic upgrade head 2>&1 | tail -1
+docker exec api-postgres-1 psql -U lull -d podcastfy -q -c "DROP DATABASE mig318_demo;" -c "DROP DATABASE mig318_fresh;" && echo "scratch DBs dropped"
+```
+
+```output
+INFO  [alembic.runtime.migration] Running upgrade 016 -> 017, Add storage_deletion_outbox table for durable storage erasure (issue #366)
+scratch DBs dropped
+```
+
+All three acceptance criteria demonstrated with outcome evidence. The full backend suite (1824 passed, 7 skipped, coverage gates enforced) ran green on this branch before the PR was opened: see PR #398.

--- a/apps/api/tests/test_migration_metadata.py
+++ b/apps/api/tests/test_migration_metadata.py
@@ -1,0 +1,50 @@
+"""
+Alembic target metadata must match the migrated schema (issue #318).
+
+env.py builds target_metadata from Base.metadata, which is only complete if
+every model module has been imported. This test compares the table-name set
+registered on Base.metadata (after importing the whole src.models package,
+exactly as env.py now does) against the tables that actually exist in the
+migrated test database. It fails in BOTH drift directions:
+
+- a migration creates a table with no corresponding model import
+  (the pre-#318 bug: the next `--autogenerate` would emit DROP TABLE), or
+- a model exists whose table was never migrated.
+
+A column-level autogenerate-clean assertion is deliberately NOT made here:
+models are known to omit some real DB constraints (see #308), so only the
+table set is compared.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.pool import NullPool
+
+from src.database import Base
+import src.models  # noqa: F401  — registers every model on Base.metadata
+
+from tests.conftest import TEST_DATABASE_URL
+
+
+def test_metadata_tables_match_migrated_schema():
+	# Mirror env.py's driver normalization so any TEST_DATABASE_URL scheme works.
+	sync_url = TEST_DATABASE_URL
+	if sync_url.startswith("postgresql+asyncpg://"):
+		sync_url = sync_url.replace("postgresql+asyncpg://", "postgresql+psycopg://")
+	elif sync_url.startswith("postgresql://"):
+		sync_url = sync_url.replace("postgresql://", "postgresql+psycopg://", 1)
+	engine = sa.create_engine(sync_url, poolclass=NullPool)
+	try:
+		db_tables = set(sa.inspect(engine).get_table_names(schema="public"))
+	finally:
+		engine.dispose()
+	db_tables.discard("alembic_version")
+
+	model_tables = set(Base.metadata.tables)
+
+	missing_models = db_tables - model_tables
+	missing_migrations = model_tables - db_tables
+	assert model_tables == db_tables, (
+		f"model/migration drift — tables in DB with no model in metadata "
+		f"(autogenerate would DROP them): {sorted(missing_models)}; "
+		f"models with no migrated table: {sorted(missing_migrations)}"
+	)

--- a/apps/api/tests/unit/test_migration_004_discriminator_indexes.py
+++ b/apps/api/tests/unit/test_migration_004_discriminator_indexes.py
@@ -3,14 +3,25 @@ Unit tests for migration 004_add_missing_discriminator_indexes.
 
 Tests cover:
 - Migration metadata (revision ID, down_revision chaining)
-- upgrade() creates all four missing indexes with correct names and columns
+- upgrade() creates all four missing indexes with correct names and columns,
+  CONCURRENTLY inside an autocommit block (issue #318 — no write-blocking locks)
+- upgrade() emits DROP INDEX IF EXISTS rerun guards (failed CONCURRENTLY
+  builds leave INVALID indexes behind)
 - downgrade() drops all four indexes
 - Index names follow project convention: idx_{table}_{column}
 """
 
 import importlib.util
 import os
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+
+
+EXPECTED_INDEXES = {
+	'idx_content_sources_source_type': ('content_sources', 'source_type'),
+	'idx_content_sources_extraction_status': ('content_sources', 'extraction_status'),
+	'idx_distribution_targets_target_type': ('distribution_targets', 'target_type'),
+	'idx_tts_configurations_provider': ('tts_configurations', 'provider'),
+}
 
 
 # ---------------------------------------------------------------------------
@@ -33,170 +44,99 @@ def _load_migration():
 	return module
 
 
+def _run_upgrade():
+	"""Run upgrade() with alembic entry points mocked.
+
+	Returns (mock_create_index, executed_sql, mock_context).
+	"""
+	executed = []
+	ctx = MagicMock()
+	with patch('alembic.op.create_index') as mock_create, \
+	     patch('alembic.op.execute', side_effect=lambda s, *a, **k: executed.append(str(s))), \
+	     patch('alembic.op.get_context', return_value=ctx):
+		_load_migration().upgrade()
+	return mock_create, executed, ctx
+
+
 # ============================================================================
 # METADATA TESTS
 # ============================================================================
 
 def test_migration_revision_id():
 	"""Migration must declare revision ID '004'."""
-	mod = _load_migration()
-	assert mod.revision == '004'
+	assert _load_migration().revision == '004'
 
 
 def test_migration_down_revision():
 	"""Migration must chain onto revision '003'."""
-	mod = _load_migration()
-	assert mod.down_revision == '003'
+	assert _load_migration().down_revision == '003'
 
 
 def test_migration_branch_labels_none():
 	"""Migration must not declare any branch labels."""
-	mod = _load_migration()
-	assert mod.branch_labels is None
+	assert _load_migration().branch_labels is None
 
 
 def test_migration_depends_on_none():
 	"""Migration must not declare any cross-branch dependencies."""
-	mod = _load_migration()
-	assert mod.depends_on is None
+	assert _load_migration().depends_on is None
 
 
 # ============================================================================
 # UPGRADE TESTS
 # ============================================================================
 
-def test_upgrade_creates_content_sources_source_type_index():
-	"""upgrade() must create idx_content_sources_source_type."""
-	mod = _load_migration()
-	with patch('alembic.op.create_index') as mock_create:
-		mod.upgrade()
-	index_names = [c.args[0] for c in mock_create.call_args_list]
-	assert 'idx_content_sources_source_type' in index_names
-
-
-def test_upgrade_creates_content_sources_extraction_status_index():
-	"""upgrade() must create idx_content_sources_extraction_status."""
-	mod = _load_migration()
-	with patch('alembic.op.create_index') as mock_create:
-		mod.upgrade()
-	index_names = [c.args[0] for c in mock_create.call_args_list]
-	assert 'idx_content_sources_extraction_status' in index_names
-
-
-def test_upgrade_creates_distribution_targets_target_type_index():
-	"""upgrade() must create idx_distribution_targets_target_type."""
-	mod = _load_migration()
-	with patch('alembic.op.create_index') as mock_create:
-		mod.upgrade()
-	index_names = [c.args[0] for c in mock_create.call_args_list]
-	assert 'idx_distribution_targets_target_type' in index_names
-
-
-def test_upgrade_creates_tts_configurations_provider_index():
-	"""upgrade() must create idx_tts_configurations_provider."""
-	mod = _load_migration()
-	with patch('alembic.op.create_index') as mock_create:
-		mod.upgrade()
-	index_names = [c.args[0] for c in mock_create.call_args_list]
-	assert 'idx_tts_configurations_provider' in index_names
-
-
-def test_upgrade_creates_exactly_four_indexes():
-	"""upgrade() must create exactly four indexes."""
-	mod = _load_migration()
-	with patch('alembic.op.create_index') as mock_create:
-		mod.upgrade()
-	assert mock_create.call_count == 4
-
-
-def test_upgrade_source_type_targets_correct_table_and_column():
-	"""idx_content_sources_source_type must target content_sources.source_type."""
-	mod = _load_migration()
-	with patch('alembic.op.create_index') as mock_create:
-		mod.upgrade()
+def test_upgrade_creates_all_four_indexes_on_correct_columns():
+	"""upgrade() must create exactly the four expected indexes."""
+	mock_create, _, _ = _run_upgrade()
 	calls_by_name = {c.args[0]: c for c in mock_create.call_args_list}
-	idx_call = calls_by_name['idx_content_sources_source_type']
-	# args: (index_name, table_name, columns, ...)
-	assert idx_call.args[1] == 'content_sources'
-	assert 'source_type' in idx_call.args[2]
+	assert set(calls_by_name) == set(EXPECTED_INDEXES)
+	for name, (table, column) in EXPECTED_INDEXES.items():
+		idx_call = calls_by_name[name]
+		assert idx_call.args[1] == table
+		assert column in idx_call.args[2]
 
 
-def test_upgrade_extraction_status_targets_correct_table_and_column():
-	"""idx_content_sources_extraction_status must target content_sources.extraction_status."""
-	mod = _load_migration()
-	with patch('alembic.op.create_index') as mock_create:
-		mod.upgrade()
-	calls_by_name = {c.args[0]: c for c in mock_create.call_args_list}
-	idx_call = calls_by_name['idx_content_sources_extraction_status']
-	assert idx_call.args[1] == 'content_sources'
-	assert 'extraction_status' in idx_call.args[2]
+def test_upgrade_creates_indexes_concurrently():
+	"""All indexes target pre-existing tables and must build CONCURRENTLY (#318)."""
+	mock_create, _, _ = _run_upgrade()
+	for c in mock_create.call_args_list:
+		assert c.kwargs.get('postgresql_concurrently') is True, (
+			f"{c.args[0]} not created CONCURRENTLY"
+		)
 
 
-def test_upgrade_target_type_targets_correct_table_and_column():
-	"""idx_distribution_targets_target_type must target distribution_targets.target_type."""
-	mod = _load_migration()
-	with patch('alembic.op.create_index') as mock_create:
-		mod.upgrade()
-	calls_by_name = {c.args[0]: c for c in mock_create.call_args_list}
-	idx_call = calls_by_name['idx_distribution_targets_target_type']
-	assert idx_call.args[1] == 'distribution_targets'
-	assert 'target_type' in idx_call.args[2]
+def test_upgrade_runs_inside_autocommit_block():
+	"""CONCURRENTLY cannot run in a transaction; an autocommit block is required."""
+	_, _, ctx = _run_upgrade()
+	assert ctx.autocommit_block.called
 
 
-def test_upgrade_provider_targets_correct_table_and_column():
-	"""idx_tts_configurations_provider must target tts_configurations.provider."""
-	mod = _load_migration()
-	with patch('alembic.op.create_index') as mock_create:
-		mod.upgrade()
-	calls_by_name = {c.args[0]: c for c in mock_create.call_args_list}
-	idx_call = calls_by_name['idx_tts_configurations_provider']
-	assert idx_call.args[1] == 'tts_configurations'
-	assert 'provider' in idx_call.args[2]
+def test_upgrade_emits_rerun_guards():
+	"""Each index needs a DROP INDEX IF EXISTS guard so a failed CONCURRENTLY
+	build (which leaves an INVALID index) doesn't wedge the migration."""
+	_, executed, _ = _run_upgrade()
+	lowered = " ".join(executed).lower()
+	for name in EXPECTED_INDEXES:
+		assert f"drop index if exists {name}" in lowered, f"missing guard for {name}"
+
+
+def test_upgrade_indexes_use_btree():
+	"""Indexes must use btree."""
+	mock_create, _, _ = _run_upgrade()
+	for c in mock_create.call_args_list:
+		assert c.kwargs.get('postgresql_using') == 'btree'
 
 
 # ============================================================================
 # DOWNGRADE TESTS
 # ============================================================================
 
-def test_downgrade_drops_content_sources_source_type_index():
-	"""downgrade() must drop idx_content_sources_source_type."""
+def test_downgrade_drops_all_four_indexes():
+	"""downgrade() must drop exactly the four indexes."""
 	mod = _load_migration()
 	with patch('alembic.op.drop_index') as mock_drop:
 		mod.downgrade()
 	index_names = [c.args[0] for c in mock_drop.call_args_list]
-	assert 'idx_content_sources_source_type' in index_names
-
-
-def test_downgrade_drops_content_sources_extraction_status_index():
-	"""downgrade() must drop idx_content_sources_extraction_status."""
-	mod = _load_migration()
-	with patch('alembic.op.drop_index') as mock_drop:
-		mod.downgrade()
-	index_names = [c.args[0] for c in mock_drop.call_args_list]
-	assert 'idx_content_sources_extraction_status' in index_names
-
-
-def test_downgrade_drops_distribution_targets_target_type_index():
-	"""downgrade() must drop idx_distribution_targets_target_type."""
-	mod = _load_migration()
-	with patch('alembic.op.drop_index') as mock_drop:
-		mod.downgrade()
-	index_names = [c.args[0] for c in mock_drop.call_args_list]
-	assert 'idx_distribution_targets_target_type' in index_names
-
-
-def test_downgrade_drops_tts_configurations_provider_index():
-	"""downgrade() must drop idx_tts_configurations_provider."""
-	mod = _load_migration()
-	with patch('alembic.op.drop_index') as mock_drop:
-		mod.downgrade()
-	index_names = [c.args[0] for c in mock_drop.call_args_list]
-	assert 'idx_tts_configurations_provider' in index_names
-
-
-def test_downgrade_drops_exactly_four_indexes():
-	"""downgrade() must drop exactly four indexes."""
-	mod = _load_migration()
-	with patch('alembic.op.drop_index') as mock_drop:
-		mod.downgrade()
+	assert set(index_names) == set(EXPECTED_INDEXES)
 	assert mock_drop.call_count == 4

--- a/apps/api/tests/unit/test_migration_005_fk_indexes.py
+++ b/apps/api/tests/unit/test_migration_005_fk_indexes.py
@@ -3,14 +3,16 @@ Unit tests for migration 005_add_fk_indexes.
 
 Tests cover:
 - Migration metadata (revision ID, down_revision chaining)
-- upgrade() creates the missing layout_id index with correct name and column
+- upgrade() creates the missing layout_id index with correct name and column,
+  CONCURRENTLY inside an autocommit block (issue #318 — no write-blocking locks)
+- upgrade() emits a DROP INDEX IF EXISTS rerun guard
 - downgrade() drops the index
 - Index name follows project convention: idx_{table}_{column}
 """
 
 import importlib.util
 import os
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 
 # ---------------------------------------------------------------------------
@@ -33,74 +35,85 @@ def _load_migration():
 	return module
 
 
+def _run_upgrade():
+	"""Run upgrade() with alembic entry points mocked.
+
+	Returns (mock_create_index, executed_sql, mock_context).
+	"""
+	executed = []
+	ctx = MagicMock()
+	with patch('alembic.op.create_index') as mock_create, \
+	     patch('alembic.op.execute', side_effect=lambda s, *a, **k: executed.append(str(s))), \
+	     patch('alembic.op.get_context', return_value=ctx):
+		_load_migration().upgrade()
+	return mock_create, executed, ctx
+
+
 # ============================================================================
 # METADATA TESTS
 # ============================================================================
 
 def test_migration_revision_id():
 	"""Migration must declare revision ID '005'."""
-	mod = _load_migration()
-	assert mod.revision == '005'
+	assert _load_migration().revision == '005'
 
 
 def test_migration_down_revision():
 	"""Migration must chain onto revision '004'."""
-	mod = _load_migration()
-	assert mod.down_revision == '004'
+	assert _load_migration().down_revision == '004'
 
 
 def test_migration_branch_labels_none():
 	"""Migration must not declare any branch labels."""
-	mod = _load_migration()
-	assert mod.branch_labels is None
+	assert _load_migration().branch_labels is None
 
 
 def test_migration_depends_on_none():
 	"""Migration must not declare any cross-branch dependencies."""
-	mod = _load_migration()
-	assert mod.depends_on is None
+	assert _load_migration().depends_on is None
 
 
 # ============================================================================
 # UPGRADE TESTS
 # ============================================================================
 
-def test_upgrade_creates_episode_compositions_layout_id_index():
-	"""upgrade() must create idx_episode_compositions_layout_id."""
-	mod = _load_migration()
-	with patch('alembic.op.create_index') as mock_create:
-		mod.upgrade()
-	index_names = [c.args[0] for c in mock_create.call_args_list]
-	assert 'idx_episode_compositions_layout_id' in index_names
-
-
-def test_upgrade_creates_exactly_one_index():
-	"""upgrade() must create exactly one index."""
-	mod = _load_migration()
-	with patch('alembic.op.create_index') as mock_create:
-		mod.upgrade()
+def test_upgrade_creates_layout_id_index_on_correct_column():
+	"""upgrade() must create exactly idx_episode_compositions_layout_id."""
+	mock_create, _, _ = _run_upgrade()
 	assert mock_create.call_count == 1
-
-
-def test_upgrade_layout_id_targets_correct_table_and_column():
-	"""idx_episode_compositions_layout_id must target episode_compositions.layout_id."""
-	mod = _load_migration()
-	with patch('alembic.op.create_index') as mock_create:
-		mod.upgrade()
-	calls_by_name = {c.args[0]: c for c in mock_create.call_args_list}
-	idx_call = calls_by_name['idx_episode_compositions_layout_id']
-	# args: (index_name, table_name, columns, ...)
+	idx_call = mock_create.call_args_list[0]
+	assert idx_call.args[0] == 'idx_episode_compositions_layout_id'
 	assert idx_call.args[1] == 'episode_compositions'
 	assert 'layout_id' in idx_call.args[2]
 
 
+def test_upgrade_creates_index_concurrently():
+	"""episode_compositions pre-exists and may be large; build CONCURRENTLY (#318)."""
+	mock_create, _, _ = _run_upgrade()
+	idx_call = mock_create.call_args_list[0]
+	assert idx_call.kwargs.get('postgresql_concurrently') is True
+
+
+def test_upgrade_runs_inside_autocommit_block():
+	"""CONCURRENTLY cannot run in a transaction; an autocommit block is required."""
+	_, _, ctx = _run_upgrade()
+	assert ctx.autocommit_block.called
+
+
+def test_upgrade_emits_rerun_guard():
+	"""A DROP INDEX IF EXISTS guard makes reruns safe after a failed
+	CONCURRENTLY build (which leaves an INVALID index)."""
+	_, executed, _ = _run_upgrade()
+	assert any(
+		"drop index if exists idx_episode_compositions_layout_id" in s.lower()
+		for s in executed
+	)
+
+
 def test_upgrade_layout_id_uses_btree():
 	"""idx_episode_compositions_layout_id must use btree index type."""
-	mod = _load_migration()
-	with patch('alembic.op.create_index') as mock_create:
-		mod.upgrade()
-	calls_by_name = {c.args[0]: c for c in mock_create.call_args_list}
-	idx_call = calls_by_name['idx_episode_compositions_layout_id']
+	mock_create, _, _ = _run_upgrade()
+	idx_call = mock_create.call_args_list[0]
 	assert idx_call.kwargs.get('postgresql_using') == 'btree'
 
 

--- a/apps/api/tests/unit/test_migration_006_episode_number_not_null.py
+++ b/apps/api/tests/unit/test_migration_006_episode_number_not_null.py
@@ -199,6 +199,15 @@ def test_upgrade_builds_unique_index_concurrently_then_attaches():
 	assert any(
 		"drop index if exists uq_episodes_project_number" in c for c in lowered
 	), "missing DROP INDEX IF EXISTS rerun guard"
+	# Rerun-safety, post-attach window: once the constraint owns the index,
+	# DROP INDEX alone errors — the constraint must be dropped first.
+	con_guard_idx = next(
+		(i for i, c in enumerate(lowered)
+		 if "drop constraint if exists uq_episodes_project_number" in c),
+		None,
+	)
+	assert con_guard_idx is not None, "missing DROP CONSTRAINT IF EXISTS rerun guard"
+	assert con_guard_idx < create_idx
 
 
 def test_upgrade_creates_composite_index_concurrently():

--- a/apps/api/tests/unit/test_migration_006_episode_number_not_null.py
+++ b/apps/api/tests/unit/test_migration_006_episode_number_not_null.py
@@ -1,9 +1,16 @@
 """
 Unit tests for migration 006_make_episode_number_not_null.
 
-Tests cover:
+Tests cover (issue #318 hardening):
 - Migration metadata (revision ID, down_revision chaining)
-- upgrade() backfills NULLs, alters column, creates unique constraint and index
+- upgrade() disables row_security before touching episodes (issue #301)
+- upgrade() renumbers pre-existing (project_id, episode_number) duplicates
+  BEFORE the NULL backfill, so the unique constraint can never abort
+- upgrade() enforces NOT NULL via CHECK NOT VALID -> VALIDATE -> SET NOT NULL
+  (no full-table scan under ACCESS EXCLUSIVE)
+- upgrade() builds the unique index CONCURRENTLY, then attaches it as the
+  uq_episodes_project_number constraint via USING INDEX
+- upgrade() builds idx_episodes_project_number CONCURRENTLY
 - downgrade() reverses all changes in correct order
 """
 
@@ -32,147 +39,191 @@ def _load_migration():
 	return module
 
 
+def _run_upgrade(mod):
+	"""Run upgrade() with all alembic entry points mocked.
+
+	Returns (sql_calls, mock_create_index) where sql_calls is the ordered list
+	of SQL strings executed across BOTH paths (connection.execute via
+	op.get_bind, and op.execute) so cross-stream ordering can be asserted.
+	"""
+	calls = []
+
+	def rec_bind(stmt, *args, **kwargs):
+		calls.append(str(stmt))
+		return MagicMock()
+
+	def rec_op(stmt, *args, **kwargs):
+		calls.append(str(stmt))
+
+	bind = MagicMock()
+	bind.execute.side_effect = rec_bind
+	with patch('alembic.op.get_bind', return_value=bind), \
+	     patch('alembic.op.execute', side_effect=rec_op), \
+	     patch('alembic.op.get_context', return_value=MagicMock()), \
+	     patch('alembic.op.create_index') as mock_idx:
+		mod.upgrade()
+	return calls, mock_idx
+
+
 # ============================================================================
 # METADATA TESTS
 # ============================================================================
 
 def test_migration_revision_id():
 	"""Migration must declare revision ID '006'."""
-	mod = _load_migration()
-	assert mod.revision == '006'
+	assert _load_migration().revision == '006'
 
 
 def test_migration_down_revision():
 	"""Migration must chain onto revision '005'."""
-	mod = _load_migration()
-	assert mod.down_revision == '005'
+	assert _load_migration().down_revision == '005'
 
 
 def test_migration_branch_labels_none():
-	"""Migration must not declare any branch labels."""
-	mod = _load_migration()
-	assert mod.branch_labels is None
+	assert _load_migration().branch_labels is None
 
 
 def test_migration_depends_on_none():
-	"""Migration must not declare any cross-branch dependencies."""
-	mod = _load_migration()
-	assert mod.depends_on is None
+	assert _load_migration().depends_on is None
 
 
 # ============================================================================
 # UPGRADE TESTS
 # ============================================================================
 
-def test_upgrade_alters_column_not_null():
-	"""upgrade() must alter episode_number to NOT NULL."""
+def test_upgrade_disables_row_security_first():
+	"""`SET LOCAL row_security = off` must precede all data access (issue #301)."""
+	calls, _ = _run_upgrade(_load_migration())
+	assert calls, "upgrade() executed no SQL"
+	assert calls[0].strip().lower() == "set local row_security = off"
+
+
+def test_upgrade_renumbers_duplicates_before_backfill():
+	"""Pre-existing (project_id, episode_number) duplicates must be renumbered
+	BEFORE the NULL backfill, otherwise the unique constraint aborts (#318)."""
+	calls, _ = _run_upgrade(_load_migration())
+	lowered = [c.lower() for c in calls]
+	dedupe_idx = next(
+		(i for i, c in enumerate(lowered) if "dup_rank" in c), None
+	)
+	backfill_idx = next(
+		(i for i, c in enumerate(lowered) if "episode_number is null" in c), None
+	)
+	assert dedupe_idx is not None, "no duplicate-renumbering statement found"
+	assert backfill_idx is not None, "no NULL backfill statement found"
+	assert dedupe_idx < backfill_idx, "dedupe must run before the NULL backfill"
+
+
+def test_upgrade_dedupe_keeps_earliest_and_renumbers_above_max():
+	"""The dedupe statement must rank duplicates by created_at (keep earliest)
+	and renumber losers above the project's current max episode_number."""
+	calls, _ = _run_upgrade(_load_migration())
+	dedupe = next(c for c in calls if "dup_rank" in c.lower())
+	lowered = dedupe.lower()
+	assert "partition by project_id, episode_number" in lowered
+	assert "order by created_at asc" in lowered
+	assert "max(episode_number)" in lowered
+
+
+def test_upgrade_not_null_uses_not_valid_then_validate():
+	"""NOT NULL must be applied via CHECK ... NOT VALID -> VALIDATE ->
+	SET NOT NULL -> DROP CHECK, never a scanning ALTER under exclusive lock."""
+	calls, _ = _run_upgrade(_load_migration())
+	lowered = [c.lower() for c in calls]
+
+	def idx_of(fragment):
+		match = next((i for i, c in enumerate(lowered) if fragment in c), None)
+		assert match is not None, f"missing statement containing: {fragment}"
+		return match
+
+	add_idx = idx_of("check (episode_number is not null) not valid")
+	validate_idx = idx_of("validate constraint ck_episodes_episode_number_not_null")
+	set_idx = idx_of("alter column episode_number set not null")
+	drop_idx = idx_of("drop constraint ck_episodes_episode_number_not_null")
+	assert add_idx < validate_idx < set_idx < drop_idx
+
+
+def test_upgrade_check_constraint_add_has_rerun_guard():
+	"""Everything before the autocommit block commits when it opens, so a
+	later failure would strand the check constraint; the re-add must be
+	preceded by DROP CONSTRAINT IF EXISTS to keep reruns safe (#318)."""
+	calls, _ = _run_upgrade(_load_migration())
+	lowered = [c.lower() for c in calls]
+	guard_idx = next(
+		(i for i, c in enumerate(lowered)
+		 if "drop constraint if exists ck_episodes_episode_number_not_null" in c),
+		None,
+	)
+	add_idx = next(
+		i for i, c in enumerate(lowered)
+		if "check (episode_number is not null) not valid" in c
+	)
+	assert guard_idx is not None, "missing DROP CONSTRAINT IF EXISTS rerun guard"
+	assert guard_idx < add_idx
+
+
+def test_upgrade_does_not_use_scanning_alter_column():
+	"""upgrade() must not call op.alter_column (full-scan ACCESS EXCLUSIVE)."""
 	mod = _load_migration()
-	mock_conn = MagicMock()
-	with patch('alembic.op.get_bind', return_value=mock_conn), \
+	bind = MagicMock()
+	with patch('alembic.op.get_bind', return_value=bind), \
+	     patch('alembic.op.execute'), \
+	     patch('alembic.op.get_context', return_value=MagicMock()), \
+	     patch('alembic.op.create_index'), \
 	     patch('alembic.op.alter_column') as mock_alter, \
-	     patch('alembic.op.create_unique_constraint'), \
-	     patch('alembic.op.create_index'):
+	     patch('alembic.op.create_unique_constraint') as mock_uq:
 		mod.upgrade()
-	# alter_column must be called for episodes.episode_number with nullable=False
-	assert mock_alter.call_count >= 1
-	alter_calls = {c.args[0]: c for c in mock_alter.call_args_list}
-	assert 'episodes' in alter_calls
-	episodes_call = alter_calls['episodes']
-	assert episodes_call.args[1] == 'episode_number'
-	assert episodes_call.kwargs.get('nullable') is False
+	assert not mock_alter.called
+	assert not mock_uq.called
 
 
-def test_upgrade_creates_unique_constraint():
-	"""upgrade() must create uq_episodes_project_number constraint."""
-	mod = _load_migration()
-	mock_conn = MagicMock()
-	with patch('alembic.op.get_bind', return_value=mock_conn), \
-	     patch('alembic.op.alter_column'), \
-	     patch('alembic.op.create_unique_constraint') as mock_unique, \
-	     patch('alembic.op.create_index'):
-		mod.upgrade()
-	constraint_names = [c.args[0] for c in mock_unique.call_args_list]
-	assert 'uq_episodes_project_number' in constraint_names
+def test_upgrade_builds_unique_index_concurrently_then_attaches():
+	"""Unique enforcement must be CREATE UNIQUE INDEX CONCURRENTLY followed by
+	ADD CONSTRAINT ... UNIQUE USING INDEX (no write-blocking index build)."""
+	calls, _ = _run_upgrade(_load_migration())
+	lowered = [c.lower() for c in calls]
+	create_idx = next(
+		(i for i, c in enumerate(lowered)
+		 if "create unique index concurrently uq_episodes_project_number" in c),
+		None,
+	)
+	attach_idx = next(
+		(i for i, c in enumerate(lowered)
+		 if "unique using index uq_episodes_project_number" in c),
+		None,
+	)
+	assert create_idx is not None, "unique index not built CONCURRENTLY"
+	assert attach_idx is not None, "unique index never attached as constraint"
+	assert create_idx < attach_idx
+	# Rerun-safety: a failed CONCURRENTLY build leaves an INVALID index behind.
+	assert any(
+		"drop index if exists uq_episodes_project_number" in c for c in lowered
+	), "missing DROP INDEX IF EXISTS rerun guard"
 
 
-def test_upgrade_unique_constraint_targets_correct_columns():
-	"""uq_episodes_project_number must cover (project_id, episode_number)."""
-	mod = _load_migration()
-	mock_conn = MagicMock()
-	with patch('alembic.op.get_bind', return_value=mock_conn), \
-	     patch('alembic.op.alter_column'), \
-	     patch('alembic.op.create_unique_constraint') as mock_unique, \
-	     patch('alembic.op.create_index'):
-		mod.upgrade()
-	calls_by_name = {c.args[0]: c for c in mock_unique.call_args_list}
-	uq_call = calls_by_name['uq_episodes_project_number']
-	# args: (name, table, columns)
-	assert uq_call.args[1] == 'episodes'
-	columns = uq_call.args[2]
-	assert 'project_id' in columns
-	assert 'episode_number' in columns
-
-
-def test_upgrade_creates_composite_index():
-	"""upgrade() must create idx_episodes_project_number index."""
-	mod = _load_migration()
-	mock_conn = MagicMock()
-	with patch('alembic.op.get_bind', return_value=mock_conn), \
-	     patch('alembic.op.alter_column'), \
-	     patch('alembic.op.create_unique_constraint'), \
-	     patch('alembic.op.create_index') as mock_idx:
-		mod.upgrade()
-	index_names = [c.args[0] for c in mock_idx.call_args_list]
-	assert 'idx_episodes_project_number' in index_names
-
-
-def test_upgrade_index_targets_correct_table_and_columns():
-	"""idx_episodes_project_number must target episodes.(project_id, episode_number)."""
-	mod = _load_migration()
-	mock_conn = MagicMock()
-	with patch('alembic.op.get_bind', return_value=mock_conn), \
-	     patch('alembic.op.alter_column'), \
-	     patch('alembic.op.create_unique_constraint'), \
-	     patch('alembic.op.create_index') as mock_idx:
-		mod.upgrade()
+def test_upgrade_creates_composite_index_concurrently():
+	"""idx_episodes_project_number must be created with CONCURRENTLY."""
+	_, mock_idx = _run_upgrade(_load_migration())
 	calls_by_name = {c.args[0]: c for c in mock_idx.call_args_list}
+	assert 'idx_episodes_project_number' in calls_by_name
 	idx_call = calls_by_name['idx_episodes_project_number']
 	assert idx_call.args[1] == 'episodes'
-	columns = idx_call.args[2]
-	assert 'project_id' in columns
-	assert 'episode_number' in columns
+	assert 'project_id' in idx_call.args[2]
+	assert 'episode_number' in idx_call.args[2]
+	assert idx_call.kwargs.get('postgresql_concurrently') is True
 
 
-def test_upgrade_executes_backfill_sql():
-	"""upgrade() must execute a SQL statement to backfill NULL episode_numbers."""
-	mod = _load_migration()
-	mock_conn = MagicMock()
-	with patch('alembic.op.get_bind', return_value=mock_conn), \
-	     patch('alembic.op.alter_column'), \
-	     patch('alembic.op.create_unique_constraint'), \
-	     patch('alembic.op.create_index'):
-		mod.upgrade()
-	assert mock_conn.execute.called
-
-
-def test_upgrade_disables_row_security_before_backfill():
-	"""upgrade() must `SET LOCAL row_security = off` before the backfill (issue #301).
-
-	This makes a non-BYPASSRLS migration run fail loudly instead of silently
-	no-oping the backfill and then building constraints over un-backfilled data.
-	"""
-	mod = _load_migration()
-	mock_conn = MagicMock()
-	with patch('alembic.op.get_bind', return_value=mock_conn), \
-	     patch('alembic.op.alter_column'), \
-	     patch('alembic.op.create_unique_constraint'), \
-	     patch('alembic.op.create_index'):
-		mod.upgrade()
-	executed = [str(c.args[0]) for c in mock_conn.execute.call_args_list]
-	assert executed, "upgrade() executed no SQL"
-	assert executed[0].strip().lower() == "set local row_security = off"
-	# The backfill (an UPDATE) must come after the guard.
-	assert any("update episodes" in sql.lower() for sql in executed[1:])
+def test_upgrade_dedupe_and_backfill_precede_constraints():
+	"""All data repair must be complete before any constraint DDL runs."""
+	calls, _ = _run_upgrade(_load_migration())
+	lowered = [c.lower() for c in calls]
+	backfill_idx = next(
+		i for i, c in enumerate(lowered) if "episode_number is null" in c
+	)
+	first_ddl_idx = next(
+		i for i, c in enumerate(lowered) if "alter table episodes" in c
+	)
+	assert backfill_idx < first_ddl_idx
 
 
 # ============================================================================
@@ -208,7 +259,6 @@ def test_downgrade_restores_nullable_column():
 	     patch('alembic.op.drop_constraint'), \
 	     patch('alembic.op.alter_column') as mock_alter:
 		mod.downgrade()
-	assert mock_alter.call_count >= 1
 	alter_calls = {c.args[0]: c for c in mock_alter.call_args_list}
 	assert 'episodes' in alter_calls
 	episodes_call = alter_calls['episodes']

--- a/apps/api/tests/unit/test_migration_012_canonicalize_user_emails.py
+++ b/apps/api/tests/unit/test_migration_012_canonicalize_user_emails.py
@@ -86,6 +86,7 @@ def test_upgrade_disables_row_security_first():
 	bind.execute.side_effect = rec_bind
 	with patch('alembic.op.get_bind', return_value=bind), \
 	     patch('alembic.op.execute', side_effect=rec_op), \
+	     patch('alembic.op.get_context', return_value=MagicMock()), \
 	     patch('alembic.op.create_index'):
 		mod.upgrade()
 
@@ -106,6 +107,7 @@ def test_upgrade_lowercases_and_creates_unique_index_when_clean():
 	bind = _bind_with_collisions([])
 	with patch('alembic.op.get_bind', return_value=bind), \
 	     patch('alembic.op.execute') as mock_exec, \
+	     patch('alembic.op.get_context', return_value=MagicMock()), \
 	     patch('alembic.op.create_index') as mock_idx:
 		mod.upgrade()
 	# op.execute carries the lowercase UPDATE.
@@ -115,12 +117,33 @@ def test_upgrade_lowercases_and_creates_unique_index_when_clean():
 	assert 'uq_users_email_lower' in index_names
 
 
+def test_upgrade_builds_index_concurrently_with_rerun_guard():
+	"""users pre-exists and may be large: the unique lower(email) index must
+	build CONCURRENTLY inside an autocommit block, with a DROP INDEX IF EXISTS
+	guard so a failed build (INVALID index) doesn't wedge reruns (#318)."""
+	mod = _load_migration()
+	bind = _bind_with_collisions([])
+	ctx = MagicMock()
+	with patch('alembic.op.get_bind', return_value=bind), \
+	     patch('alembic.op.execute') as mock_exec, \
+	     patch('alembic.op.get_context', return_value=ctx), \
+	     patch('alembic.op.create_index') as mock_idx:
+		mod.upgrade()
+	assert ctx.autocommit_block.called
+	idx_call = {c.args[0]: c for c in mock_idx.call_args_list}['uq_users_email_lower']
+	assert idx_call.kwargs.get('unique') is True
+	assert idx_call.kwargs.get('postgresql_concurrently') is True
+	executed = " ".join(str(c.args[0]).lower() for c in mock_exec.call_args_list)
+	assert "drop index if exists uq_users_email_lower" in executed
+
+
 def test_upgrade_aborts_on_case_variant_collision():
 	"""upgrade() must raise RuntimeError when case-variant duplicates exist."""
 	mod = _load_migration()
 	bind = _bind_with_collisions([SimpleNamespace(canonical="a@x.com", n=2)])
 	with patch('alembic.op.get_bind', return_value=bind), \
 	     patch('alembic.op.execute') as mock_exec, \
+	     patch('alembic.op.get_context', return_value=MagicMock()), \
 	     patch('alembic.op.create_index') as mock_idx:
 		with pytest.raises(RuntimeError, match="case-variant duplicate"):
 			mod.upgrade()

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,62 @@
-# Tasks
+# #318 — Migration safety: dupe-safe 006, lock-safe DDL, complete env.py metadata
 
-_No active task._ Last shipped: #317 (nginx upstream port drift — provision-ssl.sh API_PORT/FRONTEND_PORT parameterization + drift regression gate) via PR #397, merged 2026-07-14.
+Branch: `fix/318-migration-safety`
+
+## Context
+- All migrations ≤017 are already applied on every live env (staging VPS, CI runs fresh).
+  Edits to historical migrations only affect fresh/behind DBs — but the fixes below are
+  correctness/safety hardening that costs nothing and protects any future replay.
+- env.py bug is LIVE: `target_metadata` only sees the original 11 models, so the next
+  `alembic revision --autogenerate` would emit DROP TABLE for teams/billing/analytics/outbox.
+
+## Changes
+
+### 1. 006 — renumber pre-existing duplicates before constraint (correctness)
+Before the NULL backfill, renumber duplicate (project_id, episode_number) non-NULL rows:
+keep the earliest `created_at` per group, move later rows to `project_max + n`. Then the
+existing NULL backfill and the unique constraint can never abort.
+
+### 2. 006 — lock-safe NOT NULL + unique (acceptance: NOT VALID→VALIDATE, CONCURRENTLY)
+- NOT NULL: `ADD CONSTRAINT ... CHECK (episode_number IS NOT NULL) NOT VALID` →
+  `VALIDATE CONSTRAINT` → `SET NOT NULL` (PG12+ skips the scan via the valid check) → drop check.
+- Unique: `CREATE UNIQUE INDEX CONCURRENTLY` in an `autocommit_block()`, then
+  `ALTER TABLE ... ADD CONSTRAINT uq_episodes_project_number UNIQUE USING INDEX ...`.
+- `idx_episodes_project_number`: `postgresql_concurrently=True` in autocommit block.
+- `DROP INDEX IF EXISTS` guards before each concurrent create (rerun-safe after a failed
+  CONCURRENTLY build, which leaves an INVALID index).
+
+### 3. 004 / 005 / 008 / 012 — CONCURRENTLY for indexes on pre-existing tables
+Wrap each `op.create_index` in `op.get_context().autocommit_block()` with
+`postgresql_concurrently=True` + drop-if-exists guard. 008 keeps the column adds
+transactional; 012 keeps guard/collision-check/UPDATE transactional, index moves after.
+
+### 4. 011 — deliberately NOT concurrent (documented deviation)
+`analytics_events` is created in the same migration: the table is empty and invisible to
+other transactions, so plain CREATE INDEX blocks nothing; CONCURRENTLY would only add
+partial-failure modes. Add a comment saying so.
+
+### 5. env.py — import the whole model package
+Replace the hand-maintained 11-model import with `import src.models` (package `__init__`
+registers all models on Base.metadata). Comment warns against regressing to a hand-list.
+
+### 6. New test — metadata == migrated schema
+`tests/test_migration_metadata.py`: table-name set of `Base.metadata` (after importing
+`src.models`) == tables in the live migrated test DB (minus `alembic_version`).
+Catches both drift directions. (Column-level autogenerate-clean check is NOT possible yet —
+known model/migration drift, see memory: billing FKs in 010 absent from models.)
+
+### 7. Update existing unit tests (TDD: first)
+- 004/005/012: assert `postgresql_concurrently=True` and autocommit_block usage.
+- 006: rewrite — dupe-renumber SQL precedes backfill; NOT VALID→VALIDATE→SET NOT NULL
+  ordering; concurrent unique index + USING INDEX attach; row_security guard still first.
+
+## Verification
+- `uv run pytest tests/` (full suite, CI parity)
+- Demo (Phase 11): fresh scratch DB → migrate to 005 → seed dupes + NULLs → run 006 →
+  show renumbering, constraint present, no abort. Plus `alembic upgrade head` on fresh DB.
+- ruff + pre-commit.
+
+## Non-goals
+- Downgrade paths stay plain (dev-only).
+- No column-level autogenerate assertion (blocked by known model drift #308).
+- No changes to 013–017.


### PR DESCRIPTION
Closes #318

## Problem
1. **006 aborts on dirty data**: it backfilled only NULL `episode_number`s, then added `uq_episodes_project_number` — any pre-existing `(project_id, episode_number)` duplicate aborted the migration.
2. **Write-blocking DDL**: index creation in 004/005/006/008/012 and the `SET NOT NULL` in 006 ran inside Alembic's transaction without CONCURRENTLY, holding ACCESS EXCLUSIVE locks for the full scan/build on large tables.
3. **env.py metadata incomplete (live bug)**: `target_metadata` imported only the original 11 models — the next `alembic revision --autogenerate` would have emitted `DROP TABLE` for teams, billing, analytics, and the storage-deletion outbox.

## Changes
- **006**: renumbers duplicate `(project_id, episode_number)` rows before the backfill (earliest `created_at` keeps its number; later rows move above the project max — CTEs read the pre-UPDATE snapshot, so no collisions). NOT NULL via `CHECK ... NOT VALID → VALIDATE → SET NOT NULL` (PG12+ skips the rescan); unique constraint via `CREATE UNIQUE INDEX CONCURRENTLY` + `ADD CONSTRAINT ... UNIQUE USING INDEX`.
- **004/005/008/012**: indexes on pre-existing tables build CONCURRENTLY in `autocommit_block()`s, each with a `DROP INDEX IF EXISTS` rerun guard (failed CONCURRENTLY builds leave INVALID indexes). 008's column adds use `if_not_exists=True` and 006's check-constraint add has a drop-guard, so a failure after the autocommit split can't wedge reruns.
- **011**: deliberately **not** CONCURRENTLY — `analytics_events` is created in the same migration, so it's empty and invisible to other transactions; plain CREATE INDEX blocks nothing while CONCURRENTLY would only add partial-failure modes. Documented in the migration.
- **env.py**: imports the whole `src.models` package; comment forbids regressing to a hand-list.
- **New `tests/test_migration_metadata.py`**: asserts `Base.metadata` table set == migrated schema table set (fails in both drift directions).
- Migration unit tests for 004/005/006/012 rewritten/extended for the new DDL shapes (CONCURRENTLY kwargs, autocommit blocks, rerun guards, NOT VALID→VALIDATE ordering, dedupe-before-backfill ordering).

## Verification
- Full backend suite: **1824 passed, 7 skipped** (coverage gates enforced).
- Live end-to-end on scratch DBs: fresh DB → `upgrade 005` → seeded triplicate `2,2,2` + dupe pair + NULLs → `upgrade head` succeeds; earliest rows keep their numbers, dupes renumber above max, NULLs backfill after; `uq_episodes_project_number` (contype `u`), NOT NULL, and both indexes verified in `pg_constraint`/`pg_indexes`. Pure fresh single-shot `upgrade head` (CI parity) also green.
- Third-party review (opencode/GLM): no critical findings; its rerun-safety findings (stranded check constraint, 008 column re-add) were confirmed and fixed.

## Known limitations
- Column-level autogenerate-clean assertion is deliberately out of scope: models are known to omit some real DB constraints (#308), so the new test compares table sets only.
- Downgrade paths stay plain (non-concurrent) — dev-only.
- No live-DB test permanently exercises the 006 dupe path (the head-migrated test DB can't hold seed duplicates under the unique constraint); covered by mock-level ordering tests + the scripted scratch-DB demo.