### PR TITLE
fix(#320): stage logrotate drop-in in HOME, not $SERVER_PATH (unblocks dev deploy)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -187,19 +187,28 @@ jobs:
           # /etc/logrotate.d/nginx does NOT cover: it only globs
           # /var/log/nginx/*.log. Without this drop-in those files are never
           # rotated and eventually fill the VPS disk (issue #320).
-          # mkdir -p first: rsync does not create intermediate remote dirs.
-          ssh -i ~/.ssh/deploy_key $SSH_USER@$SSH_HOST \
-            "mkdir -p $SERVER_PATH/deployment/logrotate"
+          # Stage in the deploy user's HOME, not under $SERVER_PATH:
+          # /opt/podcaststudiohub/deployment is not writable by the deploy
+          # account, so creating a new subdir there fails with EACCES (the
+          # sibling `mkdir -p .../deployment/scripts` only works because that
+          # directory already exists — mkdir -p on an existing path is a no-op
+          # and never needs write permission on the parent).
+          # HOME rather than /tmp on purpose: this file is about to be installed
+          # into /etc/logrotate.d and run by root, and world-writable /tmp would
+          # let a local user pre-place a symlink there and have root copy in
+          # content of their choosing. The drop-in's real home is
+          # /etc/logrotate.d, so nothing needs to persist under $SERVER_PATH.
           rsync -avz -e "ssh -i ~/.ssh/deploy_key" \
             deployment/logrotate/podcaststudiohub-nginx \
-            $SSH_USER@$SSH_HOST:$SERVER_PATH/deployment/logrotate/
+            $SSH_USER@$SSH_HOST:podcaststudiohub-nginx.logrotate
 
           # NOTE: no backticks anywhere below — this is an unquoted heredoc, so
           # the runner's shell command-substitutes backticks (even inside #
           # comments) before the text is ever sent to the server.
           ssh -i ~/.ssh/deploy_key $SSH_USER@$SSH_HOST << EOF
             set -e
-            SRC="$SERVER_PATH/deployment/logrotate/podcaststudiohub-nginx"
+            # Matches the rsync target above: staged in HOME, not $SERVER_PATH.
+            SRC="\$HOME/podcaststudiohub-nginx.logrotate"
             DEST="/etc/logrotate.d/podcaststudiohub-nginx"
 
             # Privileged ops: the deploy account is the non-root service user
@@ -240,6 +249,10 @@ jobs:
             \$SUDO install -m 0644 -o root -g root \
               "\$SRC" \
               "\$DEST"
+
+            # The installed copy under /etc/logrotate.d is the live one; drop
+            # the staging copy so it can't drift or be mistaken for source.
+            rm -f "\$SRC"
 
             echo "nginx log rotation installed at \$DEST"
           EOF

--- a/deployment/tests/test_log_rotation.py
+++ b/deployment/tests/test_log_rotation.py
@@ -284,6 +284,62 @@ def _logrotate_step() -> str:
 	return match.group(1)
 
 
+def _logrotate_commands() -> str:
+	"""The nginx-logrotate step with comment lines stripped.
+
+	Assert forbidden commands against THIS, not the raw step: the step's comments
+	deliberately name the traps it avoids (mkdir, /tmp), and matching prose
+	instead of the actual invocation is its own documented trap.
+	"""
+	return "\n".join(
+		line for line in _logrotate_step().splitlines()
+		if not line.lstrip().startswith("#")
+	)
+
+
+def test_logrotate_step_does_not_create_dirs_under_server_path():
+	"""Regression: the deploy account cannot write inside $SERVER_PATH.
+
+	The first real deploy of this step died on
+	`mkdir: cannot create directory '/opt/podcaststudiohub/deployment/logrotate':
+	Permission denied`. The sibling `mkdir -p $SERVER_PATH/deployment/scripts`
+	is not a counter-example: mkdir -p on an ALREADY-EXISTING path is a no-op
+	and never needs write permission on the parent. Stage in HOME instead — the
+	drop-in's real home is /etc/logrotate.d, so nothing needs to live under
+	$SERVER_PATH at all.
+	"""
+	step = _logrotate_commands()
+	assert "mkdir" not in step, (
+		"do not mkdir under $SERVER_PATH — the deploy account cannot write there; "
+		"stage the drop-in in the deploy user's HOME"
+	)
+	assert "SERVER_PATH/deployment/logrotate" not in step, (
+		"do not stage the drop-in under $SERVER_PATH (not writable by the deploy user)"
+	)
+
+
+def test_logrotate_step_does_not_stage_in_world_writable_tmp():
+	"""This file is installed to /etc/logrotate.d and run by root.
+
+	Staging it in world-writable /tmp would let a local user pre-place a symlink
+	there and have root copy in content of their choosing. HOME is owned by the
+	deploy account, so it has no such race.
+	"""
+	step = _logrotate_commands()
+	assert "/tmp/" not in step, "stage the drop-in in HOME, not world-writable /tmp"
+	assert "$HOME/" in step or "\\$HOME/" in step, (
+		"the drop-in should be staged under the deploy user's HOME"
+	)
+
+
+def test_logrotate_step_removes_its_staging_copy():
+	"""The installed /etc/logrotate.d copy is the live one; staging must not linger."""
+	step = _logrotate_commands()
+	assert re.search(r"rm -f\s+\"?\\?\$SRC", step), (
+		"remove the staged copy after install so it cannot drift from the live file"
+	)
+
+
 # ── AC3: pm2-logrotate ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What broke

With #401 in, the deploy got past the tests and **`Configure PM2 log rotation` succeeded on the real host** — then `Install nginx log rotation` failed ([run 29395676602](https://github.com/frankbria/podcaststudiohub/actions/runs/29395676602)):

```
mkdir: cannot create directory '/opt/podcaststudiohub/deployment/logrotate': Permission denied
```

## Why the existing pattern didn't warn us

#319 does `mkdir -p $SERVER_PATH/deployment/scripts` in the Deploy API step and works fine — which is exactly why this looked safe. It isn't a counter-example:

> **`mkdir -p` on an already-existing path is a no-op and never needs write permission on the parent.**

`deployment/scripts` already exists, so that call short-circuits. Creating a *new* subdirectory needs write permission on `/opt/podcaststudiohub/deployment/`, which the deploy account does not have.

## Fix

Stage the drop-in in the deploy user's **HOME** and remove it after install. The drop-in's real home is `/etc/logrotate.d`, so nothing needs to persist under `$SERVER_PATH` at all — this deletes the failing `mkdir` rather than working around it.

**HOME rather than `/tmp`, deliberately.** This file is installed into `/etc/logrotate.d` and executed by root; staging it in world-writable `/tmp` would let a local user pre-place a symlink there and have root copy in content of their choosing. HOME is owned by the deploy account.

## Tests

3 regression tests (93 deployment tests pass):
- the step creates no directories under `$SERVER_PATH`
- it does not stage in world-writable `/tmp`
- it removes its staging copy after install

Asserted against a **comment-stripped** view of the step — my first cut failed because the step's own comments name the traps it avoids (`mkdir`, `/tmp`), and matching prose rather than the actual invocation is the trap `test_dr_durability.py` already documents.

## Honest status

`Configure PM2 log rotation` is now **verified on the real host**. The nginx half and the `/ready` deploy gate are still **unverified in production** — they're downstream of this step. This is the third fix in the #320 chain; each one was only findable by letting the real deploy run.
