### PR TITLE
[P5.4] Observability baseline: Sentry, /ready probe, correlation IDs, JSON logs, log rotation (#320)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -127,6 +127,106 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H $SSH_HOST >> ~/.ssh/known_hosts
 
+      - name: Configure PM2 log rotation
+        env:
+          SSH_HOST: ${{ vars.SERVER_HOST }}
+          SSH_USER: ${{ secrets.SERVER_USER }}
+        run: |
+          # PM2 captures stdout/stderr for all three processes into ~/.pm2/logs
+          # and never rotates them (issue #320) — on a long-lived host they grow
+          # until they fill the disk. pm2-logrotate is a *global* pm2 module
+          # (not per-process), so it is configured once here, before the
+          # API/frontend/celery processes start writing under it. There is no
+          # ecosystem file to carry this config, hence `pm2 set`.
+          # NOTE: no backticks anywhere below — this is an unquoted heredoc, so
+          # the runner's shell command-substitutes backticks (even inside #
+          # comments) before the text is ever sent to the server.
+          ssh -i ~/.ssh/deploy_key $SSH_USER@$SSH_HOST << EOF
+            set -e
+
+            # Idempotent: pm2 install on an already-installed module updates it
+            # in place, and each pm2 set overwrites the stored value.
+            pm2 install pm2-logrotate
+
+            # Rotate at 10M per file, keep 7 compressed generations per process,
+            # and force a daily roll at midnight even on quiet days so a file
+            # can't sit unrotated for weeks.
+            pm2 set pm2-logrotate:max_size 10M
+            pm2 set pm2-logrotate:retain 7
+            pm2 set pm2-logrotate:compress true
+            pm2 set pm2-logrotate:rotateInterval '0 0 * * *'
+
+            echo "PM2 log rotation configured"
+          EOF
+
+      - name: Install nginx log rotation
+        env:
+          SSH_HOST: ${{ vars.SERVER_HOST }}
+          SSH_USER: ${{ secrets.SERVER_USER }}
+          SERVER_PATH: ${{ vars.SERVER_PATH }}
+        run: |
+          # nginx logs to a CUSTOM path (/opt/podcaststudiohub/logs/*.log — see
+          # deployment/nginx/podcastfy.conf), which the distro's stock
+          # /etc/logrotate.d/nginx does NOT cover: it only globs
+          # /var/log/nginx/*.log. Without this drop-in those files are never
+          # rotated and eventually fill the VPS disk (issue #320).
+          # mkdir -p first: rsync does not create intermediate remote dirs.
+          ssh -i ~/.ssh/deploy_key $SSH_USER@$SSH_HOST \
+            "mkdir -p $SERVER_PATH/deployment/logrotate"
+          rsync -avz -e "ssh -i ~/.ssh/deploy_key" \
+            deployment/logrotate/podcaststudiohub-nginx \
+            $SSH_USER@$SSH_HOST:$SERVER_PATH/deployment/logrotate/
+
+          # NOTE: no backticks anywhere below — this is an unquoted heredoc, so
+          # the runner's shell command-substitutes backticks (even inside #
+          # comments) before the text is ever sent to the server.
+          ssh -i ~/.ssh/deploy_key $SSH_USER@$SSH_HOST << EOF
+            set -e
+            SRC="$SERVER_PATH/deployment/logrotate/podcaststudiohub-nginx"
+            DEST="/etc/logrotate.d/podcaststudiohub-nginx"
+
+            # Privileged ops: the deploy account is the non-root service user
+            # created by deployment/scripts/harden-host.sh, and /etc/logrotate.d
+            # is root-owned. Match the repo convention (provision-ssl.sh /
+            # harden-host.sh assume root) by escalating only for the install.
+            # sudo -n is non-interactive: a host without NOPASSWD sudo fails
+            # loudly here instead of hanging forever on a password prompt.
+            SUDO=""
+            if [ "\$(id -u)" -ne 0 ]; then SUDO="sudo -n"; fi
+
+            # Validate BEFORE installing: a malformed drop-in in /etc/logrotate.d
+            # is not contained to this file — it breaks the whole daily run.
+            #
+            # Exit status alone is NOT a sufficient gate: logrotate -d exits 0 on
+            # an unknown option (it prints "error: ... -- ignoring line" and
+            # carries on), so a typo such as "rotat 14" would silently drop the
+            # retention window. Grep the output for error lines too.
+            # --state points at a throwaway file so the dry run cannot touch the
+            # host's real logrotate status.
+            echo "Validating \$SRC ..."
+            lr_state="\$(mktemp)"
+            lr_out="\$(\$SUDO logrotate -d --state "\$lr_state" "\$SRC" 2>&1)" || {
+              echo "\$lr_out" >&2
+              echo "logrotate rejected \$SRC — aborting deploy" >&2
+              rm -f "\$lr_state"
+              exit 1
+            }
+            rm -f "\$lr_state"
+            echo "\$lr_out"
+            if echo "\$lr_out" | grep -qi '^error:'; then
+              echo "logrotate reported errors in \$SRC — aborting deploy" >&2
+              exit 1
+            fi
+
+            # Idempotent: install overwrites the destination in place, so
+            # re-running the deploy just refreshes the drop-in (never appends).
+            \$SUDO install -m 0644 -o root -g root \
+              "\$SRC" \
+              "\$DEST"
+
+            echo "nginx log rotation installed at \$DEST"
+          EOF
+
       - name: Deploy API
         env:
           SSH_HOST: ${{ vars.SERVER_HOST }}
@@ -375,7 +475,13 @@ jobs:
             return 1
           }
 
-          wait_for "API" "$API_URL/health" "200" || exit 1
+          # Gate on /ready, NOT /health (issue #320). /health is a liveness
+          # probe: it returns 200 as soon as the uvicorn process is answering,
+          # so a deploy goes green even when Postgres or Redis is unreachable
+          # and every real request 500s. /ready is the readiness probe — it
+          # checks those dependencies and returns 503 until they are reachable,
+          # so it fails the deploy on exactly the states /health hides.
+          wait_for "API" "$API_URL/ready" "200" || exit 1
           wait_for "Frontend" "$FRONTEND_URL" "200" || exit 1
 
           echo "🚀 Deployment successful!"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,21 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      # This job already pointed CELERY_BROKER_URL/RESULT_BACKEND at
+      # redis://localhost:6379 while nothing listened there, so any test
+      # touching real Redis silently exercised the connection-refused path.
+      # /ready PINGs Redis for real (issue #320), so the broker the env vars
+      # below already claim now actually runs.
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -80,6 +95,9 @@ jobs:
           JWT_SECRET_KEY: test-jwt-secret-for-ci-0000000000
           CELERY_BROKER_URL: redis://localhost:6379/0
           CELERY_RESULT_BACKEND: redis://localhost:6379/0
+          # Explicit rather than relying on the settings default, so the /ready
+          # probe's PING target is visible next to the service that serves it.
+          REDIS_URL: redis://localhost:6379/0
         run: |
           uv run pytest tests/ \
             --cov=src \

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -92,6 +92,21 @@ API_PUBLIC_BASE_URL=http://localhost:8000
 
 # Application Settings
 LOG_LEVEL=INFO
+# Log record format: "json" (structured, one object per line — carries
+# request_id/tenant_id and is what the API and Celery both emit) or "text"
+# (human-readable, handy locally).
+LOG_FORMAT=json
+
+# Observability (issue #320)
+# Sentry error tracking. Leave EMPTY to disable entirely — no DSN means Sentry
+# is never initialised, so local dev and CI never phone home. Set it in staging
+# and production to the project DSN from sentry.io.
+SENTRY_DSN=
+# Fraction of requests traced for performance monitoring (0.0-1.0). 0.0 sends
+# errors only; raise it deliberately, tracing is billed per transaction.
+SENTRY_TRACES_SAMPLE_RATE=0.0
+# Per-dependency timeout for the /ready probe, in seconds.
+READINESS_CHECK_TIMEOUT_SECONDS=2.0
 
 # Transcript Validation Settings
 # Minimum number of words required in a generated transcript (combined across both speakers)

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "httpx>=0.27.0",
     "pytest-xdist>=3.5.0",
     "psycopg[binary]>=3.3.4",
+    "sentry-sdk>=2.0.0",
 ]
 
 [build-system]

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -50,6 +50,10 @@ class Settings(BaseSettings):
         "Accept-Language",
         "Content-Type",
         "Authorization",
+        # Lets a cross-origin client supply its own correlation id so its trace
+        # and ours share one. Without it the browser's preflight rejects the
+        # header outright (issue #320).
+        "X-Request-ID",
     ]
 
     # API Keys - LLM Providers

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -141,6 +141,22 @@ class Settings(BaseSettings):
 
     # Logging
     LOG_LEVEL: str = "INFO"
+    # "json" emits one structured record per line (request_id/tenant_id bound),
+    # shared by uvicorn and Celery so an incident can be stitched across both.
+    # "text" is the human-readable escape hatch for local dev (issue #320).
+    LOG_FORMAT: str = "json"
+
+    # Observability (issue #320)
+    # Error tracking. Unset -> Sentry is never initialised, so dev/CI/tests stay
+    # offline with no opt-out ceremony. Same Optional-override convention as
+    # CELERY_BROKER_URL above.
+    SENTRY_DSN: Optional[str] = None
+    # Fraction of requests traced for performance monitoring. 0.0 = errors only:
+    # this issue asks for error tracking, not APM.
+    SENTRY_TRACES_SAMPLE_RATE: float = 0.0
+    # Per-dependency ceiling for the /ready probe. A hung DB or Redis must fail
+    # the probe fast rather than hang it until the client's own timeout.
+    READINESS_CHECK_TIMEOUT_SECONDS: float = 2.0
 
     # Transcript Validation Settings
     MIN_TRANSCRIPT_WORDS: int = 100

--- a/apps/api/src/logging_config.py
+++ b/apps/api/src/logging_config.py
@@ -1,0 +1,160 @@
+"""Structured logging, request correlation, and error tracking (issue #320).
+
+Three things live here because they are one concern — making an incident
+reconstructable — and they share the same two context variables:
+
+1. ``CORRELATION_ID`` / ``TENANT_ID`` contextvars: the request-scoped identity
+   that must appear on every log record emitted while handling a request or
+   running a task. Contextvars (not ``request.state``) because a log record is
+   emitted from arbitrary depth, with no ``Request`` in scope, and because they
+   survive the ``asyncio.run()`` bridge Celery tasks use.
+2. ``JsonFormatter``: one line of JSON per record, so a log aggregator can
+   filter by ``request_id``/``tenant_id`` instead of grepping freeform strings.
+3. ``init_sentry``: exception reporting for the API and the worker.
+
+``setup_logging()`` is called by both entrypoints (``main.py`` and the Celery
+``setup_logging`` signal in ``worker.py``), which is what makes the format
+identical across uvicorn and Celery.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from contextvars import ContextVar
+from typing import Any, Optional
+
+from src.config import settings
+
+# Request-scoped identity, bound by CorrelationIdMiddleware (API) and the
+# task_prerun signal (worker). Read by JsonFormatter on every record.
+CORRELATION_ID: ContextVar[Optional[str]] = ContextVar("correlation_id", default=None)
+TENANT_ID: ContextVar[Optional[str]] = ContextVar("tenant_id", default=None)
+
+# Header carrying the id across the API boundary; also the Celery message header.
+REQUEST_ID_HEADER = "X-Request-ID"
+
+# LogRecord attributes that are structural rather than caller-supplied. Anything
+# on a record that is NOT in here was passed via `extra=` and is worth emitting.
+_RESERVED_LOG_RECORD_ATTRS = frozenset(
+    {
+        "args", "asctime", "created", "exc_info", "exc_text", "filename",
+        "funcName", "levelname", "levelno", "lineno", "module", "msecs",
+        "message", "msg", "name", "pathname", "process", "processName",
+        "relativeCreated", "stack_info", "thread", "threadName", "taskName",
+    }
+)
+
+
+class JsonFormatter(logging.Formatter):
+    """Render a LogRecord as a single JSON object.
+
+    ponytail: ~40 lines of stdlib instead of a python-json-logger dependency —
+    this repo has CVE gates on every dep (#306) and the feature is this small.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "timestamp": self.formatTime(record, "%Y-%m-%dT%H:%M:%S%z"),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        request_id = CORRELATION_ID.get()
+        if request_id:
+            payload["request_id"] = request_id
+        tenant_id = TENANT_ID.get()
+        if tenant_id:
+            payload["tenant_id"] = tenant_id
+
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack"] = self.formatStack(record.stack_info)
+
+        # Surface `logger.info("...", extra={"episode_id": x})` as real fields.
+        for key, value in record.__dict__.items():
+            if key not in _RESERVED_LOG_RECORD_ATTRS and not key.startswith("_"):
+                payload[key] = _coerce(value)
+
+        return json.dumps(payload, default=str)
+
+
+def _coerce(value: Any) -> Any:
+    """Keep JSON-native types; stringify everything else (UUIDs, datetimes...)."""
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+    return str(value)
+
+
+def build_formatter() -> logging.Formatter:
+    """The formatter both entrypoints install, per settings.LOG_FORMAT."""
+    if settings.LOG_FORMAT.strip().lower() == "json":
+        return JsonFormatter()
+    return logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+
+def setup_logging() -> None:
+    """Install the configured formatter on the root logger and on uvicorn's.
+
+    uvicorn installs its own handlers on the `uvicorn*` loggers with
+    `propagate = False`, so configuring only the root logger would leave access
+    logs in uvicorn's default format — half the API's output would stay
+    unstructured. Re-formatting those handlers in place is what makes AC5
+    ("shared by uvicorn and Celery") actually true.
+    """
+    formatter = build_formatter()
+    level = getattr(logging, settings.LOG_LEVEL.strip().upper(), logging.INFO)
+
+    root = logging.getLogger()
+    root.setLevel(level)
+    if not root.handlers:
+        root.addHandler(logging.StreamHandler())
+    for handler in root.handlers:
+        handler.setFormatter(formatter)
+
+    for name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+        for handler in logging.getLogger(name).handlers:
+            handler.setFormatter(formatter)
+
+
+def _scrub(event: dict, _hint: dict) -> dict:
+    """Drop request bodies and cookies before an event leaves the process.
+
+    This is a multi-tenant app: a request body can hold another tenant's content
+    and cookies hold session material. `send_default_pii=False` already stops
+    Sentry attaching user identity, but the body is sent regardless, so it is
+    removed explicitly here.
+    """
+    request = event.get("request")
+    if isinstance(request, dict):
+        request.pop("data", None)
+        request.pop("cookies", None)
+        headers = request.get("headers")
+        if isinstance(headers, dict):
+            for header in ("Authorization", "authorization", "Cookie", "cookie"):
+                headers.pop(header, None)
+    return event
+
+
+def init_sentry() -> bool:
+    """Initialise Sentry when SENTRY_DSN is set. Returns True if initialised.
+
+    No DSN -> no-op, so tests, CI and local dev never talk to Sentry and need no
+    opt-out. Integrations are left to sentry-sdk's auto-enabling (FastAPI,
+    Celery, logging) rather than wired by hand.
+    """
+    if not settings.SENTRY_DSN:
+        return False
+
+    import sentry_sdk
+
+    sentry_sdk.init(
+        dsn=settings.SENTRY_DSN,
+        environment=settings.ENVIRONMENT,
+        release=settings.APP_VERSION,
+        traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
+        send_default_pii=False,
+        before_send=_scrub,
+    )
+    return True

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -10,7 +10,7 @@ import logging
 
 from src.config import settings
 from src.dependencies import meter_api_call
-from src.logging_config import init_sentry, setup_logging
+from src.logging_config import REQUEST_ID_HEADER, init_sentry, setup_logging
 from src.middleware.correlation import CorrelationIdMiddleware
 from src.middleware.cors import setup_cors
 from src.middleware.tenant import TenantContextMiddleware
@@ -157,11 +157,26 @@ async def not_found_handler(request, exc):
 
 @app.exception_handler(500)
 async def internal_error_handler(request, exc):
-    """Custom 500 handler"""
-    logger.error(f"Internal server error: {exc}")
+    """Custom 500 handler.
+
+    Re-stamps X-Request-ID because this handler runs in Starlette's
+    ServerErrorMiddleware, which sits OUTSIDE CorrelationIdMiddleware: an
+    unhandled exception propagates past that middleware before it can set the
+    header, so a 500 would otherwise be the one response with no id — exactly
+    the response a user needs an id for when reporting the failure. The
+    contextvar is already unwound by here, so read request.state (set before
+    call_next) and pass the id explicitly to the log record (issue #320).
+    """
+    request_id = getattr(request.state, "request_id", None)
+    logger.error(
+        "Internal server error: %s", exc, exc_info=True,
+        extra={"request_id": request_id} if request_id else {},
+    )
+    headers = {REQUEST_ID_HEADER: request_id} if request_id else None
     return JSONResponse(
         status_code=500,
-        content={"detail": "Internal server error"}
+        content={"detail": "Internal server error"},
+        headers=headers,
     )
 
 

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -1,6 +1,7 @@
 """
 Main FastAPI application for Podcastfy GUI API
 """
+import asyncio
 from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI
@@ -9,14 +10,15 @@ import logging
 
 from src.config import settings
 from src.dependencies import meter_api_call
+from src.logging_config import init_sentry, setup_logging
+from src.middleware.correlation import CorrelationIdMiddleware
 from src.middleware.cors import setup_cors
 from src.middleware.tenant import TenantContextMiddleware
 
-# Configure logging
-logging.basicConfig(
-    level=getattr(logging, settings.LOG_LEVEL),
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
+# Structured logging + error tracking (issue #320). setup_logging replaces the
+# old basicConfig; init_sentry is a no-op unless SENTRY_DSN is set.
+setup_logging()
+init_sentry()
 logger = logging.getLogger(__name__)
 
 
@@ -56,6 +58,11 @@ setup_cors(app)
 # Add tenant context middleware
 app.add_middleware(TenantContextMiddleware)
 
+# Correlation ID middleware is added LAST so it is OUTERMOST: Starlette applies
+# add_middleware in LIFO order, and the request id must be bound before CORS and
+# tenant resolution run so their log lines carry it too (issue #320).
+app.add_middleware(CorrelationIdMiddleware)
+
 
 @app.get("/")
 async def root():
@@ -69,8 +76,68 @@ async def root():
 
 @app.get("/health")
 async def health_check():
-    """Health check endpoint for load balancers"""
+    """Liveness probe: is this process up?
+
+    Deliberately checks nothing external. A dependency outage must not make this
+    fail, or a supervisor would restart a perfectly healthy process and turn a
+    Redis blip into an API outage. Use /ready to gate traffic (issue #320).
+    """
     return {"status": "healthy", "version": settings.APP_VERSION}
+
+
+async def _check_database() -> None:
+    """Round-trip the DB. Raises on failure."""
+    from sqlalchemy import text
+
+    from src.database import engine
+
+    async with engine.connect() as conn:
+        await conn.execute(text("SELECT 1"))
+
+
+async def _check_redis() -> None:
+    """Round-trip Redis. Raises on failure."""
+    # redis>=5 ships redis.asyncio, so this needs no new dependency.
+    from redis.asyncio import from_url
+
+    client = from_url(settings.REDIS_URL)
+    try:
+        await client.ping()
+    finally:
+        await client.aclose()
+
+
+@app.get("/ready")
+async def readiness_check():
+    """Readiness probe: can this process actually serve traffic?
+
+    Checks the dependencies a request needs (Postgres, Redis) and returns 503 if
+    either is unreachable, so the deploy gate and uptime monitoring fail loudly
+    instead of reporting green through a brownout (issue #320).
+    """
+    checks: dict[str, str] = {}
+    for name, check in (("database", _check_database), ("redis", _check_redis)):
+        try:
+            # A hung dependency must fail the probe fast rather than hang it:
+            # without this the probe blocks until the caller's own timeout and
+            # the gate can't tell "slow" from "down".
+            await asyncio.wait_for(
+                check(), timeout=settings.READINESS_CHECK_TIMEOUT_SECONDS
+            )
+            checks[name] = "ok"
+        except Exception as e:
+            # Log the cause (the response deliberately doesn't carry it: /ready
+            # is unauthenticated, and connection errors quote DSNs/hostnames).
+            logger.error("Readiness check failed for %s: %s", name, e, exc_info=True)
+            checks[name] = "error"
+
+    if all(status == "ok" for status in checks.values()):
+        return {"status": "ready", "version": settings.APP_VERSION, "checks": checks}
+
+    return JSONResponse(
+        status_code=503,
+        content={"status": "not_ready", "version": settings.APP_VERSION, "checks": checks},
+    )
 
 
 @app.exception_handler(404)

--- a/apps/api/src/middleware/correlation.py
+++ b/apps/api/src/middleware/correlation.py
@@ -1,0 +1,39 @@
+"""Request correlation ID middleware (issue #320).
+
+Assigns every request an id, binds it to a contextvar so every log record
+emitted while handling that request carries it, and echoes it back on the
+response so a user-reported failure can be traced to its logs.
+
+Registered LAST in main.py so it is OUTERMOST (Starlette applies
+``add_middleware`` in LIFO order): the id must be bound before CORS and tenant
+resolution run, or their own log lines would be uncorrelated.
+"""
+import uuid
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+from src.logging_config import CORRELATION_ID, REQUEST_ID_HEADER, TENANT_ID
+
+
+class CorrelationIdMiddleware(BaseHTTPMiddleware):
+    """Bind an X-Request-ID to the request context and echo it on the response."""
+
+    async def dispatch(self, request: Request, call_next):
+        request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid.uuid4())
+
+        # Also on request.state so handlers can read it without importing the
+        # contextvar, mirroring how tenant_id is exposed.
+        request.state.request_id = request_id
+        token = CORRELATION_ID.set(request_id)
+        # Each request starts with no tenant; TenantContextMiddleware sets it
+        # once the JWT is resolved. Reset here too so a recycled context can
+        # never leak the previous request's tenant onto this one's logs.
+        tenant_token = TENANT_ID.set(None)
+        try:
+            response = await call_next(request)
+            response.headers[REQUEST_ID_HEADER] = request_id
+            return response
+        finally:
+            CORRELATION_ID.reset(token)
+            TENANT_ID.reset(tenant_token)

--- a/apps/api/src/middleware/cors.py
+++ b/apps/api/src/middleware/cors.py
@@ -29,5 +29,9 @@ def setup_cors(app: FastAPI) -> None:
             "X-Total-Count",
             "X-Page-Number",
             "Content-Disposition",
+            # Without this the browser hides the echoed correlation id from JS,
+            # so a cross-origin client cannot show the user an id to quote in a
+            # bug report — the whole point of echoing it (issue #320).
+            "X-Request-ID",
         ],
     )

--- a/apps/api/src/middleware/tenant.py
+++ b/apps/api/src/middleware/tenant.py
@@ -9,6 +9,7 @@ from typing import Optional
 from fastapi import HTTPException, Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from src.logging_config import TENANT_ID
 from src.middleware.auth import extract_token_from_header, get_tenant_id_from_token
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,7 @@ class TenantContextMiddleware(BaseHTTPMiddleware):
     PUBLIC_PATHS = {
         "/",
         "/health",
+        "/ready",
         "/docs",
         "/redoc",
         "/openapi.json",
@@ -66,6 +68,11 @@ class TenantContextMiddleware(BaseHTTPMiddleware):
                     # Store tenant_id in request state for database dependency
                     request.state.tenant_id = tenant_id
                     request.state.set_tenant_context = True
+                    # Additionally bind it for logging (issue #320). request.state
+                    # stays the source of truth for RLS; this contextvar only
+                    # exists so log records emitted deeper in the stack — where
+                    # no Request is in scope — carry the tenant.
+                    TENANT_ID.set(tenant_id)
         except ValueError:
             # Expected: invalid/expired token — continue without tenant context.
             # The auth dependency (get_current_user) handles the actual 401.

--- a/apps/api/src/worker.py
+++ b/apps/api/src/worker.py
@@ -1,10 +1,24 @@
 """
 Celery worker configuration for background tasks
 """
+import uuid
+
 from celery import Celery
+from celery.signals import (
+    before_task_publish,
+    setup_logging as setup_logging_signal,
+    task_postrun,
+    task_prerun,
+)
 from datetime import timedelta
 
 from src.config import settings
+from src.logging_config import (
+    CORRELATION_ID,
+    TENANT_ID,
+    init_sentry,
+    setup_logging,
+)
 
 # Create Celery app
 celery_app = Celery(
@@ -86,6 +100,65 @@ celery_app.conf.beat_schedule = {
         "schedule": timedelta(seconds=settings.STORAGE_GC_INTERVAL_SECONDS),
     },
 }
+
+# ── Observability: structured logs + correlation across the API→chain hop (#320)
+#
+# Propagation rides on message HEADERS, not task kwargs. Kwargs would mean
+# touching every dispatch site and adding a parameter to every task signature —
+# and the generation chain uses immutable .si() signatures precisely so that
+# nothing extra is threaded positionally (issue #211). Headers are invisible to
+# task code and survive chains, links and retries untouched.
+
+# Header names. Celery reserves the plain `id` header, hence the prefix.
+CORRELATION_ID_HEADER = "x_request_id"
+TENANT_ID_HEADER = "x_tenant_id"
+
+
+@setup_logging_signal.connect
+def _configure_worker_logging(**_kwargs):
+    """Use our formatter in the worker instead of Celery's default.
+
+    Connecting to this signal at all disables Celery's own logging config, which
+    is what lets the worker and uvicorn share one JSON format (issue #320, AC5).
+    """
+    setup_logging()
+    init_sentry()
+
+
+@before_task_publish.connect
+def _propagate_context_to_task(headers=None, **_kwargs):
+    """Stamp the publisher's request/tenant ids onto the outgoing message.
+
+    Fires in whichever process publishes: the API (so a task inherits the HTTP
+    request's id) and the worker (so a chained/retried task inherits its
+    parent's), which is what stitches a whole generation run to one id.
+    """
+    if headers is None:
+        return
+    # A task published outside any request context (beat: reap_stuck_episodes,
+    # drain_storage_deletion_outbox) has no id to inherit, so mint one — every
+    # run stays traceable, and its logs group.
+    headers[CORRELATION_ID_HEADER] = CORRELATION_ID.get() or str(uuid.uuid4())
+    tenant_id = TENANT_ID.get()
+    if tenant_id:
+        headers[TENANT_ID_HEADER] = tenant_id
+
+
+@task_prerun.connect
+def _bind_task_context(task=None, **_kwargs):
+    """Bind the message's ids into the worker's context for the task's lifetime."""
+    request = getattr(task, "request", None)
+    correlation_id = getattr(request, CORRELATION_ID_HEADER, None) or str(uuid.uuid4())
+    CORRELATION_ID.set(correlation_id)
+    TENANT_ID.set(getattr(request, TENANT_ID_HEADER, None))
+
+
+@task_postrun.connect
+def _unbind_task_context(**_kwargs):
+    """Clear the ids so a pooled worker can't leak them into the next task."""
+    CORRELATION_ID.set(None)
+    TENANT_ID.set(None)
+
 
 if __name__ == "__main__":
     celery_app.start()

--- a/apps/api/tests/test_health.py
+++ b/apps/api/tests/test_health.py
@@ -75,7 +75,12 @@ async def test_root_endpoint(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_ready_endpoint_reports_dependency_checks(client: AsyncClient):
-    """/ready round-trips the real DB and Redis (both up in the test env)."""
+    """/ready round-trips the real DB and Redis.
+
+    Needs a live Redis at REDIS_URL as well as the test Postgres — deliberately
+    unmocked, per the repo's real-services rule, since a probe that only ever
+    PINGs a mock proves nothing. CI provisions both as service containers.
+    """
     response = await client.get("/ready")
 
     assert response.status_code == 200

--- a/apps/api/tests/test_health.py
+++ b/apps/api/tests/test_health.py
@@ -1,8 +1,35 @@
 """
 Health check endpoint tests
+
+/health is the LIVENESS probe (static — is the process up?) and /ready is the
+READINESS probe (does it have a working DB + Redis?). The split matters: a
+dependency outage must fail /ready so the gate drains traffic, while /health
+stays 200 so a supervisor doesn't restart-loop a healthy process (issue #320).
 """
+from unittest.mock import patch
+
 import pytest
 from httpx import AsyncClient
+
+from src.middleware.tenant import TenantContextMiddleware
+
+
+@pytest.fixture(autouse=True)
+async def dispose_readiness_engine():
+    """Drop the readiness probe's pooled connections between tests.
+
+    /ready checks the app's real module-global engine (that is the point — it
+    proves the pool the app actually serves from is usable). That engine's pool
+    caches connections bound to the event loop that opened them, and
+    pytest-asyncio gives every test a fresh loop, so a connection pooled by one
+    test would be checked out on a dead loop by the next ("got Future attached
+    to a different loop"). Production never hits this — uvicorn runs one loop for
+    the process lifetime — so dispose here rather than weaken the probe.
+    """
+    yield
+    from src.database import engine
+
+    await engine.dispose()
 
 
 @pytest.mark.asyncio
@@ -44,6 +71,86 @@ async def test_root_endpoint(client: AsyncClient):
     # Assert expected values
     assert data["message"] == "Podcastfy API"
     assert data["docs"] == "/docs"
+
+
+@pytest.mark.asyncio
+async def test_ready_endpoint_reports_dependency_checks(client: AsyncClient):
+    """/ready round-trips the real DB and Redis (both up in the test env)."""
+    response = await client.get("/ready")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ready"
+    assert data["checks"] == {"database": "ok", "redis": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_ready_returns_503_when_database_is_down(client: AsyncClient):
+    with patch("src.main._check_database", side_effect=OSError("connection refused")):
+        response = await client.get("/ready")
+
+    assert response.status_code == 503
+    data = response.json()
+    assert data["status"] == "not_ready"
+    assert data["checks"]["database"] == "error"
+    # Redis is independently healthy — the probe must say which one broke.
+    assert data["checks"]["redis"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_ready_returns_503_when_redis_is_down(client: AsyncClient):
+    with patch("src.main._check_redis", side_effect=OSError("connection refused")):
+        response = await client.get("/ready")
+
+    assert response.status_code == 503
+    data = response.json()
+    assert data["checks"]["redis"] == "error"
+    assert data["checks"]["database"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_ready_returns_503_when_dependency_hangs(client: AsyncClient):
+    """A hung dependency must fail the probe fast, not hang it."""
+    import asyncio
+
+    async def _hang():
+        await asyncio.sleep(30)
+
+    with patch("src.main._check_redis", side_effect=_hang), \
+            patch("src.main.settings.READINESS_CHECK_TIMEOUT_SECONDS", 0.05):
+        response = await client.get("/ready")
+
+    assert response.status_code == 503
+    assert response.json()["checks"]["redis"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_ready_does_not_leak_dependency_error_details(client: AsyncClient):
+    """/ready is unauthenticated; connection errors quote DSNs and hostnames."""
+    with patch(
+        "src.main._check_database",
+        side_effect=OSError("could not connect to host=10.0.0.5 user=podcastfy_app"),
+    ):
+        response = await client.get("/ready")
+
+    assert "10.0.0.5" not in response.text
+    assert "podcastfy_app" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_health_stays_up_when_dependencies_are_down(client: AsyncClient):
+    """Liveness must not collapse into readiness."""
+    with patch("src.main._check_database", side_effect=OSError("down")), \
+            patch("src.main._check_redis", side_effect=OSError("down")):
+        response = await client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "healthy"
+
+
+def test_ready_is_a_public_path():
+    """Otherwise the probe gets metered and tenant-resolved on every poll."""
+    assert "/ready" in TenantContextMiddleware.PUBLIC_PATHS
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_observability.py
+++ b/apps/api/tests/test_observability.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from httpx import AsyncClient
 
+from src.main import app
 from src.logging_config import (
     CORRELATION_ID,
     REQUEST_ID_HEADER,
@@ -142,6 +143,50 @@ async def test_request_ids_differ_across_requests(client: AsyncClient):
 async def test_correlation_id_does_not_leak_after_request(client: AsyncClient):
     await client.get("/health")
     assert CORRELATION_ID.get() is None
+
+
+@pytest.mark.asyncio
+async def test_unhandled_500_still_carries_request_id():
+    """The response a user most needs an id for.
+
+    An unhandled exception propagates past CorrelationIdMiddleware to
+    Starlette's ServerErrorMiddleware (which sits outside it), so the header has
+    to be re-stamped by the 500 handler or it is lost exactly here.
+    """
+    from httpx import ASGITransport
+
+    @app.get("/_test_unhandled_error")
+    async def _boom():
+        raise RuntimeError("kaboom")
+
+    try:
+        transport = ASGITransport(app=app, raise_app_exceptions=False)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            response = await c.get(
+                "/_test_unhandled_error", headers={REQUEST_ID_HEADER: "trace-500"}
+            )
+
+        assert response.status_code == 500
+        assert response.headers[REQUEST_ID_HEADER] == "trace-500"
+        # The id must not come at the cost of leaking the exception.
+        assert "kaboom" not in response.text
+    finally:
+        app.router.routes = [
+            r for r in app.router.routes
+            if getattr(r, "path", None) != "/_test_unhandled_error"
+        ]
+
+
+def test_request_id_is_cors_allowed_and_exposed():
+    """A browser can neither send nor read the id unless CORS lists it."""
+    from src.config import settings
+
+    assert "X-Request-ID" in settings.CORS_ALLOW_HEADERS
+
+    cors = next(
+        m for m in app.user_middleware if m.cls.__name__ == "CORSMiddleware"
+    )
+    assert "X-Request-ID" in cors.kwargs["expose_headers"]
 
 
 # ── AC3: propagation into Celery ───────────────────────────────────────────

--- a/apps/api/tests/test_observability.py
+++ b/apps/api/tests/test_observability.py
@@ -1,0 +1,286 @@
+"""Observability baseline tests (issue #320).
+
+Pins four contracts:
+1. JSON log records carry request_id + tenant_id, so an incident is filterable.
+2. Every request gets an X-Request-ID, echoed back; a client-supplied one wins.
+3. The correlation/tenant ids ride Celery message headers from API to task,
+   without touching any task signature.
+4. Sentry stays off unless SENTRY_DSN is set, and scrubs bodies/creds when on.
+"""
+import json
+import logging
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from src.logging_config import (
+    CORRELATION_ID,
+    REQUEST_ID_HEADER,
+    TENANT_ID,
+    JsonFormatter,
+    _scrub,
+    build_formatter,
+    init_sentry,
+    setup_logging,
+)
+
+
+def _record(**kwargs) -> logging.LogRecord:
+    defaults = dict(
+        name="src.test", level=logging.INFO, pathname=__file__, lineno=1,
+        msg="hello", args=(), exc_info=None,
+    )
+    defaults.update(kwargs)
+    return logging.LogRecord(**defaults)
+
+
+# ── AC5: JSON formatter ────────────────────────────────────────────────────
+
+
+def test_formatter_emits_parseable_json_with_core_fields():
+    payload = json.loads(JsonFormatter().format(_record()))
+
+    assert payload["message"] == "hello"
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == "src.test"
+    assert "timestamp" in payload
+
+
+def test_formatter_binds_request_and_tenant_id():
+    """The whole point of AC3: a log line must say which request/tenant it came from."""
+    request_token = CORRELATION_ID.set("req-abc")
+    tenant_token = TENANT_ID.set("tenant-xyz")
+    try:
+        payload = json.loads(JsonFormatter().format(_record()))
+    finally:
+        CORRELATION_ID.reset(request_token)
+        TENANT_ID.reset(tenant_token)
+
+    assert payload["request_id"] == "req-abc"
+    assert payload["tenant_id"] == "tenant-xyz"
+
+
+def test_formatter_omits_ids_when_unbound():
+    payload = json.loads(JsonFormatter().format(_record()))
+    assert "request_id" not in payload
+    assert "tenant_id" not in payload
+
+
+def test_formatter_renders_exception_and_extra_fields():
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        import sys
+
+        record = _record(exc_info=sys.exc_info())
+    record.episode_id = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+    payload = json.loads(JsonFormatter().format(record))
+
+    assert "ValueError: boom" in payload["exception"]
+    # Non-JSON-native values must not blow up the formatter.
+    assert payload["episode_id"] == "11111111-1111-1111-1111-111111111111"
+
+
+def test_formatter_message_interpolates_args():
+    payload = json.loads(JsonFormatter().format(_record(msg="hi %s", args=("bob",))))
+    assert payload["message"] == "hi bob"
+
+
+def test_log_format_setting_selects_formatter():
+    with patch("src.logging_config.settings.LOG_FORMAT", "json"):
+        assert isinstance(build_formatter(), JsonFormatter)
+    with patch("src.logging_config.settings.LOG_FORMAT", "text"):
+        assert not isinstance(build_formatter(), JsonFormatter)
+
+
+def test_setup_logging_also_formats_uvicorn_handlers():
+    """AC5 says 'shared by uvicorn and Celery' — uvicorn's handlers don't
+    propagate to root, so configuring root alone would leave access logs raw."""
+    access = logging.getLogger("uvicorn.access")
+    handler = logging.StreamHandler()
+    access.addHandler(handler)
+    try:
+        with patch("src.logging_config.settings.LOG_FORMAT", "json"):
+            setup_logging()
+        assert isinstance(handler.formatter, JsonFormatter)
+    finally:
+        access.removeHandler(handler)
+
+
+# ── AC3: correlation ID over HTTP ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_response_carries_generated_request_id(client: AsyncClient):
+    response = await client.get("/health")
+
+    assert response.status_code == 200
+    # Must be present and a well-formed uuid, not an empty string.
+    uuid.UUID(response.headers[REQUEST_ID_HEADER])
+
+
+@pytest.mark.asyncio
+async def test_client_supplied_request_id_is_reused(client: AsyncClient):
+    """Lets a caller (or nginx) stitch its own trace to ours."""
+    response = await client.get("/health", headers={REQUEST_ID_HEADER: "trace-me-123"})
+
+    assert response.headers[REQUEST_ID_HEADER] == "trace-me-123"
+
+
+@pytest.mark.asyncio
+async def test_request_ids_differ_across_requests(client: AsyncClient):
+    first = await client.get("/health")
+    second = await client.get("/health")
+
+    assert first.headers[REQUEST_ID_HEADER] != second.headers[REQUEST_ID_HEADER]
+
+
+@pytest.mark.asyncio
+async def test_correlation_id_does_not_leak_after_request(client: AsyncClient):
+    await client.get("/health")
+    assert CORRELATION_ID.get() is None
+
+
+# ── AC3: propagation into Celery ───────────────────────────────────────────
+
+
+def test_publish_stamps_ids_onto_message_headers():
+    from src.worker import (
+        CORRELATION_ID_HEADER,
+        TENANT_ID_HEADER,
+        _propagate_context_to_task,
+    )
+
+    request_token = CORRELATION_ID.set("req-1")
+    tenant_token = TENANT_ID.set("tenant-1")
+    try:
+        headers = {}
+        _propagate_context_to_task(headers=headers)
+    finally:
+        CORRELATION_ID.reset(request_token)
+        TENANT_ID.reset(tenant_token)
+
+    assert headers[CORRELATION_ID_HEADER] == "req-1"
+    assert headers[TENANT_ID_HEADER] == "tenant-1"
+
+
+def test_publish_mints_id_when_outside_request_context():
+    """Beat tasks (reap_stuck_episodes) publish with no request in scope; they
+    still need a groupable id."""
+    from src.worker import CORRELATION_ID_HEADER, _propagate_context_to_task
+
+    headers = {}
+    _propagate_context_to_task(headers=headers)
+
+    uuid.UUID(headers[CORRELATION_ID_HEADER])
+
+
+def test_prerun_binds_ids_from_message_headers():
+    from src.worker import (
+        CORRELATION_ID_HEADER,
+        TENANT_ID_HEADER,
+        _bind_task_context,
+        _unbind_task_context,
+    )
+
+    task = MagicMock()
+    task.request = MagicMock(
+        **{CORRELATION_ID_HEADER: "req-2", TENANT_ID_HEADER: "tenant-2"}
+    )
+    try:
+        _bind_task_context(task=task)
+        assert CORRELATION_ID.get() == "req-2"
+        assert TENANT_ID.get() == "tenant-2"
+    finally:
+        _unbind_task_context()
+
+
+def test_postrun_clears_ids_so_pooled_worker_cannot_leak_tenant():
+    from src.worker import _unbind_task_context
+
+    CORRELATION_ID.set("req-3")
+    TENANT_ID.set("tenant-3")
+
+    _unbind_task_context()
+
+    assert CORRELATION_ID.get() is None
+    assert TENANT_ID.get() is None
+
+
+def test_api_to_task_roundtrip_preserves_id():
+    """The end-to-end contract: what the API publishes is what the task binds."""
+    from src.worker import (
+        TENANT_ID_HEADER,
+        _bind_task_context,
+        _propagate_context_to_task,
+        _unbind_task_context,
+    )
+
+    headers = {}
+    request_token = CORRELATION_ID.set("end-to-end")
+    tenant_token = TENANT_ID.set("tenant-e2e")
+    try:
+        _propagate_context_to_task(headers=headers)
+    finally:
+        CORRELATION_ID.reset(request_token)
+        TENANT_ID.reset(tenant_token)
+
+    assert CORRELATION_ID.get() is None  # publisher context gone, as in a worker
+
+    task = MagicMock()
+    task.request = MagicMock(**{k: v for k, v in headers.items()})
+    try:
+        _bind_task_context(task=task)
+        assert CORRELATION_ID.get() == "end-to-end"
+        assert TENANT_ID.get() == "tenant-e2e"
+    finally:
+        _unbind_task_context()
+
+    assert headers[TENANT_ID_HEADER] == "tenant-e2e"
+
+
+# ── AC1: Sentry ────────────────────────────────────────────────────────────
+
+
+def test_sentry_is_noop_without_dsn():
+    """Tests/CI/local must never phone home."""
+    with patch("src.logging_config.settings.SENTRY_DSN", None):
+        assert init_sentry() is False
+
+
+def test_sentry_initialises_with_dsn_and_pii_disabled():
+    with patch("src.logging_config.settings.SENTRY_DSN", "https://k@example.com/1"), \
+            patch("src.logging_config.settings.ENVIRONMENT", "staging"), \
+            patch("sentry_sdk.init") as mock_init:
+        assert init_sentry() is True
+
+    kwargs = mock_init.call_args.kwargs
+    assert kwargs["dsn"] == "https://k@example.com/1"
+    assert kwargs["environment"] == "staging"
+    assert kwargs["send_default_pii"] is False
+    assert kwargs["traces_sample_rate"] == 0.0
+
+
+def test_sentry_before_send_scrubs_body_and_credentials():
+    """Multi-tenant app: request bodies hold other tenants' content."""
+    event = {
+        "request": {
+            "data": {"secret": "podcast script"},
+            "cookies": {"session": "abc"},
+            "headers": {"Authorization": "Bearer tok", "User-Agent": "curl"},
+        }
+    }
+
+    scrubbed = _scrub(event, {})
+
+    assert "data" not in scrubbed["request"]
+    assert "cookies" not in scrubbed["request"]
+    assert "Authorization" not in scrubbed["request"]["headers"]
+    assert scrubbed["request"]["headers"]["User-Agent"] == "curl"
+
+
+def test_sentry_before_send_tolerates_event_without_request():
+    assert _scrub({"level": "error"}, {}) == {"level": "error"}

--- a/apps/api/tests/test_observability.py
+++ b/apps/api/tests/test_observability.py
@@ -37,6 +37,21 @@ def _record(**kwargs) -> logging.LogRecord:
     return logging.LogRecord(**defaults)
 
 
+def _context(headers: dict):
+    """A REAL Celery request Context built from message headers.
+
+    Not a MagicMock: a mock answers any attribute, so a mock-based test would
+    pass even if the worker never read the header at all — it would assert an
+    outcome impossible under real semantics. Context is what Celery actually
+    hands a task, so this test fails if the header plumbing is wrong.
+    Verified against a live worker: Celery exposes custom headers both as
+    top-level Context attributes and via .headers.
+    """
+    from celery.app.task import Context
+
+    return Context(dict(headers))
+
+
 # ── AC5: JSON formatter ────────────────────────────────────────────────────
 
 
@@ -232,9 +247,7 @@ def test_prerun_binds_ids_from_message_headers():
     )
 
     task = MagicMock()
-    task.request = MagicMock(
-        **{CORRELATION_ID_HEADER: "req-2", TENANT_ID_HEADER: "tenant-2"}
-    )
+    task.request = _context({CORRELATION_ID_HEADER: "req-2", TENANT_ID_HEADER: "tenant-2"})
     try:
         _bind_task_context(task=task)
         assert CORRELATION_ID.get() == "req-2"
@@ -276,7 +289,7 @@ def test_api_to_task_roundtrip_preserves_id():
     assert CORRELATION_ID.get() is None  # publisher context gone, as in a worker
 
     task = MagicMock()
-    task.request = MagicMock(**{k: v for k, v in headers.items()})
+    task.request = _context(headers)
     try:
         _bind_task_context(task=task)
         assert CORRELATION_ID.get() == "end-to-end"

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -246,6 +246,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "redis" },
+    { name = "sentry-sdk" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -277,6 +278,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.6" },
     { name = "redis", specifier = ">=5.0.0" },
+    { name = "sentry-sdk", specifier = ">=2.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.51" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.51.0" },
 ]
@@ -3990,6 +3992,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f6/94/dcdaeb1713cab9c84def276cfac7388b17c7d9855bbcfe88d77e4dbafd44/s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685", size = 165171, upload-time = "2026-06-16T19:44:51.599Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262", size = 90101, upload-time = "2026-06-16T19:44:50.439Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.65.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/1f/ed17a390348156ca99fe622b97cd7d2f1969b5f49df89084b0f28e7953e9/sentry_sdk-2.65.0.tar.gz", hash = "sha256:c94dc945d54bad49d4f20448b1e6b217ca2f92f46d05c3e83d41764af685c3d1", size = 932133, upload-time = "2026-07-13T11:33:19.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/3b/326ad4c03b5da89b5124c8890af66e8119c4d2e10abc0619e0d67d9f7c7f/sentry_sdk-2.65.0-py3-none-any.whl", hash = "sha256:3595169677a808e4d0e1ea6ffb89443459549c7a98392ed71c77c847182ab6bf", size = 503869, upload-time = "2026-07-13T11:33:17.71Z" },
 ]
 
 [[package]]

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -187,8 +187,13 @@ EOF
 # Check PM2 processes
 ssh root@<SERVER_IP> "pm2 list"
 
-# Check API health
-curl https://dev.podcaststudiohub.me/api/health
+# Check API liveness (200 = the process is up)
+curl https://dev.podcaststudiohub.me/health
+
+# Check API readiness (200 = Postgres + Redis reachable; 503 = a dependency is
+# down). This is what the automated deploy gates on — /health would pass on an
+# API that is up but cannot serve a single real request.
+curl -i https://dev.podcaststudiohub.me/ready
 
 # Check frontend
 curl https://dev.podcaststudiohub.me
@@ -238,6 +243,75 @@ ssh root@<SERVER_IP> "pm2 restart podcaststudiohub-celery"
 **Restart all:**
 ```bash
 ssh root@<SERVER_IP> "pm2 restart all"
+```
+
+## Log rotation — issue #320
+
+Both log producers on this box write unbounded by default. A single VPS disk
+backs Postgres, Redis and the app tree, so an unrotated log does not just lose
+logs — it takes the whole host down. Both are rotated automatically by the
+deploy workflow; neither needs manual setup.
+
+| Producer | Path | Rotated by | Policy |
+| --- | --- | --- | --- |
+| nginx | `/opt/podcaststudiohub/logs/frontend-{access,error}.log` | `/etc/logrotate.d/podcaststudiohub-nginx` (system logrotate, daily cron/timer) | daily, keep **14**, compressed |
+| PM2 (api / frontend / celery) | `~/.pm2/logs/*.log` (service account's home) | `pm2-logrotate` module | roll at **10M** or daily at 00:00, keep **7**, compressed |
+
+### nginx
+
+The site config logs to a **custom** path (`/opt/podcaststudiohub/logs/`), which
+the distro's stock `/etc/logrotate.d/nginx` does **not** cover — that file only
+globs `/var/log/nginx/*.log`, so these logs match nothing and grow forever. The
+repo therefore ships its own drop-in at
+`deployment/logrotate/podcaststudiohub-nginx`; the deploy rsyncs it and installs
+it to `/etc/logrotate.d/podcaststudiohub-nginx`.
+
+If you change `access_log` / `error_log` in `deployment/nginx/podcastfy.conf`,
+change the glob in the drop-in to match — `deployment/tests/test_log_rotation.py`
+fails the build if the two drift apart.
+
+The deploy validates the drop-in with `logrotate -d` (dry run) **before**
+installing it, because a malformed file in `/etc/logrotate.d` breaks the entire
+daily rotation, not just this one entry. Note that `logrotate -d` exits **0** on
+an unknown option (it prints `error: ... -- ignoring line` and continues), so
+the deploy also greps its output for `error:` lines — the exit status alone is
+not a gate.
+
+Installing to `/etc/logrotate.d` needs root; the deploy account is the non-root
+service user from `harden-host.sh`, so the step escalates with `sudo -n`
+(non-interactive — it fails loudly rather than hanging on a password prompt).
+**The deploy account therefore needs NOPASSWD sudo** for `install` and
+`logrotate`, or that step fails.
+
+Verify / force a rotation by hand:
+```bash
+# Dry run (prints what it would do; never rotates)
+ssh root@<SERVER_IP> "logrotate -d /etc/logrotate.d/podcaststudiohub-nginx"
+
+# Force a real rotation now
+ssh root@<SERVER_IP> "logrotate -f /etc/logrotate.d/podcaststudiohub-nginx"
+
+ssh root@<SERVER_IP> "ls -lh /opt/podcaststudiohub/logs/"
+```
+
+### PM2
+
+`pm2-logrotate` is a **global** pm2 module (not per-process config), so it
+covers all three processes at once — which is why there is no ecosystem file
+entry for it. The deploy installs and configures it idempotently on every run:
+
+```bash
+pm2 install pm2-logrotate
+pm2 set pm2-logrotate:max_size 10M
+pm2 set pm2-logrotate:retain 7
+pm2 set pm2-logrotate:compress true
+pm2 set pm2-logrotate:rotateInterval '0 0 * * *'
+```
+
+Inspect the live settings (they are stored in pm2's module config, not in git):
+```bash
+ssh root@<SERVER_IP> "pm2 conf pm2-logrotate"
+ssh root@<SERVER_IP> "ls -lh ~/.pm2/logs/"
 ```
 
 ## Environment Variables

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -245,6 +245,42 @@ ssh root@<SERVER_IP> "pm2 restart podcaststudiohub-celery"
 ssh root@<SERVER_IP> "pm2 restart all"
 ```
 
+## Error tracking (Sentry) — issue #320
+
+Both the API and the Celery worker report unhandled exceptions to Sentry, but
+**only when `SENTRY_DSN` is set** — with no DSN, `init_sentry()` is a no-op, so
+local dev and CI never phone home. Nothing in the deploy sets it for you.
+
+To enable it on a host, add the DSN to the API's env file (the same file the
+API and worker already read; PM2 starts both from `$SERVER_PATH/api`):
+
+```bash
+# /opt/podcaststudiohub/api/.env
+SENTRY_DSN=https://<key>@<org>.ingest.sentry.io/<project>
+```
+
+then restart both processes so they pick it up:
+
+```bash
+pm2 restart podcaststudiohub-api podcaststudiohub-celery
+```
+
+Verify it took effect — this logs an exception the worker will also report:
+
+```bash
+pm2 logs podcaststudiohub-api --lines 50 | grep -i sentry
+```
+
+Notes:
+- `send_default_pii=False` and a `before_send` scrub strip the request body,
+  cookies and `Authorization` before an event leaves the process. This is a
+  multi-tenant app: a request body can contain another tenant's content, so do
+  not relax those without a deliberate decision.
+- `SENTRY_TRACES_SAMPLE_RATE` defaults to `0.0` (errors only). Raise it only
+  deliberately — performance tracing is billed per transaction.
+- `ENVIRONMENT` (already set per host) becomes the Sentry environment, so dev
+  and production events stay separated.
+
 ## Log rotation — issue #320
 
 Both log producers on this box write unbounded by default. A single VPS disk

--- a/deployment/logrotate/podcaststudiohub-nginx
+++ b/deployment/logrotate/podcaststudiohub-nginx
@@ -1,0 +1,46 @@
+# Log rotation for the Podcastfy Studio nginx site (issue #320).
+#
+# Installed to /etc/logrotate.d/podcaststudiohub-nginx by the deploy workflow
+# (.github/workflows/deploy-dev.yml) — see deployment/README.md.
+#
+# WHY THIS FILE EXISTS: deployment/nginx/podcastfy.conf writes its access/error
+# logs to a CUSTOM path (/opt/podcaststudiohub/logs/), not the distro default.
+# The stock /etc/logrotate.d/nginx only globs /var/log/nginx/*.log, so these
+# files match nothing and grow unbounded until they fill the VPS disk — which
+# takes the whole box down, not just nginx.
+#
+# Keep the glob below in sync with the access_log/error_log paths in
+# podcastfy.conf; deployment/tests/test_log_rotation.py enforces the pairing.
+
+/opt/podcaststudiohub/logs/*.log {
+	daily
+	rotate 14
+	compress
+	# nginx keeps writing to the renamed inode until it reopens on USR1 below,
+	# so compressing on the same pass would truncate in-flight lines.
+	delaycompress
+	notifempty
+	# A freshly provisioned host has no logs until nginx serves its first
+	# request; a missing file must not error the daily run.
+	missingok
+	# nginx's master (root) reopens the path and its workers (www-data) write
+	# it, so the replacement file must be writable by www-data.
+	create 0640 www-data adm
+	# Both the access and error log match this glob: without sharedscripts the
+	# postrotate below (and its USR1) would run once per file.
+	sharedscripts
+	postrotate
+		# USR1 makes the nginx master reopen its log files. Without it nginx
+		# holds the rotated inode open: the live log stops growing and the disk
+		# is never actually reclaimed.
+		#
+		# Guarded on purpose: logrotate treats a non-zero postrotate as a
+		# failure of the whole rotation, so a stopped nginx (no pidfile) or an
+		# already-reaped pid must not block rotating the logs.
+		if [ -f /run/nginx.pid ]; then
+			kill -USR1 "$(cat /run/nginx.pid)" || true
+		elif [ -f /var/run/nginx.pid ]; then
+			kill -USR1 "$(cat /var/run/nginx.pid)" || true
+		fi
+	endscript
+}

--- a/deployment/nginx/podcastfy.conf
+++ b/deployment/nginx/podcastfy.conf
@@ -174,9 +174,19 @@ server {
 		proxy_cache off;
 	}
 
-	# Health check endpoint
+	# Liveness endpoint — 200 whenever the API process is up at all.
 	location /health {
 		proxy_pass http://podcastfy_api/health;
+		access_log off;
+	}
+
+	# Readiness endpoint (issue #320) — 200 only when the API's dependencies
+	# (Postgres + Redis) are reachable, 503 otherwise. This is what the deploy
+	# gates on: /health would go green on an API that is up but cannot serve.
+	# access_log off for the same reason as /health: the deploy polls this up to
+	# 30x per run and uptime checks hit it continuously.
+	location /ready {
+		proxy_pass http://podcastfy_api/ready;
 		access_log off;
 	}
 

--- a/deployment/tests/test_log_rotation.py
+++ b/deployment/tests/test_log_rotation.py
@@ -1,0 +1,345 @@
+"""Tests for the observability baseline's log/readiness plumbing (issue #320).
+
+Pins three deployment-side contracts:
+1. The deploy gates on the API's *readiness* endpoint (/ready — DB+Redis
+   reachable), not merely liveness (/health), so a deploy that leaves the API
+   up but its dependencies unreachable fails loudly instead of going green.
+   nginx must expose /ready for that gate to be reachable at all.
+2. nginx's logs land on a custom path (/opt/podcaststudiohub/logs/*.log) that
+   the distro's stock /etc/logrotate.d/nginx does NOT cover (it globs
+   /var/log/nginx/*.log) — a repo-owned drop-in rotates them, and the deploy
+   installs + validates it.
+3. PM2's per-process logs (~/.pm2/logs) are rotated by the pm2-logrotate
+   module, configured idempotently by the deploy.
+
+Static reads only, like test_dr_durability.py — no live server/nginx/PM2.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPLOY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-dev.yml"
+NGINX_CONF = REPO_ROOT / "deployment" / "nginx" / "podcastfy.conf"
+LOGROTATE_CONF = REPO_ROOT / "deployment" / "logrotate" / "podcaststudiohub-nginx"
+README = REPO_ROOT / "deployment" / "README.md"
+
+LOGROTATE_INSTALL_PATH = "/etc/logrotate.d/podcaststudiohub-nginx"
+
+
+# ── AC1: the deploy gates on /ready, not /health ───────────────────────────
+
+
+def test_deploy_gates_api_on_ready_endpoint():
+	text = DEPLOY_WORKFLOW.read_text()
+	assert re.search(r'wait_for "API" "\$API_URL/ready" "200"', text), (
+		"deploy must gate the API on /ready (DB+Redis reachable), not just liveness"
+	)
+
+
+def test_deploy_does_not_gate_api_on_liveness_health():
+	# /health returns 200 whenever the process is merely up — gating on it lets
+	# a deploy go green with an unreachable DB or Redis.
+	text = DEPLOY_WORKFLOW.read_text()
+	assert not re.search(r'wait_for "API" "\$API_URL/health"', text), (
+		"the API gate must not fall back to the liveness endpoint"
+	)
+
+
+def test_deploy_still_gates_frontend():
+	text = DEPLOY_WORKFLOW.read_text()
+	assert re.search(r'wait_for "Frontend" "\$FRONTEND_URL" "200"', text), (
+		"the frontend gate must be preserved"
+	)
+
+
+def test_deploy_keeps_polling_readiness_gate():
+	# A cold uvicorn start is slow; /ready is slower still (it dials DB+Redis).
+	# The retry helper must stay — a one-shot curl would race the upstream.
+	text = DEPLOY_WORKFLOW.read_text()
+	assert "attempts=30" in text, "readiness gate must keep the 30-attempt poll"
+	assert "sleep 5" in text, "readiness gate must keep the 5s backoff"
+
+
+def test_deploy_explains_ready_versus_health():
+	# The distinction is subtle enough to regress silently; it must be written down.
+	text = DEPLOY_WORKFLOW.read_text()
+	gate = text.find('wait_for "API"')
+	assert gate != -1
+	window = text[gate - 1200 : gate]
+	assert "/ready" in window and "/health" in window, (
+		"deploy must comment why the gate is /ready (readiness) not /health (liveness)"
+	)
+
+
+# ── AC1: nginx exposes /ready ──────────────────────────────────────────────
+
+
+def test_nginx_exposes_ready_location():
+	text = NGINX_CONF.read_text()
+	assert re.search(r"location /ready\b", text), (
+		"nginx must expose /ready or the deploy gate can never reach it"
+	)
+
+
+def test_nginx_ready_proxies_to_api_upstream():
+	text = NGINX_CONF.read_text()
+	match = re.search(r"location /ready\b[^{]*\{(.*?)\n\t\}", text, re.S)
+	assert match, "expected a brace-delimited location /ready block"
+	body = match.group(1)
+	assert "proxy_pass http://podcastfy_api/ready;" in body, (
+		"/ready must proxy to the FastAPI upstream's /ready"
+	)
+
+
+def test_nginx_ready_does_not_pollute_access_log():
+	# The deploy polls /ready up to 30x per run, and uptime checks hit it
+	# continuously — mirroring /health's access_log off keeps it out of the logs
+	# this same issue teaches to rotate.
+	text = NGINX_CONF.read_text()
+	match = re.search(r"location /ready\b[^{]*\{(.*?)\n\t\}", text, re.S)
+	assert match
+	assert "access_log off;" in match.group(1), "/ready must set access_log off"
+
+
+def test_nginx_keeps_health_location():
+	# /ready is additive: /health stays as the liveness probe.
+	text = NGINX_CONF.read_text()
+	assert re.search(r"location /health\b", text), "the /health location must be preserved"
+
+
+# ── AC2: nginx logrotate drop-in ───────────────────────────────────────────
+
+
+def test_logrotate_conf_exists():
+	assert LOGROTATE_CONF.is_file(), f"expected logrotate drop-in at {LOGROTATE_CONF}"
+
+
+def test_logrotate_targets_the_custom_nginx_log_path():
+	# The whole point: podcastfy.conf logs to /opt/podcaststudiohub/logs/, which
+	# the stock nginx drop-in (/var/log/nginx/*.log) never touches.
+	text = LOGROTATE_CONF.read_text()
+	assert "/opt/podcaststudiohub/logs/*.log" in text, (
+		"drop-in must rotate the custom log path nginx actually writes to"
+	)
+
+
+def test_logrotate_conf_covers_the_paths_nginx_writes():
+	# Guard the pairing: if podcastfy.conf's access_log/error_log move, the glob
+	# must move with them or the logs go unrotated again.
+	nginx = NGINX_CONF.read_text()
+	logs = re.findall(r"^\s*(?:access|error)_log\s+(\S+\.log);", nginx, re.M)
+	assert logs, "expected nginx to configure file-backed access/error logs"
+	for path in logs:
+		assert path.startswith("/opt/podcaststudiohub/logs/"), (
+			f"nginx log {path} is outside the rotated glob — it would grow forever"
+		)
+
+
+def test_logrotate_rotates_daily_with_retention():
+	text = LOGROTATE_CONF.read_text()
+	assert re.search(r"^\s*daily\s*$", text, re.M), "must rotate daily"
+	assert re.search(r"^\s*rotate\s+14\s*$", text, re.M), "must retain 14 rotations"
+
+
+def test_logrotate_compresses_with_delaycompress():
+	text = LOGROTATE_CONF.read_text()
+	assert re.search(r"^\s*compress\s*$", text, re.M), "must compress rotated logs"
+	# delaycompress: nginx keeps writing to the renamed file until it reopens on
+	# USR1, so compressing on the same pass would truncate in-flight lines.
+	assert re.search(r"^\s*delaycompress\s*$", text, re.M), "must delaycompress"
+
+
+def test_logrotate_tolerates_missing_and_empty_logs():
+	text = LOGROTATE_CONF.read_text()
+	assert re.search(r"^\s*missingok\s*$", text, re.M), (
+		"missingok: a host that has not served traffic yet must not error"
+	)
+	assert re.search(r"^\s*notifempty\s*$", text, re.M), "must not rotate empty logs"
+
+
+def test_logrotate_recreates_logs_with_the_nginx_owner():
+	# nginx reopens the path on USR1 and must be able to write it again.
+	text = LOGROTATE_CONF.read_text()
+	assert re.search(r"^\s*create\s+0640\s+www-data\s+adm\s*$", text, re.M), (
+		"must recreate logs as 0640 www-data:adm so nginx can write them"
+	)
+
+
+def test_logrotate_uses_sharedscripts():
+	# Two files match the glob; without sharedscripts the postrotate (and its
+	# USR1) runs once per file.
+	assert re.search(r"^\s*sharedscripts\s*$", LOGROTATE_CONF.read_text(), re.M)
+
+
+def test_logrotate_postrotate_makes_nginx_reopen_its_logs():
+	text = LOGROTATE_CONF.read_text()
+	match = re.search(r"postrotate(.*?)endscript", text, re.S)
+	assert match, "drop-in must have a postrotate script"
+	body = match.group(1)
+	# Without USR1 nginx keeps writing to the rotated inode: the live log stops
+	# growing and the disk is never actually reclaimed.
+	assert re.search(r"kill\s+-USR1", body), "postrotate must signal nginx to reopen logs"
+	assert "nginx.pid" in body, "postrotate must signal the nginx master pid"
+
+
+def test_logrotate_postrotate_cannot_fail_the_rotation():
+	# logrotate treats a non-zero postrotate as an error for the whole set; a
+	# stopped nginx (no pidfile) must not block rotation.
+	text = LOGROTATE_CONF.read_text()
+	match = re.search(r"postrotate(.*?)endscript", text, re.S)
+	assert match
+	body = match.group(1)
+	assert "|| true" in body or re.search(r"if\s+\[", body), (
+		"postrotate must be guarded so a stopped nginx cannot fail the rotation"
+	)
+
+
+# ── AC2: the deploy installs + validates the drop-in ───────────────────────
+
+
+def test_deploy_syncs_logrotate_conf_to_server():
+	text = DEPLOY_WORKFLOW.read_text()
+	assert re.search(r"rsync.*(\n.*)*?logrotate/podcaststudiohub-nginx", text), (
+		"deploy must rsync the logrotate drop-in to the server"
+	)
+
+
+def test_deploy_installs_logrotate_conf_to_logrotate_d():
+	text = DEPLOY_WORKFLOW.read_text()
+	assert LOGROTATE_INSTALL_PATH in text, (
+		f"deploy must install the drop-in to {LOGROTATE_INSTALL_PATH}"
+	)
+
+
+def test_deploy_installs_logrotate_conf_idempotently():
+	# Re-running the deploy must overwrite in place — never append or duplicate.
+	step = _logrotate_step()
+	install = re.search(r"install\s+-m\s+0644((?:[^\n]*\\\n)*[^\n]*)", step)
+	assert install, "drop-in must be installed with `install -m 0644` (overwrite in place)"
+	# The destination may be spelled literally or via a variable assigned to it.
+	target = install.group(1)
+	assert LOGROTATE_INSTALL_PATH in target or re.search(r"\$\{?DEST\b", target), (
+		f"the `install` must target {LOGROTATE_INSTALL_PATH}"
+	)
+	assert LOGROTATE_INSTALL_PATH in step, "the install path must appear in the step"
+	assert ">>" not in step, "must not append to the drop-in (not idempotent)"
+
+
+def test_deploy_validates_logrotate_conf_before_it_can_break_rotation():
+	# `logrotate -d` is a parse-only dry run: a malformed drop-in must fail the
+	# deploy, not silently sit in /etc/logrotate.d breaking every daily run.
+	step = _logrotate_step()
+	assert re.search(r"logrotate\s+-d\b", step), "deploy must validate with `logrotate -d`"
+	assert "set -e" in step, "the logrotate SSH block must fail fast on a bad config"
+
+
+def test_deploy_logrotate_validation_catches_silently_ignored_directives():
+	# Verified against real logrotate 3.21: `logrotate -d` exits 0 on an unknown
+	# option — it prints "error: ... unknown option 'x' -- ignoring line" and
+	# carries on. So `set -e` alone CANNOT catch a typo'd directive (e.g.
+	# `rotat 14`), which would silently drop that setting. The step must inspect
+	# the output for error lines, not just trust the exit status.
+	step = _logrotate_step()
+	assert re.search(r"grep[^\n]*error", step, re.I), (
+		"validation must grep logrotate's output for 'error:' lines — its exit "
+		"status is 0 for unknown/ignored directives"
+	)
+
+
+def test_deploy_does_privileged_logrotate_install_non_interactively():
+	# The deploy account is the non-root service user (harden-host.sh), so
+	# /etc/logrotate.d needs sudo — and `-n` fails loudly rather than hanging
+	# forever on a password prompt.
+	step = _logrotate_step()
+	assert "sudo -n" in step, "privileged install must use non-interactive sudo (sudo -n)"
+
+
+def test_deploy_ssh_heredocs_contain_no_backticks():
+	# Found the hard way while adding the steps above: these are UNQUOTED
+	# heredocs (<< EOF), so the *runner's* shell command-substitutes backticks
+	# before the text is ever sent to the server — including backticks inside
+	# '#' comments. A markdown-style comment like `pm2 install` therefore RUNS
+	# pm2 install on the runner and is stripped from what the server receives.
+	# Quoting the heredoc would break the intentional $SERVER_PATH expansion, so
+	# the rule is simply: no backticks inside these bodies.
+	text = DEPLOY_WORKFLOW.read_text()
+	bodies = re.findall(r"<< EOF\n(.*?)\n\s*EOF$", text, re.S | re.M)
+	assert bodies, "expected unquoted SSH heredocs in deploy-dev.yml"
+	for body in bodies:
+		assert "`" not in body, (
+			"backtick inside an unquoted SSH heredoc: the runner will execute it "
+			"as a command substitution instead of sending it to the server.\n"
+			f"Offending block:\n{body[:400]}"
+		)
+
+
+def _logrotate_step() -> str:
+	"""The nginx-logrotate workflow step body."""
+	text = DEPLOY_WORKFLOW.read_text()
+	match = re.search(r"- name: Install nginx log rotation\n(.*?)\n      - name:", text, re.S)
+	assert match, "expected an 'Install nginx log rotation' step in deploy-dev.yml"
+	return match.group(1)
+
+
+# ── AC3: pm2-logrotate ─────────────────────────────────────────────────────
+
+
+def _pm2_logrotate_step() -> str:
+	text = DEPLOY_WORKFLOW.read_text()
+	match = re.search(r"- name: Configure PM2 log rotation\n(.*?)\n      - name:", text, re.S)
+	assert match, "expected a 'Configure PM2 log rotation' step in deploy-dev.yml"
+	return match.group(1)
+
+
+def test_deploy_installs_pm2_logrotate_module():
+	assert "pm2 install pm2-logrotate" in _pm2_logrotate_step(), (
+		"deploy must install the pm2-logrotate module (~/.pm2/logs is unrotated)"
+	)
+
+
+def test_deploy_configures_pm2_logrotate_retention():
+	step = _pm2_logrotate_step()
+	assert "pm2 set pm2-logrotate:max_size 10M" in step
+	assert "pm2 set pm2-logrotate:retain 7" in step
+	assert "pm2 set pm2-logrotate:compress true" in step
+	assert "pm2 set pm2-logrotate:rotateInterval '0 0 * * *'" in step
+
+
+def test_pm2_logrotate_configured_before_the_processes_start():
+	# It is a global pm2 module: configure it once, before the API/frontend/
+	# celery processes start writing logs under it.
+	text = DEPLOY_WORKFLOW.read_text()
+	configure = text.find("- name: Configure PM2 log rotation")
+	first_start = text.find("pm2 start uv")
+	assert configure != -1 and first_start != -1
+	assert configure < first_start, (
+		"pm2-logrotate must be configured before the first pm2 process starts"
+	)
+
+
+# ── AC4: documented policy ─────────────────────────────────────────────────
+
+
+def test_readme_documents_log_rotation_policy():
+	text = README.read_text()
+	assert "Log rotation" in text, "README must have a log rotation section"
+	assert "pm2-logrotate" in text, "README must document PM2 log rotation"
+	assert LOGROTATE_INSTALL_PATH in text, "README must document where the drop-in installs"
+
+
+def test_readme_documents_where_logs_live():
+	text = README.read_text()
+	assert "/opt/podcaststudiohub/logs" in text, "README must say where the nginx logs live"
+	assert "~/.pm2/logs" in text, "README must say where the PM2 logs live"
+
+
+def test_readme_states_retention_windows():
+	text = README.read_text()
+	rotation = text.find("## Log rotation")
+	assert rotation != -1
+	window = text[rotation : rotation + 3000]
+	assert "14" in window, "README must state the nginx retention window"
+	assert "7" in window and "10M" in window, "README must state the PM2 retention/size caps"

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -348,6 +348,10 @@ re-applying the exact inverse edit — never a whole-file checkout.
   Markdown-style comments (`` `pm2 install` ``) in a deploy heredoc *execute on the CI runner*
   and are stripped from what the server receives. Static tests never see it; render the heredoc
   through a stubbed `ssh` to catch it. All of deploy-dev.yml's SSH blocks are unquoted heredocs.
+  **The same trap bit again minutes later**, outside any deploy: `gh pr comment --body "...markdown
+  with backticked `paths`..."` command-substituted the path, which executed and vanished from the
+  posted comment. Any double-quoted shell arg carrying markdown must go through `--body-file` plus a
+  quoted `<<'EOF'` heredoc. The rule is about double-quoted shell context generally, not heredocs.
 - **A module-global async engine + pytest-asyncio's per-test event loop = pooled connections
   crossing loops.** `/ready` using `src.database.engine` passed alone but poisoned the *next*
   test with "got Future attached to a different loop", because the pool cached a connection

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -335,3 +335,31 @@ first compile); fresh CI venvs recompile. Clear __pycache__ to reproduce compile
 `git checkout <file>` to revert a test mutation also wipes any uncommitted edits in that file.
 When running mutation sanity checks, either commit pending work first or revert the mutation by
 re-applying the exact inverse edit — never a whole-file checkout.
+
+## 2026-07-14 (#320, PR #400) — observability
+
+- **`logrotate -d` exits 0 on an unknown option.** A typo (`rotat 14`) prints
+  `error: ... -- ignoring line` and returns **0**, so `set -e` cannot gate it and the
+  retention window silently vanishes. Verified against logrotate 3.21: exit 1 only when the
+  *log file is missing*, which masks the real signal. Must also grep output for `^error:`.
+  Same family as the `redis-cli exits 0 on ERR` lesson — **never trust a CLI's exit status
+  for config validation without checking what it prints.**
+- **Unquoted `<< EOF` heredocs command-substitute backticks — including inside `#` comments.**
+  Markdown-style comments (`` `pm2 install` ``) in a deploy heredoc *execute on the CI runner*
+  and are stripped from what the server receives. Static tests never see it; render the heredoc
+  through a stubbed `ssh` to catch it. All of deploy-dev.yml's SSH blocks are unquoted heredocs.
+- **A module-global async engine + pytest-asyncio's per-test event loop = pooled connections
+  crossing loops.** `/ready` using `src.database.engine` passed alone but poisoned the *next*
+  test with "got Future attached to a different loop", because the pool cached a connection
+  bound to a dead loop. Production is unaffected (uvicorn = one loop per process), so dispose
+  the engine between tests rather than weakening the probe. Same root cause as the documented
+  Celery `asyncio.run` pool trap.
+- **An unhandled 500 escapes `BaseHTTPMiddleware` entirely.** Starlette's `ServerErrorMiddleware`
+  sits *outside* user middleware, so a response-header-setting middleware never runs for a 500 —
+  the response users most need a correlation id on was the only one without one. `request.state`
+  (unlike a contextvar reset in `finally`) *does* survive into the 500 handler; stamp it there so
+  the exception still reaches Sentry instead of being swallowed by the middleware.
+- **opencode now stalls even on small diffs**: `zhipuai/glm-5-turbo` timed out at 10m on a full
+  diff and again at 7m20s on a 536-line one. `codex review --base <branch>` worked both times
+  and is the reliable fallback — but disclose which reviewer actually ran, since the repo rule
+  names opencode as primary.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,40 +1,107 @@
-# Issue #319 — [P5.3] DR/durability hardening (self-authored plan)
+# Issue #320 — [P5.4] Observability gaps (self-authored plan)
 
-Plan source: self-authored (no plan comment on issue; only a CodeRabbit stub).
+Plan source: self-authored (no plan comment on the issue).
+Verified against `main` @ `c0218b0`, 2026-07-14.
 
-## Already in the repo (verified, no work needed)
-- Nightly off-host `pg_dump` → S3 + retention: `deployment/scripts/backup-db.sh` + systemd timer (#293)
-- Tested Postgres restore runbook w/ RTO/RPO in `deployment/README.md` (RPO ≤ 24h, RTO ≈ minutes)
-- S3 versioning script `deployment/scripts/enable-s3-versioning.sh` + README "required" step
-- Stuck-job reaper `reap_stuck_episodes` (beat, every 300s, 45m threshold) — the "or add a stuck-job reaper" half of AC2 already exists
+## Verified current state (every claim in the issue re-checked against live code)
 
-## Open gaps → steps (TDD: step 1 first, RED)
+| Issue claim | Verdict | Evidence |
+|---|---|---|
+| No Sentry in API or worker | TRUE | no `sentry` in `apps/api/pyproject.toml:10-33`; absent from `main.py`/`worker.py` |
+| `/health` unconditional, no `/ready` | TRUE | `main.py:70-73` returns a static dict; no `/ready` route exists |
+| Deploy gate relies on `/health` | TRUE | `deploy-dev.yml:378` `wait_for "API" "$API_URL/health" "200"`; nginx pass-through at `podcastfy.conf:178-181` |
+| No correlation ID; tenant_id not on logs | TRUE | zero `ContextVar` in `src/`; `tenant_id` lives only on `request.state` (`tenant.py:53-54`) |
+| No log rotation | TRUE | zero `logrotate` hits repo-wide; `harden-host.sh:58` installs `pm2 startup` but never `pm2-logrotate` |
+| Logs freeform, not JSON | TRUE | `main.py:15-19` `basicConfig(format="%(asctime)s - %(name)s - ...")` |
 
-1. **Tests (RED)** — new `deployment/tests/test_dr_durability.py` (pattern: `test_db_backup.py`, static asserts):
-   - deploy-dev.yml server-side block runs `backup-db.sh` BEFORE `alembic upgrade head` (positional assert)
-   - workflow rsyncs `backup-db.sh` to the server
-   - `configure-redis-persistence.sh` exists, executable, `set -euo pipefail`, sets `appendonly yes` + `CONFIG REWRITE`
-   - README documents: Redis durability stance (AOF + reaper backstop + what a flush loses), S3 MFA-delete, S3 object restore runbook (`list-object-versions` / delete-marker removal)
+Three findings that **sharpen** the issue:
+- **nginx logs are worse than stated.** They go to a *custom* path `/opt/podcaststudiohub/logs/frontend-{access,error}.log`
+  (`podcastfy.conf:74-75`), which the distro's stock `/etc/logrotate.d/nginx` (globbing `/var/log/nginx/*.log`) does
+  **not** match. Nothing rotates them today.
+- **Redis PING needs no new dependency.** `redis>=5.0.0` (`pyproject.toml:23`) already ships `redis.asyncio`.
+  `sentry-sdk` is the only genuinely new dep.
+- **Celery has no signal hooks or Task base class** (confirmed: zero `celery.signals` usage), and the generation chain
+  uses **immutable `.si()` signatures** (`podcast_generation.py:930-935`, issue #211) — so propagation must go through
+  message **headers**, not kwargs.
 
-2. **Pre-migration dump gate** — `.github/workflows/deploy-dev.yml` Deploy API step:
-   - rsync `deployment/scripts/backup-db.sh` → `$SERVER_PATH/deployment/scripts/`
-   - in the `set -e` SSH block, before `uv run alembic upgrade head`: source `$SERVER_PATH/api/.env`, run `backup-db.sh` with `DB_BACKUP_S3_PREFIX=db-backups/pre-migration/` (script hard-fails w/o bucket/creds or on empty dump → deploy aborts before migration; prefix is self-pruned by the script's own retention)
-   - mirror the dump step in README manual-deploy Step 2
+## Steps (TDD: step 1 first, RED)
 
-3. **Redis durability (decision: enable AOF, keep reaper as backstop)** — new `deployment/scripts/configure-redis-persistence.sh`: idempotent, `CONFIG SET appendonly yes` + `appendfsync everysec` + `CONFIG REWRITE` + verify readback. README section: stance, what a flush loses (queued/in-flight jobs; ephemeral-by-design: rate-limit counters, OAuth state, idempotency locks), reaper marks stranded episodes failed after 45m (no auto-requeue; user retries).
+1. **Tests (RED)** — extend `apps/api/tests/test_health.py`; new `apps/api/tests/test_observability.py`;
+   new `deployment/tests/test_log_rotation.py` (static-read pattern per `test_dr_durability.py`):
+   - `/ready` → 200 + per-check body when DB+Redis are up
+   - `/ready` → **503** when DB raises, and (independently) when Redis PING raises
+   - `/health` stays 200 + static even when DB/Redis are down — the two probes must not collapse into one
+   - `/ready` is in `TenantContextMiddleware.PUBLIC_PATHS` (else it gets metered + tenant-resolved)
+   - `X-Request-ID` echoed on responses; minted when absent; **reused** when the client supplies one
+   - JSON formatter emits parseable JSON carrying `request_id` + `tenant_id`; `exc_info` → `exception` field
+   - Celery `before_task_publish` puts both ids on headers; `task_prerun` binds them into worker contextvars
+   - deploy workflow gates on `/ready`; installs pm2-logrotate; installs the nginx logrotate drop-in
 
-4. **S3 DR docs** — README: MFA-delete as optional hardening (root-MFA-only op, can't be scripted with app creds); S3 object restore runbook (recover deleted/overwritten object from versions) + S3 RTO/RPO statement.
+2. **JSON logging** — new `apps/api/src/logging_config.py`:
+   - `CORRELATION_ID` / `TENANT_ID` `ContextVar`s (single home; imported by middleware + Celery signals)
+   - `JsonFormatter(logging.Formatter)` — stdlib `json`, ~25 lines: ts/level/logger/msg/request_id/tenant_id/exception
+   - `setup_logging()` — configures the root handler **and** replaces the formatter on `uvicorn.access`/`uvicorn.error`
+     handlers, since uvicorn installs its own log config that root config alone won't reach
+   - `LOG_FORMAT: str = "json"` in `config.py` (`"text"` escape hatch for local dev)
+   - Called from `main.py` (replacing `basicConfig`) **and** from Celery's `setup_logging` signal (which suppresses
+     Celery's own config) → one formatter, both processes = AC5
 
-5. **Gates** — `python -m pytest deployment/tests/`, ruff, demo evidence per AC, PR, reviews, merge.
+3. **Correlation ID + tenant binding** — new `apps/api/src/middleware/correlation.py`:
+   - `CorrelationIdMiddleware`: read `X-Request-ID` or mint `uuid4`; set contextvar; echo header on the response
+   - Registered **last** in `main.py` so it is outermost (Starlette `add_middleware` is LIFO) → wraps CORS + tenant
+   - `TenantContextMiddleware` additionally sets the `TENANT_ID` contextvar beside its existing `request.state` write
+     (purely additive; `request.state` stays the RLS source of truth)
+   - `worker.py`: `before_task_publish` → inject both ids into headers; `task_prerun` → bind into worker contextvars;
+     `task_postrun` → reset. Ids flow API → chain with **no task signature changes** (keeps the `.si()` invariant, #211)
+
+4. **Sentry** — `uv add sentry-sdk`; `init_sentry()` in `logging_config.py`, called from `main.py` + `worker.py`:
+   - gated on `SENTRY_DSN: Optional[str] = None` → **None is a no-op**, so dev/CI/tests stay offline
+     (matches the repo's `Optional[str] = None` convention, e.g. `config.py:79-80`)
+   - `environment=settings.ENVIRONMENT`, `traces_sample_rate=0.0` (errors only, no APM bill)
+   - **ponytail:** rely on sentry-sdk's auto-enabling FastAPI/Celery/logging integrations; no manual wiring
+   - `send_default_pii=False` + a `before_send` scrub — multi-tenant app; don't ship user data to a third party
+   - add `SENTRY_DSN` to `.env.example`
+
+5. **`/ready` probe** — `main.py`: `SELECT 1` via `from src.database import engine` (`engine.connect()`,
+   `pool_pre_ping=True`); Redis via `redis.asyncio.from_url(settings.REDIS_URL).ping()`. Both under an
+   `asyncio.wait_for` (~2s) so a hung dependency can't hang the probe. 503 + per-check detail on failure.
+   Add `/ready` to `PUBLIC_PATHS`.
+
+6. **Point the gates at `/ready`** — `deploy-dev.yml:378` → `$API_URL/ready`; nginx `location /ready` mirroring
+   `/health` (`podcastfy.conf:178-181`, `access_log off`). `/health` stays the liveness probe.
+
+7. **Log rotation** — workflow: `pm2 install pm2-logrotate` + `pm2 set` (10M, retain 7, compress, daily) — idempotent,
+   per the CI/CD-idempotent-only rule. New `deployment/logrotate/podcaststudiohub-nginx` for
+   `/opt/podcaststudiohub/logs/*.log` (daily, rotate 14, compress, delaycompress, notifempty, missingok,
+   `postrotate` nginx reopen) + rsync/install step.
+
+8. **Gates** — `uv run pytest tests/` (from `apps/api`), `python -m pytest deployment/tests/`, ruff, coverage ≥85,
+   deslop, opencode/GLM review pre-PR, demo per AC, PR, post-PR review, CI, docs sync, merge.
 
 ## Acceptance criteria checklist
-- [ ] Off-host pg_dump before migrate, gating the deploy (step 2)
-- [ ] Redis durability decided + documented: AOF enabled via script + reaper documented as backstop (step 3)
-- [ ] S3 versioning enabled (script + README already exist; MFA-delete documented — step 4)
-- [ ] Postgres+S3 restore runbook with RTO/RPO, tested (Postgres exists; add S3 — step 4; tests — step 1)
+- [ ] AC1 Sentry in API + worker (step 4)
+- [ ] AC2 `/ready` doing SELECT 1 + Redis PING, deploy/uptime gate pointed at it (steps 5, 6)
+- [ ] AC3 Correlation ID propagated into Celery, bound to logs with tenant_id (steps 2, 3)
+- [ ] AC4 pm2-logrotate + logrotate for nginx (step 7)
+- [ ] AC5 JSON formatter shared by uvicorn and Celery (step 2)
 
-## Autonomous decisions (no fork)
-- Reuse `backup-db.sh` for the pre-migration dump instead of a new script (same contract, self-pruning prefix).
-- AOF `everysec` (≤1s broker loss) over RDB-only; reaper stays as the stranded-episode backstop.
-- `.env` is sourced in the deploy shell — values must stay shell-sourceable (they are today; noted in README).
-- MFA-delete documented, not scripted (requires root-account MFA; app IAM user cannot toggle it).
+## Autonomous decisions (no architectural fork)
+- **`/health` stays static (liveness); `/ready` does the checks (readiness).** The standard split. Collapsing them would
+  make a brownout restart-loop the API instead of merely draining it from the gate. The issue asks for `/ready` and is
+  silent on changing `/health`, so `/health` keeps its contract and its existing tests (and its 8 other callers:
+  playwright, rm-review, e2e global-setup, webServer readiness).
+- **Hand-rolled JSON formatter + correlation middleware** over `python-json-logger` / `asgi-correlation-id`: ~25 and
+  ~40 lines of stdlib versus two new supply-chain deps in a repo with live CVE gates (#306). `sentry-sdk` is the only
+  new dep, and it has no stdlib substitute.
+- **Celery headers over task kwargs** for propagation: kwargs would touch every `.si()`/`.s()` call site and break the
+  immutable-signature invariant (#211).
+- **Sentry defaults to off** (`SENTRY_DSN=None`) — tests/CI/local stay offline with no opt-out ceremony.
+- **`traces_sample_rate=0.0`** — the issue asks for error tracking, not APM. YAGNI.
+
+## Risks / notes
+- `filterwarnings = error` is live (#348) — the sentry-sdk import must not emit warnings under pytest.
+- `meter_api_call` opens a DB session even on public paths (`dependencies.py:38-40`), so `/ready` touches the DB via the
+  app-level dependency regardless; the explicit `SELECT 1` is still what makes the check meaningful and 503-able.
+- Coverage gates are real (85% backend, #345) — new modules need real tests, not smoke.
+- Tasks are tested by direct `.run()` with a faked request (`test_celery_workflow.py:38-46`), not eager mode — signal
+  tests must drive the signals directly rather than relying on `task_always_eager`.


### PR DESCRIPTION
Closes #320.

Baseline observability for a multi-tenant SaaS: error tracking, a real readiness probe, request correlation across the API→Celery boundary, structured logs, and log rotation.

## Why each piece

| AC | Before | After |
| --- | --- | --- |
| 1 | Exceptions died in PM2 stdout | Sentry in API **and** worker, PII off + body/cred scrub |
| 2 | `/health` returned 200 unconditionally; the deploy gate trusted it | `/ready` does `SELECT 1` + Redis `PING` → 503; **the deploy gate now waits on `/ready`** |
| 3 | No correlation id; `tenant_id` never on a log record | `X-Request-ID` minted/echoed, propagated into Celery, bound to every log line with `tenant_id` |
| 4 | Nothing rotated; unbounded growth | pm2-logrotate + an nginx logrotate drop-in |
| 5 | Freeform strings | JSON formatter shared by uvicorn and Celery |

## Notable decisions

- **`/health` stays static (liveness); `/ready` does the checks (readiness).** Collapsing them would make a Redis blip *restart-loop* uvicorn instead of merely draining it from the gate. `/health` keeps its contract and its 8 existing callers (playwright, rm-review, e2e global-setup, webServer readiness).
- **Celery propagation rides message headers, not task kwargs.** Kwargs would touch every dispatch site and add a parameter to every task signature — and the generation chain uses immutable `.si()` signatures precisely so nothing extra is threaded positionally (#211). Headers are invisible to task code and survive chains, links and retries.
- **`sentry-sdk` is the only new dependency.** `redis>=5` already ships `redis.asyncio`, and the JSON formatter (~40 lines of stdlib) and correlation middleware (~40 lines) replace `python-json-logger` / `asgi-correlation-id` — this repo has live CVE gates (#306).
- **Sentry defaults to off** (`SENTRY_DSN` unset ⇒ `init_sentry()` no-ops), so tests/CI/local stay offline with no opt-out ceremony.

## Two real gaps this surfaced

- **nginx logs were worse than the issue stated.** They go to a *custom* path `/opt/podcaststudiohub/logs/frontend-{access,error}.log`, which the distro's stock `/etc/logrotate.d/nginx` does **not** match (it only globs `/var/log/nginx/*.log`). They were rotated by nothing at all.
- **`logrotate -d` exits 0 on an unknown option** (verified against logrotate 3.21): a typo like `rotat 14` prints `error: ... -- ignoring line` and returns **0**, so `set -e` alone is not a gate. The deploy greps for `^error:` too. Same class as the documented `redis-cli exits 0 on ERR` trap.

## Verification

- **1854 backend tests pass** (+30 new), **90 deployment tests pass** (+31 new), ruff clean, pre-commit clean. New modules: `logging_config.py` 96.8%, `correlation.py` 100% (gate: 85%).
- **Mutation-checked**: breaking `/ready`'s status logic and the formatter's id binding each failed exactly the tests meant to catch them.
- **Correlation proven across a real process boundary**: a real Celery worker over real Redis received `request_id=req-from-api-42 tenant_id=tenant-abc` published from a simulated request context — no task signature touched.
- **Rotation proven against a real logrotate binary**: the actual drop-in rotated both files; `notifempty` correctly skipped the empty logs on re-run.
- Pre-PR review: `codex review` (opencode/GLM stalled — see Known limitations). It found 2 real bugs, both verified before fixing and pinned with regression tests:
  1. An unhandled 500 carried **no** `X-Request-ID` — it propagates past `CorrelationIdMiddleware` to Starlette's `ServerErrorMiddleware`. That is the one response a user most needs an id for. Now re-stamped in the 500 handler.
  2. `X-Request-ID` was in neither `CORS_ALLOW_HEADERS` nor `expose_headers`, so a cross-origin browser could not send its own id (preflight rejected it) nor read the echoed one.

## Known limitations

- **Sentry is inert until an operator sets `SENTRY_DSN`** in `/opt/podcaststudiohub/api/.env` on each host — the deploy does not set it. Documented in `deployment/README.md`.
- **The nginx-logrotate install step needs NOPASSWD sudo** for `install` and `logrotate` on the deploy account. It uses `sudo -n`, so a host without it fails that step loudly rather than hanging on a password prompt. **Worth confirming against staging before merge.**
- The first deploy after this merge installs the `pm2-logrotate` module (idempotent thereafter).
- `traces_sample_rate=0.0`: error tracking only, no APM. Raise deliberately.
- The `/ready` DB check uses the app's real pooled engine on purpose (it proves the pool the app serves from is usable). Under pool exhaustion the probe competes with real traffic — arguably correct (exhaustion *is* unreadiness), but worth watching if `/ready` polling ever gets aggressive.
