### PR TITLE
fix(#321): offload blocking boto3 calls in async paths to thread

### DIFF
--- a/apps/api/src/routers/episodes.py
+++ b/apps/api/src/routers/episodes.py
@@ -6,6 +6,7 @@ status filtering, and generation management. All endpoints require authenticatio
 and automatically enforce tenant isolation via RLS.
 """
 
+import asyncio
 import os
 from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException, status, Query, Header
@@ -406,7 +407,10 @@ async def download_episode_audio(
 
 	if has_s3:
 		storage = StorageService()
-		head_response = storage.s3_client.head_object(
+		# boto3 is synchronous; run it off the event loop so concurrent
+		# requests are not blocked during the head (#321).
+		head_response = await asyncio.to_thread(
+			storage.s3_client.head_object,
 			Bucket=storage.bucket_name,
 			Key=episode.s3_key
 		)
@@ -432,14 +436,18 @@ async def download_episode_audio(
 		extra_headers["Content-Range"] = f"bytes {start_byte}-{end_byte}/{total_size}"
 
 	if has_s3:
+		# boto3 is synchronous; run it off the event loop so concurrent
+		# requests are not blocked during the object fetch (#321).
 		if range:
-			s3_response = storage.s3_client.get_object(
+			s3_response = await asyncio.to_thread(
+				storage.s3_client.get_object,
 				Bucket=storage.bucket_name,
 				Key=episode.s3_key,
 				Range=f"bytes={start_byte}-{end_byte}"
 			)
 		else:
-			s3_response = storage.s3_client.get_object(
+			s3_response = await asyncio.to_thread(
+				storage.s3_client.get_object,
 				Bucket=storage.bucket_name,
 				Key=episode.s3_key
 			)

--- a/apps/api/src/services/storage_service.py
+++ b/apps/api/src/services/storage_service.py
@@ -137,7 +137,10 @@ class StorageService:
             s3_key: S3 object key
         """
         try:
-            self.s3_client.delete_object(
+            # boto3 is synchronous; run it off the event loop so concurrent
+            # requests/tasks are not blocked during the delete (#321).
+            await asyncio.to_thread(
+                self.s3_client.delete_object,
                 Bucket=self.bucket_name,
                 Key=s3_key,
             )
@@ -185,7 +188,10 @@ class StorageService:
             True if file exists, False otherwise
         """
         try:
-            self.s3_client.head_object(
+            # boto3 is synchronous; run it off the event loop so concurrent
+            # requests/tasks are not blocked during the existence check (#321).
+            await asyncio.to_thread(
+                self.s3_client.head_object,
                 Bucket=self.bucket_name,
                 Key=s3_key,
             )

--- a/apps/api/tests/test_download_endpoint.py
+++ b/apps/api/tests/test_download_endpoint.py
@@ -377,3 +377,30 @@ async def test_download_invalid_range_returns_416(client, episode_and_auth):
 		)
 
 	assert response.status_code == 416
+
+
+# ============================================================================
+# Event-loop offload (issue #321)
+# ============================================================================
+
+async def _run_inline(func, /, *args, **kwargs):
+	"""Stand-in for asyncio.to_thread that runs the callable inline (#321)."""
+	return func(*args, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_download_s3_calls_offloaded_to_thread(client, episode_and_auth):
+	"""head_object/get_object are network-bound; both must go through
+	asyncio.to_thread so the download handler cannot pin the event loop (#321)."""
+	episode_id, headers = episode_and_auth
+	fake_audio = b"FAKE_MP3_CONTENT_" * 10
+
+	with patch("src.routers.episodes.StorageService") as MockStorage:
+		mock_instance = _mock_s3_storage(len(fake_audio), fake_audio, MockStorage)
+		with patch("asyncio.to_thread", side_effect=_run_inline) as mock_tt:
+			response = await client.get(f"/episodes/{episode_id}/download", headers=headers)
+
+	assert response.status_code == 200
+	offloaded = {await_call.args[0] for await_call in mock_tt.await_args_list}
+	assert mock_instance.s3_client.head_object in offloaded
+	assert mock_instance.s3_client.get_object in offloaded

--- a/apps/api/tests/unit/test_storage_service.py
+++ b/apps/api/tests/unit/test_storage_service.py
@@ -26,6 +26,16 @@ def _make_client_error(code="NoSuchKey"):
 	return ClientError({"Error": {"Code": code, "Message": "Test error"}}, "test_op")
 
 
+async def _run_inline(func, /, *args, **kwargs):
+	"""Stand-in for asyncio.to_thread that runs the callable inline.
+
+	Patching asyncio.to_thread with this lets tests assert a boto3 call was
+	offloaded to a thread (and inspect the call) without a real thread
+	handoff (#321).
+	"""
+	return func(*args, **kwargs)
+
+
 @pytest.fixture
 def mock_boto3_client():
 	"""Patch boto3.client so StorageService can be instantiated without AWS creds."""
@@ -193,6 +203,17 @@ async def test_delete_file_client_error_raises(service, mock_boto3_client):
 		await service.delete_file("key.mp3")
 
 
+@pytest.mark.asyncio
+async def test_delete_file_offloads_boto3_to_thread(service, mock_boto3_client):
+	"""delete_object is network-bound; it must be offloaded via asyncio.to_thread
+	so it cannot pin the event loop (#321)."""
+	with patch("asyncio.to_thread", side_effect=_run_inline) as mock_tt:
+		await service.delete_file("some/key.mp3")
+	mock_tt.assert_awaited_once()
+	assert mock_tt.await_args.args[0] == mock_boto3_client.delete_object
+	assert mock_tt.await_args.kwargs == {"Bucket": "test-bucket", "Key": "some/key.mp3"}
+
+
 # ===========================================================================
 # generate_presigned_url
 # ===========================================================================
@@ -227,3 +248,15 @@ async def test_file_exists_returns_true_when_object_found(service, mock_boto3_cl
 async def test_file_exists_returns_false_on_client_error(service, mock_boto3_client):
 	mock_boto3_client.head_object.side_effect = _make_client_error("NoSuchKey")
 	assert await service.file_exists("key.mp3") is False
+
+
+@pytest.mark.asyncio
+async def test_file_exists_offloads_boto3_to_thread(service, mock_boto3_client):
+	"""head_object is network-bound; it must be offloaded via asyncio.to_thread
+	so it cannot pin the event loop (#321)."""
+	mock_boto3_client.head_object.return_value = {"ContentLength": 1}
+	with patch("asyncio.to_thread", side_effect=_run_inline) as mock_tt:
+		assert await service.file_exists("some/key.mp3") is True
+	mock_tt.assert_awaited_once()
+	assert mock_tt.await_args.args[0] == mock_boto3_client.head_object
+	assert mock_tt.await_args.kwargs == {"Bucket": "test-bucket", "Key": "some/key.mp3"}

--- a/docs/GAP_ANALYSIS.md
+++ b/docs/GAP_ANALYSIS.md
@@ -196,18 +196,15 @@ But the API uses JWT token-based auth, not cookies.
 
 | ID | Gap | Location | Severity |
 |----|-----|----------|----------|
-| GAP-021 | StorageService async methods use sync boto3 | `services/storage_service.py:43-152` | HIGH |
+| GAP-021 | ~~StorageService async methods use sync boto3~~ RESOLVED (#321): all network-bound boto3 calls in async paths offloaded via `asyncio.to_thread` (incl. `delete_file`/`file_exists` and the episode download handler) | `services/storage_service.py` | HIGH |
 | GAP-022 | PodcastService methods return hardcoded lists | `services/podcast_service.py:20-30` | MEDIUM |
 | GAP-023 | Script generation has no timeout for Gemini API | `services/script_generation_service.py:170` | MEDIUM |
 | GAP-024 | ~~S3 PDF extraction not implemented~~ RESOLVED (#242): `extract_from_pdf` implemented | `services/content_extraction_service.py` | HIGH |
 | GAP-025 | Transcript validation is minimal (only checks tags) | `services/script_generation_service.py:314-326` | LOW |
 
-**StorageService Blocking Issue:**
-```python
-async def upload_file(...):  # Declared async
-    self.s3_client.upload_file(...)  # But calls sync boto3!
-```
-This blocks the event loop on every S3 operation.
+**StorageService Blocking Issue (RESOLVED in #321):** all StorageService methods now wrap
+boto3 in `await asyncio.to_thread(...)`, and the episode download handler offloads its
+`head_object`/`get_object` calls, so S3 round-trips no longer block the event loop.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,107 +1,82 @@
-# Issue #320 — [P5.4] Observability gaps (self-authored plan)
+# Issue #321 — [P5.5] Blocking synchronous boto3 calls in async handlers (self-authored plan)
 
 Plan source: self-authored (no plan comment on the issue).
-Verified against `main` @ `c0218b0`, 2026-07-14.
+Verified against `main` @ `1b3d76c`, 2026-07-19.
 
-## Verified current state (every claim in the issue re-checked against live code)
+## Verified current state (issue line refs re-checked against live code — they drifted)
 
 | Issue claim | Verdict | Evidence |
 |---|---|---|
-| No Sentry in API or worker | TRUE | no `sentry` in `apps/api/pyproject.toml:10-33`; absent from `main.py`/`worker.py` |
-| `/health` unconditional, no `/ready` | TRUE | `main.py:70-73` returns a static dict; no `/ready` route exists |
-| Deploy gate relies on `/health` | TRUE | `deploy-dev.yml:378` `wait_for "API" "$API_URL/health" "200"`; nginx pass-through at `podcastfy.conf:178-181` |
-| No correlation ID; tenant_id not on logs | TRUE | zero `ContextVar` in `src/`; `tenant_id` lives only on `request.state` (`tenant.py:53-54`) |
-| No log rotation | TRUE | zero `logrotate` hits repo-wide; `harden-host.sh:58` installs `pm2 startup` but never `pm2-logrotate` |
-| Logs freeform, not JSON | TRUE | `main.py:15-19` `basicConfig(format="%(asctime)s - %(name)s - ...")` |
+| Download handler calls `head_object` synchronously | TRUE | `apps/api/src/routers/episodes.py:407-413` (issue said :362) |
+| Download handler calls `get_object` synchronously | TRUE | `episodes.py:434-446` ×2 (range + non-range; issue said :389-398) |
+| `StorageService.delete_file` calls boto3 directly in `async def` | TRUE | `apps/api/src/services/storage_service.py:132-146` → `delete_object` at :140 |
+| `StorageService.file_exists` calls boto3 directly in `async def` | TRUE | `storage_service.py:177-195` → `head_object` at :188 |
+| `upload_file`/`download_file` already offloaded | TRUE | `storage_service.py:82-98`, :114-130 — `await asyncio.to_thread(...)` is the established idiom |
 
-Three findings that **sharpen** the issue:
-- **nginx logs are worse than stated.** They go to a *custom* path `/opt/podcaststudiohub/logs/frontend-{access,error}.log`
-  (`podcastfy.conf:74-75`), which the distro's stock `/etc/logrotate.d/nginx` (globbing `/var/log/nginx/*.log`) does
-  **not** match. Nothing rotates them today.
-- **Redis PING needs no new dependency.** `redis>=5.0.0` (`pyproject.toml:23`) already ships `redis.asyncio`.
-  `sentry-sdk` is the only genuinely new dep.
-- **Celery has no signal hooks or Task base class** (confirmed: zero `celery.signals` usage), and the generation chain
-  uses **immutable `.si()` signatures** (`podcast_generation.py:930-935`, issue #211) — so propagation must go through
-  message **headers**, not kwargs.
+In-scope blocking calls: exactly the 4 above (`head_object`×2, `get_object`×2, `delete_object`×1).
+Confirmed NOT in scope (verified by full sweep of `apps/api/src`):
+- `storage_service.py:164` `generate_presigned_url` — CPU-only local signing, no network I/O; existing convention leaves it sync.
+- `episodes.py:415` `os.path.getsize` — local filesystem stat, not network-bound.
+- `tasks/audio_composition.py`, `tasks/s3_upload.py` — plain sync Celery tasks, no event loop.
+- Every other S3 touch point already goes through the offloaded wrappers.
 
-## Steps (TDD: step 1 first, RED)
+Callers that benefit with no change needed: `rss_feed.py:313` (public audio route → `file_exists`),
+`audio_snippet_service.py:309` (`delete_file`), `tasks/maintenance.py:150` (`asyncio.run` → `delete_file`).
 
-1. **Tests (RED)** — extend `apps/api/tests/test_health.py`; new `apps/api/tests/test_observability.py`;
-   new `deployment/tests/test_log_rotation.py` (static-read pattern per `test_dr_durability.py`):
-   - `/ready` → 200 + per-check body when DB+Redis are up
-   - `/ready` → **503** when DB raises, and (independently) when Redis PING raises
-   - `/health` stays 200 + static even when DB/Redis are down — the two probes must not collapse into one
-   - `/ready` is in `TenantContextMiddleware.PUBLIC_PATHS` (else it gets metered + tenant-resolved)
-   - `X-Request-ID` echoed on responses; minted when absent; **reused** when the client supplies one
-   - JSON formatter emits parseable JSON carrying `request_id` + `tenant_id`; `exc_info` → `exception` field
-   - Celery `before_task_publish` puts both ids on headers; `task_prerun` binds them into worker contextvars
-   - deploy workflow gates on `/ready`; installs pm2-logrotate; installs the nginx logrotate drop-in
+## Steps (TDD: tests first, RED)
 
-2. **JSON logging** — new `apps/api/src/logging_config.py`:
-   - `CORRELATION_ID` / `TENANT_ID` `ContextVar`s (single home; imported by middleware + Celery signals)
-   - `JsonFormatter(logging.Formatter)` — stdlib `json`, ~25 lines: ts/level/logger/msg/request_id/tenant_id/exception
-   - `setup_logging()` — configures the root handler **and** replaces the formatter on `uvicorn.access`/`uvicorn.error`
-     handlers, since uvicorn installs its own log config that root config alone won't reach
-   - `LOG_FORMAT: str = "json"` in `config.py` (`"text"` escape hatch for local dev)
-   - Called from `main.py` (replacing `basicConfig`) **and** from Celery's `setup_logging` signal (which suppresses
-     Celery's own config) → one formatter, both processes = AC5
+1. **Tests (RED) — storage service** — extend `apps/api/tests/unit/test_storage_service.py`:
+   - `delete_file` offloads: patch `asyncio.to_thread` with an AsyncMock whose side_effect invokes the
+     func synchronously; assert awaited once with `service.s3_client.delete_object` and
+     `Bucket`/`Key` kwargs; assert `delete_object` itself was NOT called directly on the mock's thread path.
+   - `file_exists` offloads: same pattern for `service.s3_client.head_object`.
+   - Existing behavior tests (`test_delete_file_success`, `test_file_exists_*`) must keep passing unchanged
+     (plain MagicMock survives `to_thread`).
 
-3. **Correlation ID + tenant binding** — new `apps/api/src/middleware/correlation.py`:
-   - `CorrelationIdMiddleware`: read `X-Request-ID` or mint `uuid4`; set contextvar; echo header on the response
-   - Registered **last** in `main.py` so it is outermost (Starlette `add_middleware` is LIFO) → wraps CORS + tenant
-   - `TenantContextMiddleware` additionally sets the `TENANT_ID` contextvar beside its existing `request.state` write
-     (purely additive; `request.state` stays the RLS source of truth)
-   - `worker.py`: `before_task_publish` → inject both ids into headers; `task_prerun` → bind into worker contextvars;
-     `task_postrun` → reset. Ids flow API → chain with **no task signature changes** (keeps the `.si()` invariant, #211)
+2. **Implement storage service** — `storage_service.py`:
+   - `delete_file`: `await asyncio.to_thread(self.s3_client.delete_object, Bucket=..., Key=...)`
+   - `file_exists`: `await asyncio.to_thread(self.s3_client.head_object, Bucket=..., Key=...)`
+   - Reuse the verbatim idiom + comment style from `upload_file`/`download_file`
+     ("boto3 is synchronous; run it off the event loop …"), citing `#321`. 4-space indent file.
 
-4. **Sentry** — `uv add sentry-sdk`; `init_sentry()` in `logging_config.py`, called from `main.py` + `worker.py`:
-   - gated on `SENTRY_DSN: Optional[str] = None` → **None is a no-op**, so dev/CI/tests stay offline
-     (matches the repo's `Optional[str] = None` convention, e.g. `config.py:79-80`)
-   - `environment=settings.ENVIRONMENT`, `traces_sample_rate=0.0` (errors only, no APM bill)
-   - **ponytail:** rely on sentry-sdk's auto-enabling FastAPI/Celery/logging integrations; no manual wiring
-   - `send_default_pii=False` + a `before_send` scrub — multi-tenant app; don't ship user data to a third party
-   - add `SENTRY_DSN` to `.env.example`
+3. **Tests (RED) — download endpoint** — extend `apps/api/tests/test_download_endpoint.py`:
+   - Wrap `client.get(.../download)` in `patch("asyncio.to_thread", side_effect=<async passthrough>)`;
+     assert it was awaited for `head_object` and `get_object` (≥2 awaits, bound methods of the mocked
+     `s3_client` as first arg).
+   - Existing download tests (full/range/local-file/404/403/416) must keep passing unchanged.
 
-5. **`/ready` probe** — `main.py`: `SELECT 1` via `from src.database import engine` (`engine.connect()`,
-   `pool_pre_ping=True`); Redis via `redis.asyncio.from_url(settings.REDIS_URL).ping()`. Both under an
-   `asyncio.wait_for` (~2s) so a hung dependency can't hang the probe. 503 + per-check detail on failure.
-   Add `/ready` to `PUBLIC_PATHS`.
+4. **Implement router** — `episodes.py` (tab-indented file — preserve tabs):
+   - Add `import asyncio`.
+   - `head_response = await asyncio.to_thread(storage.s3_client.head_object, Bucket=..., Key=...)`
+   - Both `s3_response = storage.s3_client.get_object(...)` → `await asyncio.to_thread(storage.s3_client.get_object, ...)`
+   - Keep `iter_s3_body` streaming unchanged (it already offloads per-chunk reads via `to_thread`,
+     `download_utils.py:180-198`).
 
-6. **Point the gates at `/ready`** — `deploy-dev.yml:378` → `$API_URL/ready`; nginx `location /ready` mirroring
-   `/health` (`podcastfy.conf:178-181`, `access_log off`). `/health` stays the liveness probe.
-
-7. **Log rotation** — workflow: `pm2 install pm2-logrotate` + `pm2 set` (10M, retain 7, compress, daily) — idempotent,
-   per the CI/CD-idempotent-only rule. New `deployment/logrotate/podcaststudiohub-nginx` for
-   `/opt/podcaststudiohub/logs/*.log` (daily, rotate 14, compress, delaycompress, notifempty, missingok,
-   `postrotate` nginx reopen) + rsync/install step.
-
-8. **Gates** — `uv run pytest tests/` (from `apps/api`), `python -m pytest deployment/tests/`, ruff, coverage ≥85,
-   deslop, opencode/GLM review pre-PR, demo per AC, PR, post-PR review, CI, docs sync, merge.
+5. **Gates** — `cd apps/api && uv run pytest tests/` (coverage ≥85), `ruff check .`, deslop scan,
+   opencode/GLM review pre-PR, demo per AC, PR, post-PR review, CI, docs sync, merge.
 
 ## Acceptance criteria checklist
-- [ ] AC1 Sentry in API + worker (step 4)
-- [ ] AC2 `/ready` doing SELECT 1 + Redis PING, deploy/uptime gate pointed at it (steps 5, 6)
-- [ ] AC3 Correlation ID propagated into Celery, bound to logs with tenant_id (steps 2, 3)
-- [ ] AC4 pm2-logrotate + logrotate for nginx (step 7)
-- [ ] AC5 JSON formatter shared by uvicorn and Celery (step 2)
+- [ ] AC1 All network-bound boto3 calls in async paths wrapped in `await asyncio.to_thread(...)`
+      (steps 2, 4 — the 4 verified call sites)
+- [ ] AC2 No new sync boto3 calls in async paths (step 5 — grep sweep in quality gate +
+      reviewer checklist item)
 
 ## Autonomous decisions (no architectural fork)
-- **`/health` stays static (liveness); `/ready` does the checks (readiness).** The standard split. Collapsing them would
-  make a brownout restart-loop the API instead of merely draining it from the gate. The issue asks for `/ready` and is
-  silent on changing `/health`, so `/health` keeps its contract and its existing tests (and its 8 other callers:
-  playwright, rm-review, e2e global-setup, webServer readiness).
-- **Hand-rolled JSON formatter + correlation middleware** over `python-json-logger` / `asgi-correlation-id`: ~25 and
-  ~40 lines of stdlib versus two new supply-chain deps in a repo with live CVE gates (#306). `sentry-sdk` is the only
-  new dep, and it has no stdlib substitute.
-- **Celery headers over task kwargs** for propagation: kwargs would touch every `.si()`/`.s()` call site and break the
-  immutable-signature invariant (#211).
-- **Sentry defaults to off** (`SENTRY_DSN=None`) — tests/CI/local stay offline with no opt-out ceremony.
-- **`traces_sample_rate=0.0`** — the issue asks for error tracking, not APM. YAGNI.
+- **`asyncio.to_thread` over presigned-URL redirect.** The issue sanctions both; `to_thread` is the
+  listed-first option and the minimal change. A 302 redirect would change endpoint semantics (auth is
+  checked once at redirect time, URL then reusable), drop server-side Range handling, and force rewriting
+  the existing download test suite. The streaming path already offloads chunk reads — only the initial
+  HEAD/GET block. Not a fork: safe default exists.
+- **`generate_presigned_url` left sync** — CPU-only (no network); matches existing code's own convention
+  and the issue's "network-bound" wording.
+- **Fix `StorageService` internals rather than every caller** — `rss_feed.py:313` and
+  `audio_snippet_service.py:309` are fixed for free; no call-site churn.
+- **Tests assert offload via patched `asyncio.to_thread`** rather than timing-based event-loop probes —
+  deterministic, no flaky sleeps.
 
 ## Risks / notes
-- `filterwarnings = error` is live (#348) — the sentry-sdk import must not emit warnings under pytest.
-- `meter_api_call` opens a DB session even on public paths (`dependencies.py:38-40`), so `/ready` touches the DB via the
-  app-level dependency regardless; the explicit `SELECT 1` is still what makes the check meaningful and 503-able.
-- Coverage gates are real (85% backend, #345) — new modules need real tests, not smoke.
-- Tasks are tested by direct `.run()` with a faked request (`test_celery_workflow.py:38-46`), not eager mode — signal
-  tests must drive the signals directly rather than relying on `task_always_eager`.
+- `filterwarnings = error` is live (#348) — no new warnings tolerated.
+- Coverage gate ≥85% (#345) — the new tests add branches, not uncovered code.
+- `episodes.py` uses tabs; `storage_service.py` uses 4 spaces — preserve each file's style.
+- `patch("asyncio.to_thread")` patches the module globally for the duration of the test — acceptable in
+  test scope; ensure passthrough side_effect so the handler body still executes.


### PR DESCRIPTION
## Summary
Implements #321: blocking synchronous boto3 calls inside async handlers pinned the FastAPI event loop. Every network-bound boto3 call in an async path now goes through `await asyncio.to_thread(...)`, using the idiom already established by `StorageService.upload_file`/`download_file`.

Five `to_thread` call expressions across four logical sites (verified as the complete set by a repo-wide sweep):
- `routers/episodes.py` — `download_episode_audio`: `head_object` (total size) + both `get_object` calls (ranged and full) offloaded; added `import asyncio`
- `services/storage_service.py` — `delete_file` (`delete_object`) and `file_exists` (`head_object`) offloaded; this also fixes the async callers `rss_feed.py:313` and `audio_snippet_service.py:309` with no call-site changes

`iter_s3_body` streaming already offloaded per-chunk reads; only the initial HEAD/GET blocked.

## Acceptance Criteria
- [x] Wrap all network-bound boto3 calls in `await asyncio.to_thread(...)` — all 4 verified sites
- [x] Add no new sync boto3 calls in async paths — none added; sweep re-verified in review

## Test Plan
- [x] Unit tests written (TDD — RED confirmed against pre-impl code, then GREEN)
  - `test_delete_file_offloads_boto3_to_thread`, `test_file_exists_offloads_boto3_to_thread` (patch `asyncio.to_thread`, assert awaited once with exact boto3 callable + kwargs)
  - `test_download_s3_calls_offloaded_to_thread` (asserts head/get both go through `to_thread`)
- [x] All tests passing: **1857 passed, 7 skipped** (full API suite)
- [x] Diff coverage on changed lines: **100%** (6/6 lines, diff-cover vs origin/main; gate ≥85%)
- [x] Linting clean: `ruff check src/ tests/` (CI scope)
- [x] Internal code review (advisory) completed — no Critical/Major
- [x] Cross-family review pass: **opencode (GLM) — APPROVE**
- [x] Test mutation sanity check (Phase 7d): all 3 new tests failed against the pre-implementation code (RED evidence — `assert_awaited_once` saw 0 awaits; endpoint test saw only `iter_s3_body`'s `body.read`)

## Known Limitations / Intentionally Deferred
- **Presigned-URL redirect not adopted** — the issue sanctions either approach; `to_thread` keeps the endpoint's streaming + Range semantics and existing auth flow unchanged. A redirect would issue a reusable URL after a one-time auth check.
- **`generate_presigned_url` left synchronous** — CPU-only local signing, no network I/O; matches the issue's "network-bound" scope and the codebase's existing convention.
- **`os.path.getsize` in the local-file branch left synchronous** — local filesystem stat, not network-bound.
- **Sync Celery tasks (`tasks/s3_upload.py`, `tasks/audio_composition.py`) untouched** — they run in worker processes, not on an event loop.
- Cross-family review suggestions triaged: two sequential `to_thread` calls per download (head then get) accepted — one-shot calls, negligible vs. the per-chunk offloads `iter_s3_body` already performs; endpoint-test tightness suggestion rebutted by RED evidence (test fails the moment head/get stop being offloaded).

## Implementation Notes
- Plan was self-authored (no plan comment on the issue) and is persisted in `tasks/todo.md`.
- Issue's cited line numbers had drifted; actual sites re-verified against `main` @ `2d26713`.
- Local test environment: scratch Postgres 16 (role `podcastfy_app`, per `tests/conftest.py` RLS requirement) + scratch Redis; CI remains the authoritative gate.

Closes #321