### PR TITLE
fix(provision): install AWS CLI v2 in harden-host.sh so S3 backups work

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -615,7 +615,10 @@ logical dumps are the deliberate, lazy-correct choice for a single-VPS dev host.
 
 - `deployment/scripts/backup-db.sh` — `pg_dump -Fc` → timestamped object
   at `s3://$DB_BACKUP_S3_BUCKET/$DB_BACKUP_S3_PREFIX`, then prunes objects older
-  than `DB_BACKUP_RETENTION_DAYS` (default 14). Dumps connect as
+  than `DB_BACKUP_RETENTION_DAYS` (default 14). Uploads via the **AWS CLI v2**,
+  which `harden-host.sh` installs to `/usr/local/bin` (on the service account's
+  PATH) — without it the pre-migration dump fails `aws: command not found` and
+  aborts the deploy. Dumps connect as
   `MIGRATION_DATABASE_URL` (the BYPASSRLS role) when set — tenant tables are
   FORCE RLS, so a dump as the app role would error or omit every tenant row —
   falling back to `DATABASE_URL` for single-role setups.

--- a/deployment/scripts/harden-host.sh
+++ b/deployment/scripts/harden-host.sh
@@ -116,8 +116,14 @@ if ! aws --version 2>&1 | grep -q 'aws-cli/2'; then
 	curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" \
 		-o "$_aws_tmp/awscliv2.zip"
 	unzip -q -o "$_aws_tmp/awscliv2.zip" -d "$_aws_tmp"
-	# --update makes a partial/older install idempotent; plain install otherwise.
-	"$_aws_tmp/aws/install" $([ -e /usr/local/aws-cli ] && echo --update)
+	# The installer REFUSES to overwrite an existing /usr/local/bin/aws (a prior
+	# v2, or a v1 that landed there) unless --update is passed; without it set -e
+	# would abort. Pass --update whenever either the v2 install dir OR the bin
+	# symlink already exists. (An `if` — not `&& _x=...` — so a both-absent host
+	# doesn't trip set -e on the failed test.)
+	_aws_update=""
+	if [ -e /usr/local/aws-cli ] || [ -e /usr/local/bin/aws ]; then _aws_update="--update"; fi
+	"$_aws_tmp/aws/install" $_aws_update
 	rm -rf "$_aws_tmp"
 fi
 echo "AWS CLI: $(aws --version 2>&1)"

--- a/deployment/scripts/harden-host.sh
+++ b/deployment/scripts/harden-host.sh
@@ -106,7 +106,11 @@ ufw status verbose
 # NOT what we require. This branch fires when aws is absent OR is v1.
 if ! aws --version 2>&1 | grep -q 'aws-cli/2'; then
 	echo "Installing AWS CLI v2..."
-	command -v unzip >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq unzip; }
+	# curl (download) and unzip (extract) may both be absent on a minimal VPS
+	# image; ensure them before use or `set -e` would abort mid-provision.
+	if ! command -v curl >/dev/null 2>&1 || ! command -v unzip >/dev/null 2>&1; then
+		apt-get update -qq && apt-get install -y -qq curl unzip
+	fi
 	_aws_tmp="$(mktemp -d)"
 	# uname -m is x86_64 or aarch64 — AWS ships an exe bundle for each.
 	curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" \

--- a/deployment/scripts/harden-host.sh
+++ b/deployment/scripts/harden-host.sh
@@ -10,7 +10,11 @@
 # Idempotent: safe to re-run. Run once as root on the VPS:
 #
 #   ssh root@<server>
-#   cd /opt/podcaststudiohub && bash deployment/scripts/harden-host.sh
+#   sudo git clone https://github.com/frankbria/podcaststudiohub /root/podcaststudiohub
+#   cd /root/podcaststudiohub && bash deployment/scripts/harden-host.sh
+#
+# Runs from the root-owned provisioning clone, never the deploy-account tree
+# (deployment/README.md → "How the box gets deployment assets").
 #
 # After running, point the GitHub `SERVER_USER` deploy secret at $SERVICE_USER
 # and re-run the deploy workflow so PM2 processes start under the new account.
@@ -88,6 +92,27 @@ ufw default allow outgoing
 # Non-interactive enable (no-op if already active).
 ufw --force enable
 ufw status verbose
+
+# ── 5. AWS CLI v2 (S3 backups — issue #319) ────────────────────────────────
+# backup-db.sh (the pre-migration dump gating every deploy, and the nightly
+# timer) pushes to S3 with the AWS CLI. It runs as $SERVICE_USER, so `aws` must
+# be on that account's PATH — installing to /usr/local/bin covers it. The distro
+# ships only AWS CLI v1, so pull v2 from AWS's official bundle. Without this the
+# deploy dies with "aws: command not found" the moment S3 backups are configured
+# (found the hard way on the dev host: rsync-permission masked it until fixed).
+if ! command -v aws >/dev/null 2>&1; then
+	echo "Installing AWS CLI v2..."
+	command -v unzip >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq unzip; }
+	_aws_tmp="$(mktemp -d)"
+	# uname -m is x86_64 or aarch64 — AWS ships an exe bundle for each.
+	curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" \
+		-o "$_aws_tmp/awscliv2.zip"
+	unzip -q -o "$_aws_tmp/awscliv2.zip" -d "$_aws_tmp"
+	# --update makes a partial/older install idempotent; plain install otherwise.
+	"$_aws_tmp/aws/install" $([ -e /usr/local/aws-cli ] && echo --update)
+	rm -rf "$_aws_tmp"
+fi
+echo "AWS CLI: $(aws --version 2>&1)"
 
 echo
 echo "Host hardening complete."

--- a/deployment/scripts/harden-host.sh
+++ b/deployment/scripts/harden-host.sh
@@ -100,7 +100,11 @@ ufw status verbose
 # ships only AWS CLI v1, so pull v2 from AWS's official bundle. Without this the
 # deploy dies with "aws: command not found" the moment S3 backups are configured
 # (found the hard way on the dev host: rsync-permission masked it until fixed).
-if ! command -v aws >/dev/null 2>&1; then
+#
+# Gate on aws-cli/2 specifically, not just `command -v aws`: a box with the
+# distro's v1 package would otherwise skip the installer and keep v1, which is
+# NOT what we require. This branch fires when aws is absent OR is v1.
+if ! aws --version 2>&1 | grep -q 'aws-cli/2'; then
 	echo "Installing AWS CLI v2..."
 	command -v unzip >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq unzip; }
 	_aws_tmp="$(mktemp -d)"

--- a/deployment/tests/test_deploy_hardening.py
+++ b/deployment/tests/test_deploy_hardening.py
@@ -104,8 +104,15 @@ def test_harden_script_installs_aws_cli():
 		"harden-host.sh must install AWS CLI v2 from AWS's official bundle "
 		"(backup-db.sh needs `aws` on the service account's PATH)"
 	)
-	# guarded so a re-run doesn't reinstall on every provisioning pass
-	assert re.search(r"command -v aws\b", text), "AWS CLI install must be idempotent"
+	# Idempotent AND version-correct: the guard must check for aws-cli/2 on the
+	# guard line itself, not just any `aws` — a distro v1 would otherwise satisfy a
+	# presence-only check and the v2 requirement would silently go unmet (codex,
+	# PR #405). Match the actual `aws --version … aws-cli/2` guard, not comment
+	# prose that merely mentions the version.
+	assert re.search(r"aws --version[^\n]*aws-cli/2", text), (
+		"AWS CLI install must gate on `aws --version … aws-cli/2`, so v1-only boxes "
+		"still get upgraded (a bare `command -v aws` would skip them)"
+	)
 
 
 # ── AC1: docs no longer assume a root deploy ───────────────────────────────

--- a/deployment/tests/test_deploy_hardening.py
+++ b/deployment/tests/test_deploy_hardening.py
@@ -94,6 +94,20 @@ def test_harden_script_installs_pm2_startup_for_service_user():
 	assert m, "pm2 startup must target the dedicated service account, not root"
 
 
+def test_harden_script_installs_aws_cli():
+	"""backup-db.sh pushes to S3 via the AWS CLI and runs as the service account,
+	so provisioning must install `aws` — otherwise the pre-migration dump (which
+	gates every deploy) dies with 'aws: command not found' once S3 is configured.
+	The distro only ships v1, so it must come from AWS's official installer."""
+	text = HARDEN_SCRIPT.read_text()
+	assert "awscli-exe-linux" in text, (
+		"harden-host.sh must install AWS CLI v2 from AWS's official bundle "
+		"(backup-db.sh needs `aws` on the service account's PATH)"
+	)
+	# guarded so a re-run doesn't reinstall on every provisioning pass
+	assert re.search(r"command -v aws\b", text), "AWS CLI install must be idempotent"
+
+
 # ── AC1: docs no longer assume a root deploy ───────────────────────────────
 
 

--- a/deployment/tests/test_deploy_hardening.py
+++ b/deployment/tests/test_deploy_hardening.py
@@ -113,6 +113,11 @@ def test_harden_script_installs_aws_cli():
 		"AWS CLI install must gate on `aws --version … aws-cli/2`, so v1-only boxes "
 		"still get upgraded (a bare `command -v aws` would skip them)"
 	)
+	# curl + unzip are used by the install and may be absent on a minimal image;
+	# provisioning must ensure them or `set -e` aborts mid-run (codex, PR #405).
+	assert "curl unzip" in text or ("install -y" in text and "curl" in text and "unzip" in text), (
+		"harden-host.sh must ensure curl and unzip before the AWS CLI download"
+	)
 
 
 # ── AC1: docs no longer assume a root deploy ───────────────────────────────


### PR DESCRIPTION
## What this fixes

The post-#404 deploy got **past** the rsync (the ownership fix worked) and then died one step later:

```
/opt/podcaststudiohub/deployment/scripts/backup-db.sh: line 69: aws: command not found  (exit 127)
```

The pre-migration S3 dump (#319) — which gates every deploy — uploads via the AWS CLI, but **nothing ever installed it**. It stayed hidden behind the earlier rsync-permission failure; once that was fixed, this surfaced. S3 backups **are** configured (`AWS_S3_BUCKET`, `AWS_REGION`, creds in `.env`), so the correct fix is to install the CLI, not to skip the dump. The dump fails *before* any service teardown, so the live app was never at risk.

## Change

- **`harden-host.sh`**: new idempotent, arch-aware section (§5) installing **AWS CLI v2** from AWS's official bundle to `/usr/local/bin` (on the `$SERVICE_USER` PATH). Guarded by `command -v aws` so re-provisioning is a no-op. Header updated to the root-owned-clone model from #404.
- **test**: `test_harden_script_installs_aws_cli` (mutation-verified).
- **README**: note the backup path depends on the CLI `harden-host.sh` provides.

## Already applied on the box + verified

Per the "install now + add to provisioning" decision, I installed it on the dev host directly (this PR makes it reproducible):
- `aws-cli/2.36.1` on `/usr/local/bin`, visible to the `podcastfy` deploy user.
- Verified `podcastfy` can reach `s3://podcaststudiohub-audio` with the configured creds (`aws s3 ls db-backups/` → exit 0).

## Validation
- 93 deployment tests pass; `harden-host.sh` passes `bash -n`.
- On merge, the triggered deploy should finally clear the pre-migration dump — I'll watch it.
