### PR TITLE
[P5.3] DR/durability hardening: pre-migration dump gates deploy, Redis AOF, S3 restore runbook (#319)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -161,6 +161,13 @@ jobs:
             apps/api/alembic/ \
             $SSH_USER@$SSH_HOST:$SERVER_PATH/api/alembic/
 
+          # Sync the backup script so the pre-migration dump below always runs
+          # the committed version (issue #319). Same path the #293 systemd
+          # timer executes, so this also keeps the nightly backup fresh.
+          rsync -avz -e "ssh -i ~/.ssh/deploy_key" \
+            deployment/scripts/backup-db.sh \
+            $SSH_USER@$SSH_HOST:$SERVER_PATH/deployment/scripts/
+
           # Install dependencies and restart on server
           ssh -i ~/.ssh/deploy_key $SSH_USER@$SSH_HOST << EOF
             # Fail fast: a failed migration or sync must abort the deploy before
@@ -176,6 +183,20 @@ jobs:
 
             # Sync dependencies using uv (creates .venv automatically)
             uv sync
+
+            # Pre-migration off-host dump (issue #319): gate the migration on a
+            # fresh restore point. backup-db.sh hard-fails if the S3 bucket or
+            # creds are missing or the dump comes out empty, and set -e above
+            # aborts the deploy BEFORE the live schema is touched. The
+            # pre-migration/ prefix keeps these dumps distinguishable from the
+            # nightly ones and is pruned by the script's own retention window.
+            # The app .env supplies DATABASE_URL / AWS_* (values must stay
+            # shell-sourceable — see deployment/README.md).
+            set -a
+            . ./.env
+            set +a
+            DB_BACKUP_S3_PREFIX="db-backups/pre-migration/" \
+              bash $SERVER_PATH/deployment/scripts/backup-db.sh
 
             # Run database migrations
             uv run alembic upgrade head

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -164,6 +164,10 @@ jobs:
           # Sync the backup script so the pre-migration dump below always runs
           # the committed version (issue #319). Same path the #293 systemd
           # timer executes, so this also keeps the nightly backup fresh.
+          # mkdir -p first: rsync does not create intermediate remote dirs,
+          # and a host deployed only by this workflow has no deployment/ tree.
+          ssh -i ~/.ssh/deploy_key $SSH_USER@$SSH_HOST \
+            "mkdir -p $SERVER_PATH/deployment/scripts"
           rsync -avz -e "ssh -i ~/.ssh/deploy_key" \
             deployment/scripts/backup-db.sh \
             $SSH_USER@$SSH_HOST:$SERVER_PATH/deployment/scripts/

--- a/apps/api/docs/demos/issue319-dr-durability.md
+++ b/apps/api/docs/demos/issue319-dr-durability.md
@@ -1,0 +1,383 @@
+# Issue #319 — DR/durability: pre-migration dump gate, RLS-safe backup+restore, Redis AOF
+
+*2026-07-15T03:50:05Z*
+
+Acceptance criteria under demo: **(AC1)** an off-host `pg_dump` runs BEFORE `alembic upgrade head` and a failed dump aborts the deploy; **(AC2)** Redis durability is decided and actionable (AOF script + reaper backstop); **(AC3)** S3 versioning + MFA-delete hardening documented; **(AC4)** Postgres + S3 restore runbooks with RTO/RPO.
+
+**Environment shims (disclosed).** This host has no `pg_dump` binary and no S3 credentials, so `pg_dump`/`pg_restore` are shimmed through the real `postgres:16` container holding the dev database, and `aws s3` is shimmed onto a local directory. Everything under test — `backup-db.sh`, `restore-db.sh`, `configure-redis-persistence.sh`, the deploy workflow, a real Redis 7 container — runs **unmodified**. The shims stand in for the transport only, never for the behavior being verified.
+
+## AC1 — the dump runs before the migration, and gates the deploy
+
+Ordering is a property of the deploy workflow, so start there.
+
+```bash
+grep -n "mkdir -p \$SERVER_PATH/deployment/scripts\|backup-db.sh\|alembic upgrade head" .github/workflows/deploy-dev.yml
+```
+
+```output
+78:        run: uv run alembic upgrade head
+170:            "mkdir -p $SERVER_PATH/deployment/scripts"
+172:            deployment/scripts/backup-db.sh \
+192:            # fresh restore point. backup-db.sh hard-fails if the S3 bucket or
+203:              bash $SERVER_PATH/deployment/scripts/backup-db.sh
+206:            uv run alembic upgrade head
+```
+
+The dump (203) precedes `alembic upgrade head` (206), and 170 `mkdir -p`s the remote dir before the rsync at 172 — rsync does not create intermediate remote dirs, so without it the deploy dies on a host with no `deployment/` tree. (78 is the CI migration job, a different workflow stage.)
+
+Here is the gating block verbatim.
+
+```bash
+sed -n "188,207p" .github/workflows/deploy-dev.yml
+```
+
+```output
+            # Sync dependencies using uv (creates .venv automatically)
+            uv sync
+
+            # Pre-migration off-host dump (issue #319): gate the migration on a
+            # fresh restore point. backup-db.sh hard-fails if the S3 bucket or
+            # creds are missing or the dump comes out empty, and set -e above
+            # aborts the deploy BEFORE the live schema is touched. The
+            # pre-migration/ prefix keeps these dumps distinguishable from the
+            # nightly ones and is pruned by the script's own retention window.
+            # The app .env supplies DATABASE_URL / AWS_* (values must stay
+            # shell-sourceable — see deployment/README.md).
+            set -a
+            . ./.env
+            set +a
+            DB_BACKUP_S3_PREFIX="db-backups/pre-migration/" \
+              bash $SERVER_PATH/deployment/scripts/backup-db.sh
+
+            # Run database migrations
+            uv run alembic upgrade head
+
+```
+
+Now run the real script the deploy invokes, against the real dev database, with the same `pre-migration/` prefix.
+
+```bash
+. /tmp/claude-1000/-home-frankbria-projects-podcaststudiohub/18be6d28-8867-4764-acca-fa4a5e34cadf/scratchpad/demo-env.sh && rm -rf "$FAKE_S3_ROOT" && DB_BACKUP_S3_PREFIX=db-backups/pre-migration/ bash deployment/scripts/backup-db.sh
+```
+
+```output
+Dumping database -> s3://demo-bucket/db-backups/pre-migration/podcastfy-20260715T035019Z.dump
+copy: /tmp/podcastfy-db-GhjF90.dump -> s3://demo-bucket/db-backups/pre-migration/podcastfy-20260715T035019Z.dump
+Uploaded 96K to s3://demo-bucket/db-backups/pre-migration/podcastfy-20260715T035019Z.dump
+Pruning backups older than 2026-07-01 (retention 14d)
+Backup complete.
+```
+
+A 94 KB dump landed off-host under the dedicated prefix. Outcome evidence that it is a *real, restorable* dump rather than a file that merely exists — list the object, then read the table-of-contents `pg_restore` sees inside it:
+
+```bash
+. /tmp/claude-1000/-home-frankbria-projects-podcaststudiohub/18be6d28-8867-4764-acca-fa4a5e34cadf/scratchpad/demo-env.sh && aws s3 ls s3://demo-bucket/db-backups/pre-migration/ && cp "$FAKE_S3_ROOT"/demo-bucket/db-backups/pre-migration/*.dump /tmp/ac1.dump && docker cp /tmp/ac1.dump api-postgres-1:/tmp/ac1.dump >/dev/null && echo '--- tenant TABLE DATA entries inside the dump ---' && docker exec api-postgres-1 pg_restore -l /tmp/ac1.dump | grep -E 'TABLE DATA public (users|projects|episodes) '
+```
+
+```output
+2026-07-14 20:50:20      94232 podcastfy-20260715T035019Z.dump
+--- tenant TABLE DATA entries inside the dump ---
+3807; 0 20888 TABLE DATA public episodes podcastfy
+3806; 0 20857 TABLE DATA public projects podcastfy
+3803; 0 20796 TABLE DATA public users podcastfy
+```
+
+The dump carries real tenant `TABLE DATA` for `users`, `projects` and `episodes`.
+
+**The gate.** The claim is not just "a dump is taken" but "a failed dump stops the deploy before the schema is touched". Simulate the deploy block — `set -e`, dump, then migrate — with the backup misconfigured (no bucket), and check whether the migration still runs.
+
+```bash
+set +e; . /tmp/claude-1000/-home-frankbria-projects-podcaststudiohub/18be6d28-8867-4764-acca-fa4a5e34cadf/scratchpad/demo-env.sh; unset DB_BACKUP_S3_BUCKET AWS_S3_BUCKET; ( set -e; bash deployment/scripts/backup-db.sh; echo 'MIGRATION RAN — GATE FAILED'; ); echo "deploy step exit code: $?"
+```
+
+```output
+DB_BACKUP_S3_BUCKET (or AWS_S3_BUCKET) must be set — refusing a host-only backup.
+deploy step exit code: 1
+```
+
+The dump hard-failed, `set -e` aborted the block, the migration line never printed, and the deploy step exits non-zero — GitHub Actions marks the deploy failed with the schema untouched. **AC1 verified.**
+
+## AC1b — the dump/restore pair is RLS-safe (the two review findings)
+
+A restore point is only worth the migration it guards if it can actually be *reloaded*. Tenant tables carry FORCE row-level security (migration 014), which makes the connecting role decisive on both sides. First, the ground truth:
+
+```bash
+docker exec api-postgres-1 psql -U podcastfy -d podcastfy -Atc "select relname, relrowsecurity as rls, relforcerowsecurity as force_rls from pg_class where relname in ('users','projects','episodes') order by 1" && echo '--- roles: does this role escape RLS? ---' && docker exec api-postgres-1 psql -U podcastfy -d podcastfy -Atc "select rolname, rolsuper, rolbypassrls, rolsuper or rolbypassrls as escapes_rls from pg_roles where rolname like 'podcastfy%' order by 1"
+```
+
+```output
+episodes|t|t
+projects|t|t
+users|t|t
+--- roles: does this role escape RLS? ---
+podcastfy|t|f|t
+podcastfy_app|f|f|f
+podcastfy_user|f|t|t
+```
+
+FORCE RLS is on for all three tenant tables — that is the flag that makes RLS bind even the table owner, so ownership alone is no escape. Only a **superuser** or a **BYPASSRLS** role escapes it. On this host `MIGRATION_DATABASE_URL` resolves to `podcastfy` (superuser, escapes); `DATABASE_URL` resolves to `podcastfy_app` (escapes nothing). The staging VPS has the same split — a privileged migration role plus the RLS-subject app role.
+
+That asymmetry is the entire bug on both sides. A restore session never arms `app.tenant_id`, so under `podcastfy_app` every tenant row fails its `WITH CHECK` policy. Show the mechanism directly rather than asserting it — insert one row as the app role into a restored copy:
+
+```bash
+bash /tmp/claude-1000/-home-frankbria-projects-podcaststudiohub/18be6d28-8867-4764-acca-fa4a5e34cadf/scratchpad/rls-mechanism.sh
+```
+
+```output
+--- INSERT one tenant row as podcastfy_app, no app.tenant_id armed (exactly a restore session) ---
+ERROR:  new row violates row-level security policy for table "projects"
+--- how many of the 15 restored projects can the app role even SEE? ---
+0
+```
+
+There it is, live: the app role cannot write a tenant row (`new row violates row-level security policy`) and cannot read one either (0 of 15). `restore-db.sh` runs `pg_restore --single-transaction --exit-on-error`, so that first `COPY` error rolls back the **entire** restore — the guaranteed restore point would have been unrestorable via the documented rollback path. Same root cause on the dump side: `pg_dump` as this role errors rather than silently shipping an empty dump.
+
+Both halves now prefer the privileged role. Dump side (`backup-db.sh`) and restore side (`restore-db.sh`, fixed this cycle from the GLM review finding):
+
+```bash
+grep -n -A2 "^SRC_URL=" deployment/scripts/backup-db.sh deployment/scripts/restore-db.sh
+```
+
+```output
+deployment/scripts/backup-db.sh:43:SRC_URL="${MIGRATION_DATABASE_URL:-${DATABASE_URL:-}}"
+deployment/scripts/backup-db.sh-44-CONN=()
+deployment/scripts/backup-db.sh-45-if [[ -n "$SRC_URL" ]]; then
+--
+deployment/scripts/restore-db.sh:34:SRC_URL="${MIGRATION_DATABASE_URL:-${DATABASE_URL:-}}"
+deployment/scripts/restore-db.sh-35-if [[ -n "$SRC_URL" ]]; then
+deployment/scripts/restore-db.sh-36-	TARGET_DB="${SRC_URL/postgresql+asyncpg:/postgresql:}"
+```
+
+## AC4 — the restore runbook actually round-trips
+
+The real test of AC4 is not that a runbook exists but that its commands reload the dump AC1 just took. Run the documented rollback path verbatim against a throwaway database and compare row counts to the source.
+
+```bash
+. /tmp/claude-1000/-home-frankbria-projects-podcaststudiohub/18be6d28-8867-4764-acca-fa4a5e34cadf/scratchpad/demo-env.sh && bash /tmp/claude-1000/-home-frankbria-projects-podcaststudiohub/18be6d28-8867-4764-acca-fa4a5e34cadf/scratchpad/roundtrip.sh
+```
+
+```output
+--- source database ---
+users=15|projects=15|episodes=13
+--- documented rollback: restore-db.sh, pre-migration prefix, throwaway target ---
+Selected backup: s3://demo-bucket/db-backups/pre-migration/podcastfy-20260715T035019Z.dump
+Downloading s3://demo-bucket/db-backups/pre-migration/podcastfy-20260715T035019Z.dump...
+copy: s3://demo-bucket/db-backups/pre-migration/podcastfy-20260715T035019Z.dump -> /tmp/podcastfy-restore-NAJ0s5.dump
+Restoring into target database...
+Restore complete from s3://demo-bucket/db-backups/pre-migration/podcastfy-20260715T035019Z.dump.
+--- restored database ---
+users=15|projects=15|episodes=13
+```
+
+15/15/13 in, 15/15/13 out — the pre-migration dump reloads through the documented path.
+
+**Is the restore-side fix actually load-bearing?** Green tests prove little if the old code also passed. Re-run the same round-trip with the fix reverted (target derived from `DATABASE_URL`, the RLS-subject role) — the pre-fix behavior:
+
+```bash
+. /tmp/claude-1000/-home-frankbria-projects-podcaststudiohub/18be6d28-8867-4764-acca-fa4a5e34cadf/scratchpad/demo-env.sh && bash /tmp/claude-1000/-home-frankbria-projects-podcaststudiohub/18be6d28-8867-4764-acca-fa4a5e34cadf/scratchpad/counterfactual.sh
+```
+
+```output
+--- restoring as podcastfy_app (pre-fix code path) ---
+pg_restore: error: could not execute query: ERROR:  permission denied to create extension "pgcrypto"
+exit=1
+--- rows recovered by the pre-fix path ---
+ERROR:  relation "projects" does not exist
+```
+
+The pre-fix path recovers **nothing**: `pg_restore` exits 1 and `projects` does not exist. Precisely what this run shows, without overclaiming: on this host the app role hits an even earlier barrier — it cannot create the `pgcrypto` extension — and `--exit-on-error --single-transaction` rolls the whole restore back there, before reaching the tenant `COPY`s. The RLS `WITH CHECK` barrier is real and was demonstrated directly in AC1b above (`new row violates row-level security policy`); this run simply proves the unprivileged target is unusable *whichever* barrier it meets first, and the privileged role clears both. Fixed path: 15/15/13. Pre-fix path: zero. **The fix is load-bearing.**
+
+The behavior is pinned by a static contract test on each side. Mutation check — the test must fail against the pre-fix script, not merely pass against the fixed one:
+
+```bash
+cd apps/api && uv run pytest ../../deployment/tests/test_dr_durability.py -q -k "privileged_role or restore_targets" 2>&1 | tail -3
+echo "--- MUTATION: revert restore-db.sh to the pre-fix DATABASE_URL target ---"
+cp ../../deployment/scripts/restore-db.sh /tmp/restore-db.bak
+sed -i "s|^SRC_URL=\"\${MIGRATION_DATABASE_URL:-\${DATABASE_URL:-}}\"|SRC_URL=\"\${DATABASE_URL:-}\"|" ../../deployment/scripts/restore-db.sh
+uv run pytest ../../deployment/tests/test_dr_durability.py -q -k "restore_targets" 2>&1 | tail -2
+cp /tmp/restore-db.bak ../../deployment/scripts/restore-db.sh
+echo "--- restored; suite green again ---"
+uv run pytest ../../deployment/tests/ -q 2>&1 | tail -1
+```
+
+```output
+..                                                                       [100%]
+2 passed, 14 deselected in 0.01s
+--- MUTATION: revert restore-db.sh to the pre-fix DATABASE_URL target ---
+FAILED ../../deployment/tests/test_dr_durability.py::test_restore_targets_privileged_role
+1 failed, 15 deselected in 0.03s
+--- restored; suite green again ---
+58 passed in 2.10s
+```
+
+## AC2 — Redis durability: AOF enabled, and it survives a hard kill
+
+Redis is the Celery broker, result backend and OAuth-state store; without persistence a restart silently drops every queued generation job. Run the real script against a real Redis 7 container that starts with persistence off, then prove durability the only way that counts — `SIGKILL`, not a graceful shutdown that would flush anyway.
+
+```bash
+docker rm -f demo-redis-319 >/dev/null 2>&1; docker volume rm demo319 >/dev/null 2>&1
+# conf on a named volume so a restart re-reads what CONFIG REWRITE wrote,
+# rather than an entrypoint re-truncating it (that would test the harness, not redis).
+docker volume create demo319 >/dev/null
+docker run --rm -v demo319:/data redis:7 sh -c "printf \"save \\\"\\\"\n\" > /data/redis.conf"
+docker run -d --name demo-redis-319 -v demo319:/data redis:7 redis-server /data/redis.conf >/dev/null
+sleep 2
+echo "--- baseline: AOF off, RDB snapshots disabled (save \"\") — a restart here loses everything ---"
+docker exec demo-redis-319 redis-cli CONFIG GET appendonly | tail -1
+```
+
+```output
+--- baseline: AOF off, RDB snapshots disabled (save "") — a restart here loses everything ---
+no
+```
+
+```bash
+REDIS_CLI="docker exec demo-redis-319 redis-cli" bash deployment/scripts/configure-redis-persistence.sh
+echo "--- queue a job, then SIGKILL redis (no graceful shutdown flush) ---"
+docker exec demo-redis-319 redis-cli SET celery-queued-job "{\"episode_id\": 42}" >/dev/null
+sleep 2
+docker kill -s KILL demo-redis-319 >/dev/null && docker start demo-redis-319 >/dev/null && sleep 2
+echo "--- after SIGKILL + restart ---"
+echo "job survived:    $(docker exec demo-redis-319 redis-cli GET celery-queued-job)"
+echo "appendonly still: $(docker exec demo-redis-319 redis-cli CONFIG GET appendonly | tail -1)"
+```
+
+```output
+Redis AOF persistence enabled (appendonly=yes, appendfsync=everysec) and persisted to redis.conf.
+--- queue a job, then SIGKILL redis (no graceful shutdown flush) ---
+--- after SIGKILL + restart ---
+job survived:    {"episode_id": 42}
+appendonly still: yes
+```
+
+The queued job survived a `SIGKILL` and `appendonly` is still `yes` after restart — the `CONFIG REWRITE` reached `redis.conf`, so the setting is not just live-but-amnesiac. **AC2 verified.**
+
+### A real bug this demo caught
+
+The first pass of this demo ran Redis with a **read-only** config file. The script printed its success line anyway. Cause: `redis-cli` exits **0** even when the server replies `ERR`, so `set -euo pipefail` could not see a refused `CONFIG REWRITE` — the script would report AOF enabled while it silently evaporated on the next restart, which is exactly the failure it exists to prevent. Fixed this cycle (capture the reply, hard-fail unless `OK`) and pinned by a new test. Reproduced live below against an unwritable conf:
+
+```bash
+docker rm -f demo-redis-ro >/dev/null 2>&1
+printf "save \"\"\n" > /tmp/ro-redis.conf && chmod 444 /tmp/ro-redis.conf
+docker run -d --name demo-redis-ro -v /tmp/ro-redis.conf:/usr/local/etc/redis/redis.conf:ro redis:7 redis-server /usr/local/etc/redis/redis.conf >/dev/null
+sleep 2
+echo "--- redis-cli exit code on a refused CONFIG REWRITE (the trap) ---"
+docker exec demo-redis-ro redis-cli CONFIG SET appendonly yes >/dev/null
+docker exec demo-redis-ro redis-cli CONFIG REWRITE; echo "redis-cli exit code: $?  <-- zero, despite the ERR"
+echo "--- the fixed script refuses to report success ---"
+REDIS_CLI="docker exec demo-redis-ro redis-cli" bash deployment/scripts/configure-redis-persistence.sh; echo "script exit code: $?"
+docker rm -f demo-redis-ro >/dev/null 2>&1
+```
+
+```output
+--- redis-cli exit code on a refused CONFIG REWRITE (the trap) ---
+ERR Rewriting config file: Permission denied
+
+redis-cli exit code: 0  <-- zero, despite the ERR
+--- the fixed script refuses to report success ---
+CONFIG REWRITE failed: ERR Rewriting config file: Permission denied
+AOF is live now but would be lost on restart — fix redis.conf permissions and re-run.
+script exit code: 1
+```
+
+The reaper is the documented backstop for anything stranded despite AOF — it exists and is scheduled, not just described:
+
+```bash
+grep -rn "reap_stuck_episodes" apps/api/src/ --include=*.py | head -4
+```
+
+```output
+apps/api/src/tasks/maintenance.py:4:``reap_stuck_episodes`` is the final safety net for issue #294: if a generation
+apps/api/src/tasks/maintenance.py:52:@celery_app.task(bind=True, name="reap_stuck_episodes")
+apps/api/src/tasks/maintenance.py:53:def reap_stuck_episodes(self: Task) -> int:
+apps/api/src/worker.py:68:    "reap_stuck_episodes": {"queue": "callbacks"},
+```
+
+## AC3 — S3 versioning + MFA-delete hardening documented
+
+S3 durability is documentation-and-runbook by nature (one-time console/root actions; no IaC in this repo to enforce them). The verifiable outcome is that the runbooks exist, are specific, and are pinned by tests so they cannot silently rot.
+
+```bash
+grep -n "^### \|^## " deployment/README.md | sed -n "/S3\|Redis durability\|Pre-migration\|backup\|Restore/Ip"
+```
+
+```output
+325:### AWS S3 / IAM permissions
+423:## Database Backup & Restore (DR) — issue #293
+485:### Restore runbook (tested)
+518:### Pre-migration dumps — issue #319
+537:## Redis durability — issue #319
+562:## S3 object storage DR — issue #319
+571:### Restore runbook: recover an overwritten or deleted object
+```
+
+```bash
+sed -n "562,600p" deployment/README.md
+```
+
+````output
+## S3 object storage DR — issue #319
+
+Generated audio lives in the versioned S3 bucket (versioning is a required
+setup step — see "Enable bucket versioning" above). **Recovery targets: RPO = 0
+for overwrites/deletes of existing objects** (every prior version is retained);
+**RTO ≈ minutes** (one `aws s3api` call per object). An object mid-upload when
+a job dies is simply regenerated — Postgres is the source of truth for what
+should exist.
+
+### Restore runbook: recover an overwritten or deleted object
+
+```bash
+# 1. List versions of the object (shows delete markers too):
+aws s3api list-object-versions --bucket podcaststudiohub-audio \
+  --prefix "episodes/<episode_id>/audio.mp3"
+
+# 2a. Object was DELETED → remove the delete marker (newest "DeleteMarkers" entry);
+#     the previous version becomes current again:
+aws s3api delete-object --bucket podcaststudiohub-audio \
+  --key "episodes/<episode_id>/audio.mp3" --version-id "<DELETE_MARKER_VERSION_ID>"
+
+# 2b. Object was OVERWRITTEN → copy the good old version over the current one:
+aws s3api copy-object --bucket podcaststudiohub-audio \
+  --copy-source "podcaststudiohub-audio/episodes/<episode_id>/audio.mp3?versionId=<GOOD_VERSION_ID>" \
+  --key "episodes/<episode_id>/audio.mp3"
+
+# 3. Verify the object serves again (presigned URL via the app, or):
+aws s3api head-object --bucket podcaststudiohub-audio --key "episodes/<episode_id>/audio.mp3"
+```
+
+Run steps 1–3 against a scratch key at least once after enabling versioning to
+prove the runbook (upload → overwrite → restore → verify). Note: the app's
+least-privilege IAM user lacks `ListBucket`, so `list-object-versions` needs
+the admin/backup credential, same as the versioning toggle.
+
+## Nginx Configuration
+
+Nginx reverse proxy configuration is in `deployment/nginx/podcastfy.conf`.
+
+````
+
+The S3 DR section carries MFA-delete hardening (documented as a root-MFA-only action, deliberately not scripted), an object-restore runbook, and explicit RTO/RPO. Every section above is pinned by the static contract suite — delete a heading or reorder the dump/migrate steps and the tests fail.
+
+```bash
+cd apps/api && uv run pytest ../../deployment/tests/test_dr_durability.py -q 2>&1 | tail -2
+```
+
+```output
+................                                                         [100%]
+16 passed in 0.01s
+```
+
+## Result
+
+| Criterion | Action | Outcome evidence | Status |
+|---|---|---|---|
+| **AC1** — off-host `pg_dump` before migrate, gating the deploy | Ran the deploy's own `backup-db.sh`; then simulated the deploy block with the backup misconfigured | 94 KB dump at `db-backups/pre-migration/`, `pg_restore -l` shows real `TABLE DATA` for users/projects/episodes; workflow orders dump (203) before `alembic upgrade head` (206). Gate: dump hard-failed → `set -e` aborted → migration line never printed, exit 1, schema untouched | **VERIFIED** |
+| **AC1b** — dump/restore are RLS-safe | Inserted a tenant row as `podcastfy_app` into a restored copy; ran the round-trip under both roles | App role: `new row violates row-level security policy`, sees 0 of 15 projects. Fixed path restores 15/15/13; pre-fix path recovers zero and exits 1. Mutation: reverting the fix turns the test RED | **VERIFIED** |
+| **AC2** — Redis durability decided + actionable | Ran `configure-redis-persistence.sh` on a real Redis 7 with persistence off, `SET` a job, `SIGKILL`, restart | Job `{"episode_id": 42}` survived the kill; `appendonly=yes` persisted across restart. Refused-`CONFIG REWRITE` case now exits 1 instead of falsely reporting success. `reap_stuck_episodes` present as the documented backstop | **VERIFIED** |
+| **AC3** — S3 versioning + MFA-delete documented | Read the S3 DR section | `## S3 object storage DR` with MFA-delete hardening, object-restore runbook, RTO/RPO; pinned by contract tests | **VERIFIED** |
+| **AC4** — Postgres + S3 restore runbooks with RTO/RPO | Ran the documented rollback verbatim into a throwaway DB | Source 15/15/13 → restored 15/15/13 through `restore-db.sh` off the `pre-migration/` prefix | **VERIFIED** |
+
+Two defects were found and fixed during this demo cycle, both pinned by tests that fail against the pre-fix code: the **restore-side RLS role** (from the GLM review) and the **silently-swallowed `CONFIG REWRITE` failure** (found here). 58 deployment tests green.
+
+*Reproduce:* `showboat verify apps/api/docs/demos/issue319-dr-durability.md` — needs the `api-postgres-1` container, docker, and the shims described at the top.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -553,6 +553,11 @@ reset, 10-minute OAuth states are re-initiated, locks re-acquire).
   ```
 
   `appendfsync everysec` bounds broker loss on a crash to ≤1s of writes.
+
+  The script **exits 1 if `CONFIG REWRITE` is refused** (unwritable or absent
+  `redis.conf`) rather than reporting success — otherwise AOF would be live in
+  memory but silently lost on the next restart. If you hit this, fix the
+  `redis.conf` path/permissions and re-run; do not ignore it.
 - **Backstop:** the `reap_stuck_episodes` beat task (every 5 min) marks any
   episode stuck in a non-terminal generation status for >45 min as `failed`,
   so even a job lost despite AOF (e.g. a manual `FLUSHALL`) surfaces to the

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -93,6 +93,12 @@ rsync -avz --exclude='__pycache__' --exclude='*.pyc' \
 ssh root@<SERVER_IP> << 'EOF'
 cd /opt/podcaststudiohub/api
 uv sync
+# Pre-migration off-host dump (issue #319): take a fresh restore point BEFORE
+# touching the live schema. backup-db.sh fails hard (aborting the deploy) if
+# the bucket/creds are missing or the dump is empty.
+set -a && . ./.env && set +a
+DB_BACKUP_S3_PREFIX="db-backups/pre-migration/" \
+  bash /opt/podcaststudiohub/deployment/scripts/backup-db.sh
 # Migrations MUST run under the privileged role (issue #301): MIGRATION_DATABASE_URL
 # (set in .env) points Alembic at the superuser/BYPASSRLS owner so RLS-affected
 # backfills apply to all rows. The app keeps connecting as the non-privileged
@@ -368,6 +374,17 @@ one-time **administrative** action — run it from AWS CloudShell (admin identit
 deployment/scripts/enable-s3-versioning.sh podcaststudiohub-audio
 ```
 
+**MFA-delete (optional hardening):** with versioning on, a leaked app credential can still
+`DeleteObject` current versions (recoverable) — MFA-delete additionally requires the **root
+account's MFA device** to permanently delete versions or suspend versioning. It can only be
+enabled by the root identity via the CLI, so it is documented rather than scripted:
+
+```bash
+aws s3api put-bucket-versioning --bucket podcaststudiohub-audio \
+  --versioning-configuration Status=Enabled,MFADelete=Enabled \
+  --mfa "arn:aws:iam::<ACCOUNT_ID>:mfa/root-account-mfa-device <MFA_CODE>"
+```
+
 ### Tenant offboarding / GDPR erasure — issue #308
 
 `DELETE /auth/me` (authenticated, self-service — the app has no admin/superuser role) permanently
@@ -489,6 +506,85 @@ dropdb podcastfy_restore_test
 
 A green restore-test is the only proof the backups are usable — an untested
 backup is not a backup.
+
+### Pre-migration dumps — issue #319
+
+Every deploy (automated and manual) takes an extra dump to
+`s3://$DB_BACKUP_S3_BUCKET/db-backups/pre-migration/` **before** running
+`alembic upgrade head`, and the deploy aborts if the dump fails — a partial or
+destructive migration always has a seconds-old restore point. To roll back a
+bad migration, restore the newest object under that prefix:
+
+```bash
+aws s3 ls s3://$AWS_S3_BUCKET/db-backups/pre-migration/
+DB_BACKUP_S3_PREFIX="db-backups/pre-migration/" \
+  bash deployment/scripts/restore-db.sh podcastfy-<stamp>.dump
+```
+
+These dumps are pruned by the same `DB_BACKUP_RETENTION_DAYS` window as the
+nightly ones. The deploy sources the API `.env` in a shell to feed the backup
+script, so its values must stay shell-sourceable (plain `KEY=value`, quotes
+around anything with spaces — true of every var the app uses today).
+
+## Redis durability — issue #319
+
+Redis serves four roles (one instance, db 0): Celery **broker** (queued +
+in-flight generation jobs), Celery **result backend**, **rate-limit counters**,
+and **OAuth CSRF state** + **generation idempotency locks**. Only the broker
+holds data whose loss matters: a flush/restart without persistence silently
+drops queued and in-flight episodes. The rest is ephemeral by design (counters
+reset, 10-minute OAuth states are re-initiated, locks re-acquire).
+
+**Stance (decided): AOF persistence on, reaper as backstop.**
+
+- Enable append-only-file persistence once per host (idempotent, verified by
+  readback, persisted to `redis.conf` via `CONFIG REWRITE`):
+
+  ```bash
+  bash deployment/scripts/configure-redis-persistence.sh
+  ```
+
+  `appendfsync everysec` bounds broker loss on a crash to ≤1s of writes.
+- **Backstop:** the `reap_stuck_episodes` beat task (every 5 min) marks any
+  episode stuck in a non-terminal generation status for >45 min as `failed`,
+  so even a job lost despite AOF (e.g. a manual `FLUSHALL`) surfaces to the
+  user as a retryable failure instead of hanging forever. It does **not**
+  auto-requeue — the user retries generation from the UI.
+
+## S3 object storage DR — issue #319
+
+Generated audio lives in the versioned S3 bucket (versioning is a required
+setup step — see "Enable bucket versioning" above). **Recovery targets: RPO = 0
+for overwrites/deletes of existing objects** (every prior version is retained);
+**RTO ≈ minutes** (one `aws s3api` call per object). An object mid-upload when
+a job dies is simply regenerated — Postgres is the source of truth for what
+should exist.
+
+### Restore runbook: recover an overwritten or deleted object
+
+```bash
+# 1. List versions of the object (shows delete markers too):
+aws s3api list-object-versions --bucket podcaststudiohub-audio \
+  --prefix "episodes/<episode_id>/audio.mp3"
+
+# 2a. Object was DELETED → remove the delete marker (newest "DeleteMarkers" entry);
+#     the previous version becomes current again:
+aws s3api delete-object --bucket podcaststudiohub-audio \
+  --key "episodes/<episode_id>/audio.mp3" --version-id "<DELETE_MARKER_VERSION_ID>"
+
+# 2b. Object was OVERWRITTEN → copy the good old version over the current one:
+aws s3api copy-object --bucket podcaststudiohub-audio \
+  --copy-source "podcaststudiohub-audio/episodes/<episode_id>/audio.mp3?versionId=<GOOD_VERSION_ID>" \
+  --key "episodes/<episode_id>/audio.mp3"
+
+# 3. Verify the object serves again (presigned URL via the app, or):
+aws s3api head-object --bucket podcaststudiohub-audio --key "episodes/<episode_id>/audio.mp3"
+```
+
+Run steps 1–3 against a scratch key at least once after enabling versioning to
+prove the runbook (upload → overwrite → restore → verify). Note: the app's
+least-privilege IAM user lacks `ListBucket`, so `list-object-versions` needs
+the admin/backup credential, same as the versioning toggle.
 
 ## Nginx Configuration
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -446,6 +446,9 @@ logical dumps are the deliberate, lazy-correct choice for a single-VPS dev host.
   `podcastfy` service account, reading DB/S3 settings from the API `.env`.
 - `deployment/scripts/restore-db.sh` — pulls a dump from S3 and `pg_restore`s it
   (latest by default, or a named backup), guarded by a confirmation prompt.
+  Like the dump side, it targets `MIGRATION_DATABASE_URL` when set — restoring
+  as the RLS-subject app role would trip the FORCE RLS `WITH CHECK` policies
+  and abort the whole `--exit-on-error` restore.
 
 Settings (env, defaulting to the app's existing `AWS_*` / `DATABASE_URL`):
 
@@ -500,8 +503,10 @@ bash deployment/scripts/restore-db.sh podcastfy-20260601T033000Z.dump
 
 ```bash
 # Restore the latest dump into a throwaway database and sanity-check row counts.
+# Override MIGRATION_DATABASE_URL (not just DATABASE_URL): it takes precedence,
+# so a value inherited from api/.env would silently retarget the live database.
 createdb podcastfy_restore_test
-DATABASE_URL="postgresql://user:pass@localhost/podcastfy_restore_test" \
+MIGRATION_DATABASE_URL="postgresql://user:pass@localhost/podcastfy_restore_test" \
   DB_RESTORE_FORCE=1 bash deployment/scripts/restore-db.sh
 psql podcastfy_restore_test -c "SELECT count(*) FROM users;"
 dropdb podcastfy_restore_test

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -437,7 +437,10 @@ logical dumps are the deliberate, lazy-correct choice for a single-VPS dev host.
 
 - `deployment/scripts/backup-db.sh` — `pg_dump -Fc` → timestamped object
   at `s3://$DB_BACKUP_S3_BUCKET/$DB_BACKUP_S3_PREFIX`, then prunes objects older
-  than `DB_BACKUP_RETENTION_DAYS` (default 14).
+  than `DB_BACKUP_RETENTION_DAYS` (default 14). Dumps connect as
+  `MIGRATION_DATABASE_URL` (the BYPASSRLS role) when set — tenant tables are
+  FORCE RLS, so a dump as the app role would error or omit every tenant row —
+  falling back to `DATABASE_URL` for single-role setups.
 - `deployment/scripts/install-db-backup-timer.sh` — installs a systemd service +
   nightly timer (`03:30` by default) that runs the backup as the non-root
   `podcastfy` service account, reading DB/S3 settings from the API `.env`.

--- a/deployment/scripts/backup-db.sh
+++ b/deployment/scripts/backup-db.sh
@@ -30,13 +30,20 @@ if [[ -z "$DB_BACKUP_S3_BUCKET" ]]; then
 	exit 1
 fi
 
-# pg_dump reads DATABASE_URL directly if given; otherwise it falls back to the
-# standard libpq PG* environment variables. We pass the conn string explicitly
-# so a DATABASE_URL with a +asyncpg driver suffix (SQLAlchemy style) is
-# normalised to a plain postgres:// URL pg_dump understands.
+# Prefer the privileged migration role (issue #319): tenant tables carry
+# FORCE ROW LEVEL SECURITY (migration 014), and pg_dump as the RLS-subject
+# podcastfy_app role either errors out or — with row security enabled —
+# silently omits every tenant row, producing a non-empty but unusable dump.
+# MIGRATION_DATABASE_URL is the BYPASSRLS owner the app .env already defines
+# for Alembic (issue #301); fall back to DATABASE_URL for single-role setups.
+#
+# The conn string is passed explicitly so a +asyncpg driver suffix
+# (SQLAlchemy style) is normalised to a plain postgres:// URL pg_dump
+# understands; without one, pg_dump falls back to the libpq PG* variables.
+SRC_URL="${MIGRATION_DATABASE_URL:-${DATABASE_URL:-}}"
 CONN=()
-if [[ -n "${DATABASE_URL:-}" ]]; then
-	CONN=("${DATABASE_URL/postgresql+asyncpg:/postgresql:}")
+if [[ -n "$SRC_URL" ]]; then
+	CONN=("${SRC_URL/postgresql+asyncpg:/postgresql:}")
 	CONN=("${CONN[0]/postgres+asyncpg:/postgres:}")
 fi
 

--- a/deployment/scripts/configure-redis-persistence.sh
+++ b/deployment/scripts/configure-redis-persistence.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Enable Redis AOF persistence on the VPS (issue #319).
+#
+# Redis is the Celery broker + result backend + OAuth-state store. Without
+# persistence, a restart silently drops every queued/in-flight generation job.
+# AOF with appendfsync=everysec bounds that loss to <=1s of writes; the
+# reap_stuck_episodes beat task remains the backstop for anything stranded
+# (see deployment/README.md "Redis durability").
+#
+# Idempotent — safe to re-run. Run on the VPS as any user that can reach
+# redis (default localhost, no auth):
+#
+#   bash deployment/scripts/configure-redis-persistence.sh
+#
+# Configuration (env):
+#   REDIS_CLI   redis-cli invocation, e.g. "redis-cli -p 6380" (default: redis-cli)
+
+set -euo pipefail
+
+REDIS_CLI="${REDIS_CLI:-redis-cli}"
+
+$REDIS_CLI CONFIG SET appendonly yes >/dev/null
+$REDIS_CLI CONFIG SET appendfsync everysec >/dev/null
+
+# CONFIG SET alone is lost on restart — persist it into redis.conf. Fails on
+# a config-file-less redis (e.g. ad-hoc `redis-server` with no conf); that is
+# deliberate: such an instance can't hold the setting across restarts anyway.
+$REDIS_CLI CONFIG REWRITE >/dev/null
+
+# Trust but verify: read the setting back rather than assuming it stuck.
+STATE="$($REDIS_CLI CONFIG GET appendonly | tail -1)"
+if [[ "$STATE" != "yes" ]]; then
+	echo "appendonly readback returned '$STATE', expected 'yes'" >&2
+	exit 1
+fi
+
+echo "Redis AOF persistence enabled (appendonly=yes, appendfsync=everysec) and persisted to redis.conf."

--- a/deployment/scripts/configure-redis-persistence.sh
+++ b/deployment/scripts/configure-redis-persistence.sh
@@ -23,10 +23,17 @@ REDIS_CLI="${REDIS_CLI:-redis-cli}"
 $REDIS_CLI CONFIG SET appendonly yes >/dev/null
 $REDIS_CLI CONFIG SET appendfsync everysec >/dev/null
 
-# CONFIG SET alone is lost on restart — persist it into redis.conf. Fails on
-# a config-file-less redis (e.g. ad-hoc `redis-server` with no conf); that is
-# deliberate: such an instance can't hold the setting across restarts anyway.
-$REDIS_CLI CONFIG REWRITE >/dev/null
+# CONFIG SET alone is lost on restart — persist it into redis.conf. redis-cli
+# exits 0 even when the server replies with an ERR, so `set -e` can't catch a
+# refused rewrite (unwritable/absent redis.conf); capture the reply and check
+# it. Hard-fail: an instance that can't persist the setting silently loses AOF
+# on its next restart, which is exactly the failure this script exists to stop.
+REWRITE="$($REDIS_CLI CONFIG REWRITE 2>&1 || true)"
+if [[ "$REWRITE" != "OK" ]]; then
+	echo "CONFIG REWRITE failed: ${REWRITE}" >&2
+	echo "AOF is live now but would be lost on restart — fix redis.conf permissions and re-run." >&2
+	exit 1
+fi
 
 # Trust but verify: read the setting back rather than assuming it stuck.
 STATE="$($REDIS_CLI CONFIG GET appendonly | tail -1)"

--- a/deployment/scripts/restore-db.sh
+++ b/deployment/scripts/restore-db.sh
@@ -11,7 +11,7 @@
 #   DB_RESTORE_FORCE=1 bash deployment/scripts/restore-db.sh   # skip the prompt
 #
 # Configuration mirrors backup-db.sh:
-#   DATABASE_URL / PG* libpq vars   target database
+#   MIGRATION_DATABASE_URL / DATABASE_URL / PG* libpq vars   target database
 #   DB_BACKUP_S3_BUCKET (default $AWS_S3_BUCKET), DB_BACKUP_S3_PREFIX (db-backups/)
 #   DB_RESTORE_FORCE=1              skip the confirmation prompt
 
@@ -25,11 +25,15 @@ if [[ -z "$DB_BACKUP_S3_BUCKET" ]]; then
 	exit 1
 fi
 
-# pg_restore --dbname needs an explicit target. Prefer DATABASE_URL (normalised
-# off any +asyncpg driver suffix); otherwise fall back to PGDATABASE so the
-# remaining libpq PG* vars (host/user/password) still apply.
-if [[ -n "${DATABASE_URL:-}" ]]; then
-	TARGET_DB="${DATABASE_URL/postgresql+asyncpg:/postgresql:}"
+# pg_restore --dbname needs an explicit target. Prefer the BYPASSRLS migration
+# role (mirrors backup-db.sh): tenant tables are FORCE RLS (migration 014), and
+# a restore as the RLS-subject app role trips every WITH CHECK policy —
+# --exit-on-error then aborts the whole restore. Normalise off any +asyncpg
+# driver suffix; otherwise fall back to PGDATABASE so the remaining libpq PG*
+# vars (host/user/password) still apply.
+SRC_URL="${MIGRATION_DATABASE_URL:-${DATABASE_URL:-}}"
+if [[ -n "$SRC_URL" ]]; then
+	TARGET_DB="${SRC_URL/postgresql+asyncpg:/postgresql:}"
 	TARGET_DB="${TARGET_DB/postgres+asyncpg:/postgres:}"
 elif [[ -n "${PGDATABASE:-}" ]]; then
 	TARGET_DB="$PGDATABASE"

--- a/deployment/tests/test_dr_durability.py
+++ b/deployment/tests/test_dr_durability.py
@@ -66,6 +66,16 @@ def test_pre_migration_dumps_use_dedicated_prefix():
 	)
 
 
+def test_backup_dumps_with_privileged_role():
+	# Tenant tables are FORCE RLS (migration 014); a dump as the RLS-subject
+	# app role errors or silently omits tenant rows. The backup must prefer
+	# the BYPASSRLS migration role.
+	backup = REPO_ROOT / "deployment" / "scripts" / "backup-db.sh"
+	assert re.search(r"MIGRATION_DATABASE_URL[}:]", backup.read_text()), (
+		"backup-db.sh must prefer MIGRATION_DATABASE_URL so RLS doesn't truncate dumps"
+	)
+
+
 def test_manual_deploy_runbook_includes_pre_migration_dump():
 	text = README.read_text()
 	dump = text.find("backup-db.sh", text.find("Step 2: Deploy API"))

--- a/deployment/tests/test_dr_durability.py
+++ b/deployment/tests/test_dr_durability.py
@@ -36,11 +36,14 @@ def _server_deploy_block() -> str:
 
 def test_deploy_dumps_before_migrating():
 	block = _server_deploy_block()
-	dump = block.find("backup-db.sh")
-	migrate = block.find("alembic upgrade head")
-	assert dump != -1, "server-side deploy must run backup-db.sh (pre-migration dump)"
-	assert migrate != -1, "server-side deploy must still run migrations"
-	assert dump < migrate, "the pre-migration dump must run BEFORE alembic upgrade head"
+	# Match the actual invocation, not prose in comments that mentions the script.
+	dump = re.search(r"bash .*backup-db\.sh", block)
+	migrate = re.search(r"uv run alembic upgrade head", block)
+	assert dump, "server-side deploy must run backup-db.sh (pre-migration dump)"
+	assert migrate, "server-side deploy must still run migrations"
+	assert dump.start() < migrate.start(), (
+		"the pre-migration dump must run BEFORE alembic upgrade head"
+	)
 
 
 def test_deploy_block_fails_fast_so_dump_gates_migration():

--- a/deployment/tests/test_dr_durability.py
+++ b/deployment/tests/test_dr_durability.py
@@ -76,6 +76,16 @@ def test_backup_dumps_with_privileged_role():
 	)
 
 
+def test_restore_targets_privileged_role():
+	# Symmetric half of the dump-side RLS fix: pg_restore as the RLS-subject
+	# app role trips every FORCE RLS WITH CHECK policy and --exit-on-error
+	# aborts the whole restore. The restore must prefer the BYPASSRLS role.
+	restore = REPO_ROOT / "deployment" / "scripts" / "restore-db.sh"
+	assert re.search(r"MIGRATION_DATABASE_URL[}:]", restore.read_text()), (
+		"restore-db.sh must prefer MIGRATION_DATABASE_URL so RLS doesn't abort restores"
+	)
+
+
 def test_manual_deploy_runbook_includes_pre_migration_dump():
 	text = README.read_text()
 	dump = text.find("backup-db.sh", text.find("Step 2: Deploy API"))

--- a/deployment/tests/test_dr_durability.py
+++ b/deployment/tests/test_dr_durability.py
@@ -1,0 +1,141 @@
+"""Tests for DR/durability hardening (issue #319).
+
+Pins three contracts on top of the #293 backup tooling:
+1. The automated deploy takes a fresh off-host pg_dump BEFORE running
+   `alembic upgrade head` on the live DB, and a dump failure aborts the deploy.
+2. Redis durability is decided and actionable: an idempotent script enables
+   AOF persistence, and the README documents the stance (AOF + stuck-job
+   reaper backstop, what a flush loses).
+3. S3 DR is documented: MFA-delete hardening and an object-restore runbook
+   (versioned recovery) with stated RTO/RPO.
+
+Static reads only, like test_db_backup.py — no live server/Redis/S3 needed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPLOY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-dev.yml"
+REDIS_SCRIPT = REPO_ROOT / "deployment" / "scripts" / "configure-redis-persistence.sh"
+README = REPO_ROOT / "deployment" / "README.md"
+
+
+# ── AC1: pre-migration off-host dump gates the deploy ──────────────────────
+
+
+def _server_deploy_block() -> str:
+	"""The server-side SSH block of the Deploy API step (after the rsyncs)."""
+	text = DEPLOY_WORKFLOW.read_text()
+	match = re.search(r"Install dependencies and restart on server(.*?)\n      - name:", text, re.S)
+	assert match, "expected the server-side SSH deploy block in deploy-dev.yml"
+	return match.group(1)
+
+
+def test_deploy_dumps_before_migrating():
+	block = _server_deploy_block()
+	dump = block.find("backup-db.sh")
+	migrate = block.find("alembic upgrade head")
+	assert dump != -1, "server-side deploy must run backup-db.sh (pre-migration dump)"
+	assert migrate != -1, "server-side deploy must still run migrations"
+	assert dump < migrate, "the pre-migration dump must run BEFORE alembic upgrade head"
+
+
+def test_deploy_block_fails_fast_so_dump_gates_migration():
+	# `set -e` is what turns a failed dump into an aborted deploy.
+	assert "set -e" in _server_deploy_block(), "SSH deploy block must fail fast (set -e)"
+
+
+def test_deploy_syncs_backup_script_to_server():
+	text = DEPLOY_WORKFLOW.read_text()
+	assert re.search(r"rsync.*\n?.*backup-db\.sh", text), (
+		"deploy must rsync backup-db.sh to the server so the dump step can run"
+	)
+
+
+def test_pre_migration_dumps_use_dedicated_prefix():
+	# A separate self-pruning prefix keeps "restore to just before the deploy"
+	# distinguishable from the nightly dumps.
+	assert "pre-migration" in DEPLOY_WORKFLOW.read_text(), (
+		"pre-migration dumps must land under a dedicated S3 prefix"
+	)
+
+
+def test_manual_deploy_runbook_includes_pre_migration_dump():
+	text = README.read_text()
+	dump = text.find("backup-db.sh", text.find("Step 2: Deploy API"))
+	migrate = text.find("alembic upgrade head", text.find("Step 2: Deploy API"))
+	assert dump != -1 and migrate != -1 and dump < migrate, (
+		"manual deploy runbook must take a pre-migration dump before migrating"
+	)
+
+
+# ── AC2: Redis durability — AOF script + documented stance ─────────────────
+
+
+def test_redis_persistence_script_exists_and_executable():
+	assert REDIS_SCRIPT.is_file(), f"expected script at {REDIS_SCRIPT}"
+	assert REDIS_SCRIPT.stat().st_mode & 0o111, "script must be executable"
+
+
+def test_redis_persistence_script_fails_fast():
+	assert "set -euo pipefail" in REDIS_SCRIPT.read_text()
+
+
+def test_redis_persistence_script_enables_aof_durably():
+	text = REDIS_SCRIPT.read_text()
+	assert "appendonly" in text, "script must enable AOF (appendonly)"
+	assert "appendfsync" in text, "script must pin the fsync policy"
+	# CONFIG SET alone is lost on restart — it must persist to redis.conf.
+	assert re.search(r"CONFIG\s+REWRITE", text, re.I), (
+		"script must CONFIG REWRITE so AOF survives a redis restart"
+	)
+
+
+def test_redis_persistence_script_verifies_readback():
+	# Trust but verify: the script must read the setting back, not assume it.
+	assert re.search(r"CONFIG\s+GET\s+appendonly", REDIS_SCRIPT.read_text(), re.I)
+
+
+def test_readme_documents_redis_durability_stance():
+	text = README.read_text()
+	assert "Redis durability" in text, "README must have a Redis durability section"
+	assert "appendonly" in text or "AOF" in text, "README must document AOF"
+	assert "reap_stuck_episodes" in text, (
+		"README must document the stuck-job reaper as the backstop"
+	)
+	assert "configure-redis-persistence.sh" in text, (
+		"README must reference the enable script"
+	)
+
+
+# ── AC3/AC4: S3 versioning hardening + restore runbook ─────────────────────
+
+
+def test_readme_documents_mfa_delete():
+	assert "MFA" in README.read_text(), (
+		"README must document MFA-delete as S3 versioning hardening"
+	)
+
+
+def test_readme_has_s3_object_restore_runbook():
+	text = README.read_text()
+	assert "list-object-versions" in text, (
+		"S3 restore runbook must show how to find prior versions"
+	)
+	assert "delete marker" in text.lower(), (
+		"S3 restore runbook must cover recovering a deleted object (delete marker)"
+	)
+
+
+def test_readme_states_s3_rto_rpo():
+	# The Postgres runbook already states RTO/RPO; the S3 section needs its own.
+	text = README.read_text()
+	s3_restore = text.find("list-object-versions")
+	assert s3_restore != -1
+	window = text[s3_restore - 2000 : s3_restore + 2000].upper()
+	assert "RPO" in window and "RTO" in window, (
+		"S3 restore runbook must state its RTO/RPO"
+	)

--- a/deployment/tests/test_dr_durability.py
+++ b/deployment/tests/test_dr_durability.py
@@ -117,6 +117,19 @@ def test_redis_persistence_script_enables_aof_durably():
 	)
 
 
+def test_redis_persistence_script_checks_rewrite_result():
+	# redis-cli exits 0 even on an ERR reply, so `set -e` cannot catch a failed
+	# CONFIG REWRITE (found live: rewrite denied → script reported success, AOF
+	# evaporated on restart). The script must capture the reply and assert OK.
+	text = REDIS_SCRIPT.read_text()
+	assert re.search(r'=\s*"?\$\([^)]*CONFIG\s+REWRITE[^)]*\)', text, re.I), (
+		"script must capture the CONFIG REWRITE reply into a variable"
+	)
+	assert re.search(r'!=\s*"OK"', text), (
+		"script must hard-fail when the CONFIG REWRITE reply isn't OK"
+	)
+
+
 def test_redis_persistence_script_verifies_readback():
 	# Trust but verify: the script must read the setting back, not assume it.
 	assert re.search(r"CONFIG\s+GET\s+appendonly", REDIS_SCRIPT.read_text(), re.I)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,40 @@
-# Tasks
+# Issue #319 — [P5.3] DR/durability hardening (self-authored plan)
 
-_No active task._ Last shipped: #318 (migration safety — dedupe-safe 006, CONCURRENTLY/autocommit DDL in 004/005/006/008/012, complete env.py target_metadata + table-set drift test) via PR #398, merged 2026-07-14.
+Plan source: self-authored (no plan comment on issue; only a CodeRabbit stub).
+
+## Already in the repo (verified, no work needed)
+- Nightly off-host `pg_dump` → S3 + retention: `deployment/scripts/backup-db.sh` + systemd timer (#293)
+- Tested Postgres restore runbook w/ RTO/RPO in `deployment/README.md` (RPO ≤ 24h, RTO ≈ minutes)
+- S3 versioning script `deployment/scripts/enable-s3-versioning.sh` + README "required" step
+- Stuck-job reaper `reap_stuck_episodes` (beat, every 300s, 45m threshold) — the "or add a stuck-job reaper" half of AC2 already exists
+
+## Open gaps → steps (TDD: step 1 first, RED)
+
+1. **Tests (RED)** — new `deployment/tests/test_dr_durability.py` (pattern: `test_db_backup.py`, static asserts):
+   - deploy-dev.yml server-side block runs `backup-db.sh` BEFORE `alembic upgrade head` (positional assert)
+   - workflow rsyncs `backup-db.sh` to the server
+   - `configure-redis-persistence.sh` exists, executable, `set -euo pipefail`, sets `appendonly yes` + `CONFIG REWRITE`
+   - README documents: Redis durability stance (AOF + reaper backstop + what a flush loses), S3 MFA-delete, S3 object restore runbook (`list-object-versions` / delete-marker removal)
+
+2. **Pre-migration dump gate** — `.github/workflows/deploy-dev.yml` Deploy API step:
+   - rsync `deployment/scripts/backup-db.sh` → `$SERVER_PATH/deployment/scripts/`
+   - in the `set -e` SSH block, before `uv run alembic upgrade head`: source `$SERVER_PATH/api/.env`, run `backup-db.sh` with `DB_BACKUP_S3_PREFIX=db-backups/pre-migration/` (script hard-fails w/o bucket/creds or on empty dump → deploy aborts before migration; prefix is self-pruned by the script's own retention)
+   - mirror the dump step in README manual-deploy Step 2
+
+3. **Redis durability (decision: enable AOF, keep reaper as backstop)** — new `deployment/scripts/configure-redis-persistence.sh`: idempotent, `CONFIG SET appendonly yes` + `appendfsync everysec` + `CONFIG REWRITE` + verify readback. README section: stance, what a flush loses (queued/in-flight jobs; ephemeral-by-design: rate-limit counters, OAuth state, idempotency locks), reaper marks stranded episodes failed after 45m (no auto-requeue; user retries).
+
+4. **S3 DR docs** — README: MFA-delete as optional hardening (root-MFA-only op, can't be scripted with app creds); S3 object restore runbook (recover deleted/overwritten object from versions) + S3 RTO/RPO statement.
+
+5. **Gates** — `python -m pytest deployment/tests/`, ruff, demo evidence per AC, PR, reviews, merge.
+
+## Acceptance criteria checklist
+- [ ] Off-host pg_dump before migrate, gating the deploy (step 2)
+- [ ] Redis durability decided + documented: AOF enabled via script + reaper documented as backstop (step 3)
+- [ ] S3 versioning enabled (script + README already exist; MFA-delete documented — step 4)
+- [ ] Postgres+S3 restore runbook with RTO/RPO, tested (Postgres exists; add S3 — step 4; tests — step 1)
+
+## Autonomous decisions (no fork)
+- Reuse `backup-db.sh` for the pre-migration dump instead of a new script (same contract, self-pruning prefix).
+- AOF `everysec` (≤1s broker loss) over RDB-only; reaper stays as the stranded-episode backstop.
+- `.env` is sourced in the deploy shell — values must stay shell-sourceable (they are today; noted in README).
+- MFA-delete documented, not scripted (requires root-account MFA; app IAM user cannot toggle it).


### PR DESCRIPTION
## Summary
Implements #319: DR/durability hardening.

Most of the issue's surface pre-existed (#293 nightly backup + Postgres restore runbook w/ RTO/RPO, `enable-s3-versioning.sh`, the `reap_stuck_episodes` reaper). This PR closes the remaining gaps:

- **Pre-migration dump gates the deploy**: `deploy-dev.yml` now rsyncs `backup-db.sh` to the server and takes an off-host `pg_dump` (to the self-pruning `db-backups/pre-migration/` prefix) *before* `alembic upgrade head`; `set -e` aborts the deploy before the schema is touched if the dump fails. Manual-deploy runbook mirrors it.
- **Dumps use the BYPASSRLS role** (codex review P1): tenant tables are FORCE RLS (migration 014), so a `pg_dump` as `podcastfy_app` errors or silently omits tenant rows. `backup-db.sh` now prefers `MIGRATION_DATABASE_URL` — fixing the nightly backup path too.
- **Restore is RLS-safe too** (post-PR GLM review): `restore-db.sh` derived its `pg_restore` target from
  `DATABASE_URL`, so the *documented rollback path* for the very dump this PR guarantees aborted under
  FORCE RLS — the symmetric half of the dump-side bug. Now prefers `MIGRATION_DATABASE_URL`. Demo shows
  the fixed path restoring 15/15/13 where the pre-fix path recovers zero.
- **`CONFIG REWRITE` failures no longer swallowed** (found during the demo): `redis-cli` exits 0 even on an
  `ERR` reply, so `set -e` could not catch a refused rewrite — the script reported AOF enabled while it
  silently evaporated on the next restart. Now captures the reply and exits 1 unless `OK`.
- **Redis durability decided + actionable**: new idempotent `configure-redis-persistence.sh` enables AOF (`appendonly yes`, `appendfsync everysec`, `CONFIG REWRITE`, readback verify). README documents the stance: AOF bounds broker loss to ≤1s; `reap_stuck_episodes` (45 min) is the backstop; rate-limit counters / OAuth state / idempotency locks are ephemeral by design.
- **S3 DR docs**: MFA-delete as optional hardening (root-MFA-only, documented not scripted) + an object restore runbook (`list-object-versions`, delete-marker removal, version copy-back) with S3 RTO/RPO.
- **Contract tests**: `deployment/tests/test_dr_durability.py` (static, TDD-first) pins dump-before-migrate ordering, the rsync, the AOF script contract, the privileged-role dump, and every new README section.

## Acceptance Criteria
- [x] Off-host pg_dump before migrate, gating the deploy
- [x] Redis durability decided + documented (AOF enabled via script; reaper documented as backstop)
- [x] S3 versioning (pre-existing script/README; MFA-delete hardening documented)
- [x] Postgres+S3 restore runbook with RTO/RPO (Postgres pre-existing; S3 added; pinned by tests)

## Test Plan
- [x] Unit tests written first (TDD) — 14 new static contract tests, RED→GREEN
- [x] All deployment tests passing (56 passed)
- [x] Diff coverage gate: no-op — no app-code executable lines changed (workflow/script/docs/tests only)
- [x] Linting clean (ruff; pre-commit hooks incl. gitleaks, yaml check; actionlint on the workflow)
- [x] Internal code review (advisory) completed
- [x] Cross-family review pass: codex (opencode/GLM timed out) — 1 P1 finding, fixed (BYPASSRLS dump role)
- [x] Post-PR GLM review — 1 major finding, fixed (restore-side RLS role, `7728602`)
- [x] Demo verification: all 5 criteria mapped to outcome evidence (`apps/api/docs/demos/issue319-dr-durability.md`)
- [x] Test mutation sanity check completed — dump-reorder and CONFIG REWRITE mutations both fail tests (first mutation exposed a comment-matching test, tightened)

## Known Limitations / Intentionally Deferred
- The dump gate runs on the **dev VPS deploy** (the only deploy pipeline); server needs `aws` CLI + backup IAM creds in `api/.env` — same prerequisites the #293 nightly timer already documents.
- `.env` is shell-sourced by the deploy; values must stay plain `KEY=value` (true of all current vars; noted in README).
- Enabling AOF and S3 MFA-delete are one-time host/admin actions run from the runbook, not enforced by CI — no IaC exists in this repo to enforce them.
- Redis reaper marks stranded episodes `failed` (user retries); auto-requeue intentionally not built (YAGNI — AOF makes broker loss ≤1s).
- Restore runbooks are documented + statically tested; live restore drills against the VPS are an operational task, not CI.

## Implementation Notes
Self-authored plan (no plan comment on the issue). The "or add a stuck-job reaper" half of AC2 already existed (#294/#366), so the decision was AOF **and** reaper, documented. Pre-migration dumps reuse `backup-db.sh` rather than a new script — same contract, self-pruning prefix.

Closes #319
