### PR TITLE
fix(#320): provision Redis in the deploy workflow's test job (unblocks dev deploy on main)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -47,6 +47,20 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      # This job runs the API suite too, so it needs the same broker test.yml
+      # provisions: the env below already points CELERY_BROKER_URL at
+      # redis://localhost:6379 while nothing listened there, and /ready PINGs
+      # Redis for real (issue #320).
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -87,6 +101,9 @@ jobs:
           JWT_SECRET_KEY: test-jwt-secret-for-ci-0000000000
           CELERY_BROKER_URL: redis://localhost:6379/0
           CELERY_RESULT_BACKEND: redis://localhost:6379/0
+          # Explicit rather than relying on the settings default, so the /ready
+          # probe's PING target is visible next to the service that serves it.
+          REDIS_URL: redis://localhost:6379/0
         run: |
           uv run pytest tests/ \
             --cov=src \


### PR DESCRIPTION
## What broke

The first `main` deploy after #400 ([run 29394434131](https://github.com/frankbria/podcaststudiohub/actions/runs/29394434131)) **failed at `Run API tests`**, so it never reached the new log-rotation or `/ready` steps.

`deploy-dev.yml` runs its own copy of the API suite with its **own** `services:` block. #400 added a `redis:7` service to `test.yml` but missed this one, so the two readiness tests that need a live Redis failed exactly as they had in CI before that fix:

- `test_ready_endpoint_reports_dependency_checks`
- `test_ready_returns_503_when_database_is_down`

## Fix

Same as #400's: add the `redis:7` service + explicit `REDIS_URL`. The job **already** pointed `CELERY_BROKER_URL`/`CELERY_RESULT_BACKEND` at `redis://localhost:6379` with nothing listening there — so this makes the config honest rather than adding a new dependency.

## Audit — is anywhere else affected?

Checked every workflow that runs pytest, to fix this once rather than one workflow at a time:

| workflow | runs API suite | redis service | status |
| --- | --- | --- | --- |
| `test.yml` | yes | yes | fixed in #400 |
| `deploy-dev.yml` | yes | **was missing** | **fixed here** |
| `rm-review.yml` | yes | yes | already fine |
| `rm-loop.yml` | no — its `pytest` is prompt text for an agent, not a step | n/a | n/a |

`deploy-dev.yml` was the only real gap.

## My miss

#400's own PR body flagged that the log-rotation step needed confirming against staging — but the deploy never got that far, because I fixed the Redis gap in one of the two workflows that run the suite and didn't check for a second. The rotation/`/ready` steps on a real host remain **unverified** until this merges and the deploy proceeds.