### PR TITLE
perf(#322): batch team counts, offload URL HEAD, queue analytics inserts, index episode search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ podcaststudiohub/
 ├── apps/
 │   ├── api/              # FastAPI backend (Python, uv)
 │   │   ├── src/          # Application code (api, routers, services, tasks, models, schemas, middleware, utils)
-│   │   ├── alembic/      # DB migrations (versions/ up to 017_…)
+│   │   ├── alembic/      # DB migrations (versions/ up to 018_…)
 │   │   ├── tests/        # pytest + pytest-bdd
 │   │   └── pyproject.toml
 │   └── web/              # Next.js 15 frontend (TypeScript, App Router)

--- a/apps/api/alembic/versions/018_episode_search_indexes.py
+++ b/apps/api/alembic/versions/018_episode_search_indexes.py
@@ -1,0 +1,78 @@
+"""Add episode search indexes: pg_trgm GIN on title/description + btree on created_at
+
+Episode search (episode_service.list_episodes) filters titles/descriptions with a
+leading-wildcard ILIKE on episode_metadata->>'title' and ->>'description', and
+filters/sorts by created_at — all unindexed, so large tenants hit sequential
+scans (issue #322).
+
+This migration adds:
+- the pg_trgm extension (provides the gin_trgm_ops operator class)
+- GIN gin_trgm_ops expression indexes on (episode_metadata->>'title') and
+  (episode_metadata->>'description') so substring/ILIKE (incl. leading wildcard)
+  can use an index instead of a sequential scan
+- a btree index on created_at for the range filters and ordering
+
+pg_trgm preserves the exact current substring-match semantics (unlike full-text
+search, which would change tokenization/ranking and API-visible results).
+
+`episodes` pre-exists and may hold data, so every index is built CONCURRENTLY
+inside an autocommit block (issue #318) — the build never takes a write-blocking
+lock. A DROP INDEX IF EXISTS guard precedes each create so a rerun is safe after
+a failed CONCURRENTLY build (which leaves an INVALID index behind).
+
+Revision ID: 018
+Revises: 017
+Create Date: 2026-07-19 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '018'
+down_revision: Union[str, None] = '017'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TITLE_INDEX = "idx_episodes_metadata_title_trgm"
+DESCRIPTION_INDEX = "idx_episodes_metadata_description_trgm"
+CREATED_AT_INDEX = "idx_episodes_created_at"
+
+
+def upgrade() -> None:
+	# gin_trgm_ops lets a GIN index serve substring/ILIKE matches, including the
+	# leading-wildcard patterns the episode search uses.
+	op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+
+	# Build CONCURRENTLY in an autocommit block so the build never blocks writes
+	# on the populated episodes table (issue #318). DROP IF EXISTS makes reruns
+	# safe after a failed CONCURRENTLY build (leaves an INVALID index behind).
+	with op.get_context().autocommit_block():
+		op.execute(f"DROP INDEX IF EXISTS {TITLE_INDEX}")
+		op.execute(
+			f"CREATE INDEX CONCURRENTLY {TITLE_INDEX} "
+			f"ON episodes USING gin ((episode_metadata->>'title') gin_trgm_ops)"
+		)
+
+		op.execute(f"DROP INDEX IF EXISTS {DESCRIPTION_INDEX}")
+		op.execute(
+			f"CREATE INDEX CONCURRENTLY {DESCRIPTION_INDEX} "
+			f"ON episodes USING gin ((episode_metadata->>'description') gin_trgm_ops)"
+		)
+
+		op.execute(f"DROP INDEX IF EXISTS {CREATED_AT_INDEX}")
+		op.execute(
+			f"CREATE INDEX CONCURRENTLY {CREATED_AT_INDEX} "
+			f"ON episodes USING btree (created_at)"
+		)
+
+
+def downgrade() -> None:
+	# Plain DROP INDEX (brief ACCESS EXCLUSIVE lock) is acceptable in a
+	# downgrade; IF EXISTS keeps it idempotent. pg_trgm is left installed — other
+	# objects may come to depend on it and dropping a shared extension is unsafe.
+	op.execute(f"DROP INDEX IF EXISTS {CREATED_AT_INDEX}")
+	op.execute(f"DROP INDEX IF EXISTS {DESCRIPTION_INDEX}")
+	op.execute(f"DROP INDEX IF EXISTS {TITLE_INDEX}")

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -2,6 +2,7 @@
 Analytics router: event tracking and usage metrics endpoints.
 """
 
+import logging
 from datetime import datetime
 from typing import Optional
 from uuid import UUID
@@ -22,6 +23,8 @@ from ..schemas.analytics import (
 	TrackEventRequest,
 )
 from ..services import analytics_service
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["analytics"])
 
@@ -65,18 +68,39 @@ async def track_event(
 	user_agent = request.headers.get("User-Agent")
 	referer = request.headers.get("Referer")
 
-	event = await analytics_service.track_event(
-		db=db,
-		tenant_id=current_user.tenant_id,
-		event_type=body.event_type,
-		episode_id=body.episode_id,
-		project_id=body.project_id,
-		user_agent=user_agent,
-		referer=referer,
-		ip_address=client_ip,
-		event_metadata=body.metadata,
+	# Build the event payload in-process (id + created_at minted here) and queue
+	# the insert so the per-event commit is off the request path (issue #322).
+	# ValueError → 422 for an invalid event_type (Pydantic already constrains the
+	# request, but keep the contract explicit).
+	try:
+		payload = analytics_service.build_event_payload(
+			tenant_id=current_user.tenant_id,
+			event_type=body.event_type,
+			episode_id=body.episode_id,
+			project_id=body.project_id,
+			user_agent=user_agent,
+			referer=referer,
+			ip_address=client_ip,
+			event_metadata=body.metadata,
+		)
+	except ValueError as exc:
+		raise HTTPException(status_code=422, detail=str(exc))
+
+	try:
+		from ..tasks.analytics import track_analytics_event_task
+		track_analytics_event_task.delay(payload=payload)
+	except Exception as e:
+		# Broker unavailable — analytics are fire-and-forget; log and still 201.
+		logger.warning(f"Could not queue analytics event {payload['id']}: {e}")
+
+	return AnalyticsEventResponse(
+		id=payload["id"],
+		event_type=payload["event_type"],
+		episode_id=payload["episode_id"],
+		project_id=payload["project_id"],
+		event_metadata=payload["event_metadata"],
+		created_at=payload["created_at"],
 	)
-	return event
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/src/routers/content.py
+++ b/apps/api/src/routers/content.py
@@ -129,6 +129,24 @@ async def create_content_source(
             logger.warning(
                 f"Could not queue extraction task for {content_source.id}: {e}"
             )
+    elif content_source.source_type == 'url':
+        # auto_extract disabled: create no longer verifies reachability inline
+        # (issue #322 — a blocking HEAD could tie the request up ~40s), so check
+        # it off the request path. The auto_extract path above needs no separate
+        # check — extraction re-fetches the URL and reports failure itself.
+        try:
+            from ..tasks.content_extraction import validate_url_reachability_task
+            validate_url_reachability_task.delay(
+                content_source_id=str(content_source.id),
+            )
+            logger.info(
+                f"Queued URL reachability check for content source {content_source.id}"
+            )
+        except Exception as e:
+            # Broker unavailable — log but don't fail creation
+            logger.warning(
+                f"Could not queue reachability check for {content_source.id}: {e}"
+            )
 
     return content_source
 

--- a/apps/api/src/routers/teams.py
+++ b/apps/api/src/routers/teams.py
@@ -2,7 +2,7 @@
 Teams router: team management, membership, and invitation endpoints.
 """
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from uuid import UUID
 
@@ -29,11 +29,15 @@ router = APIRouter(prefix="/teams", tags=["teams"])
 # ---------------------------------------------------------------------------
 
 
-async def _team_response(team, db: AsyncSession) -> TeamResponse:
-	count = await team_service.get_member_count(db, team.id)
+def _team_response_with_count(team, count: int) -> TeamResponse:
 	data = TeamResponse.model_validate(team)
 	data.member_count = count
 	return data
+
+
+async def _team_response(team, db: AsyncSession) -> TeamResponse:
+	count = await team_service.get_member_count(db, team.id)
+	return _team_response_with_count(team, count)
 
 
 # ---------------------------------------------------------------------------
@@ -54,13 +58,26 @@ async def create_team(
 
 @router.get("", response_model=TeamListResponse)
 async def list_teams(
+	limit: int = Query(100, ge=1, le=500),
+	offset: int = Query(0, ge=0),
 	current_user: User = Depends(get_current_user),
 	db: AsyncSession = Depends(get_db),
 ):
-	"""List all teams the current user belongs to."""
-	teams = await team_service.get_teams_for_user(db, current_user.id)
-	team_responses = [await _team_response(t, db) for t in teams]
-	return TeamListResponse(teams=team_responses, total=len(team_responses))
+	"""List teams the current user belongs to (paginated).
+
+	Constant query count regardless of page size: one page query, one total
+	COUNT, one grouped member-count query — never a COUNT per team. ``total``
+	is the full membership count so a UI can page through it.
+	"""
+	teams = await team_service.get_teams_for_user(
+		db, current_user.id, limit=limit, offset=offset
+	)
+	total = await team_service.count_teams_for_user(db, current_user.id)
+	counts = await team_service.get_member_counts(db, [t.id for t in teams])
+	team_responses = [
+		_team_response_with_count(t, counts.get(t.id, 0)) for t in teams
+	]
+	return TeamListResponse(teams=team_responses, total=total)
 
 
 @router.get("/{team_id}", response_model=TeamResponse)

--- a/apps/api/src/services/analytics_service.py
+++ b/apps/api/src/services/analytics_service.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from sqlalchemy import Boolean, Float, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,8 +21,7 @@ from ..models.analytics_event import (
 logger = logging.getLogger(__name__)
 
 
-async def track_event(
-	db: AsyncSession,
+def build_event_payload(
 	tenant_id: UUID,
 	event_type: str,
 	episode_id: Optional[UUID] = None,
@@ -31,31 +30,33 @@ async def track_event(
 	referer: Optional[str] = None,
 	ip_address: Optional[str] = None,
 	event_metadata: Optional[Dict[str, Any]] = None,
-) -> AnalyticsEvent:
-	"""Persist a single engagement event. IP is hashed before storage."""
+) -> Dict[str, Any]:
+	"""Build a JSON-safe engagement-event payload WITHOUT touching the DB.
+
+	The per-event commit is moved off the request path (issue #322): the router
+	returns immediately from this payload and a Celery task
+	(``track_analytics_event_task``) performs the insert. The id and created_at
+	are minted here so the response is answerable without a DB read (no
+	``refresh``), and every value is JSON-serializable so it survives Celery's
+	JSON task serializer. IP is hashed before it leaves this function.
+	"""
 	if event_type not in VALID_EVENT_TYPES:
 		raise ValueError(f"Invalid event_type: {event_type}")
 
-	hashed_ip = hash_ip(ip_address) if ip_address else None
-	device_type = detect_device_type(user_agent or "")
-	app_name = detect_app_name(user_agent or "")
-
-	event = AnalyticsEvent(
-		tenant_id=tenant_id,
-		episode_id=episode_id,
-		project_id=project_id,
-		event_type=event_type,
-		user_agent=user_agent,
-		referer=referer,
-		ip_address=hashed_ip,
-		device_type=device_type,
-		app_name=app_name,
-		event_metadata=event_metadata,
-	)
-	db.add(event)
-	await db.commit()
-	await db.refresh(event)
-	return event
+	return {
+		"id": str(uuid4()),
+		"tenant_id": str(tenant_id),
+		"episode_id": str(episode_id) if episode_id else None,
+		"project_id": str(project_id) if project_id else None,
+		"event_type": event_type,
+		"user_agent": user_agent,
+		"referer": referer,
+		"ip_address": hash_ip(ip_address) if ip_address else None,
+		"device_type": detect_device_type(user_agent or ""),
+		"app_name": detect_app_name(user_agent or ""),
+		"event_metadata": event_metadata,
+		"created_at": utcnow().isoformat(),
+	}
 
 
 async def get_episode_analytics(

--- a/apps/api/src/services/source_validator_service.py
+++ b/apps/api/src/services/source_validator_service.py
@@ -237,9 +237,15 @@ class SourceValidatorService:
 
 	async def validate_url_source(self, url: str, title: str) -> Tuple[bool, Optional[str]]:
 		"""
-		Validate URL source for podcast content.
+		Validate a URL source's format and SSRF-safety.
 
-		Checks URL format and accessibility via a HEAD request.
+		Reachability is deliberately NOT checked here (issue #322): a network
+		HEAD following up to MAX_REDIRECT_HOPS × URL_FETCH_TIMEOUT could tie the
+		request up for ~40s on a slow target. Verification happens off the
+		request path — the extraction task re-fetches the URL for the default
+		``auto_extract`` path, and ``validate_url_reachability_task`` covers the
+		``auto_extract=False`` case. ``_check_url_accessibility`` is retained for
+		that task.
 
 		Args:
 			url: URL string to validate
@@ -249,11 +255,11 @@ class SourceValidatorService:
 			Tuple of (is_valid, error_message)
 
 		Raises:
-			URLValidationError: If validation fails
+			URLValidationError: If the format is invalid or the target is a
+				private/loopback/reserved address (SSRF).
 		"""
 		self._validate_url_format(url)
 		self._validate_url_not_internal(url)
-		await self._check_url_accessibility(url)
 		return True, None
 
 	async def validate_text_source(self, content: str) -> Tuple[bool, Optional[str]]:

--- a/apps/api/src/services/team_service.py
+++ b/apps/api/src/services/team_service.py
@@ -72,15 +72,41 @@ async def get_team(db: AsyncSession, team_id: UUID) -> Team:
 	return team
 
 
-async def get_teams_for_user(db: AsyncSession, user_id: UUID) -> list[Team]:
-	"""Return all teams the user is an active member of."""
-	result = await db.execute(
+async def get_teams_for_user(
+	db: AsyncSession,
+	user_id: UUID,
+	limit: int | None = None,
+	offset: int = 0,
+) -> list[Team]:
+	"""Return teams the user is an active member of, ordered by creation.
+
+	When ``limit`` is given the result is a single page (with ``offset``); the
+	list endpoint uses this to cap response size. ``count_teams_for_user`` gives
+	the unpaginated total.
+	"""
+	query = (
 		select(Team)
 		.join(TeamMember, TeamMember.team_id == Team.id)
 		.where(TeamMember.user_id == user_id, TeamMember.status == "active")
 		.order_by(Team.created_at)
 	)
+	if offset:
+		query = query.offset(offset)
+	if limit is not None:
+		query = query.limit(limit)
+	result = await db.execute(query)
 	return list(result.scalars().all())
+
+
+async def count_teams_for_user(db: AsyncSession, user_id: UUID) -> int:
+	"""Count all teams the user is an active member of (pagination total)."""
+	result = await db.execute(
+		select(func.count())
+		.select_from(Team)
+		.join(TeamMember, TeamMember.team_id == Team.id)
+		.where(TeamMember.user_id == user_id, TeamMember.status == "active")
+	)
+	return result.scalar_one() or 0
 
 
 async def update_team(
@@ -107,7 +133,7 @@ async def delete_team(db: AsyncSession, team_id: UUID) -> None:
 
 
 async def get_member_count(db: AsyncSession, team_id: UUID) -> int:
-	"""Return count of active members in team."""
+	"""Return count of active members in team (single team)."""
 	result = await db.execute(
 		select(func.count(TeamMember.id)).where(
 			TeamMember.team_id == team_id,
@@ -115,6 +141,28 @@ async def get_member_count(db: AsyncSession, team_id: UUID) -> int:
 		)
 	)
 	return result.scalar_one() or 0
+
+
+async def get_member_counts(
+	db: AsyncSession, team_ids: list[UUID]
+) -> dict[UUID, int]:
+	"""Return active-member counts for many teams in one grouped query.
+
+	Replaces the N+1 loop of per-team ``get_member_count`` calls in list
+	endpoints. Teams with zero active members are absent from the dict
+	(callers default to 0).
+	"""
+	if not team_ids:
+		return {}
+	result = await db.execute(
+		select(TeamMember.team_id, func.count(TeamMember.id))
+		.where(
+			TeamMember.team_id.in_(team_ids),
+			TeamMember.status == "active",
+		)
+		.group_by(TeamMember.team_id)
+	)
+	return {team_id: count for team_id, count in result.all()}
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/src/tasks/analytics.py
+++ b/apps/api/src/tasks/analytics.py
@@ -1,0 +1,89 @@
+"""
+Celery task for persisting analytics engagement events (issue #322).
+
+The high-cardinality track endpoint used to do an INSERT + commit + refresh per
+event on the request path. That write now happens here so the request returns
+immediately. The event id and created_at are minted by the caller
+(`analytics_service.build_event_payload`) and passed through, so the insert is
+idempotent-ish (a duplicate id is a permanent, non-retried drop) and the HTTP
+response never needed the row read back.
+
+Runs under `celery_async_session`. `analytics_events` has FORCE ROW LEVEL
+SECURITY (migration 014), so tenant context is armed before the insert — the
+same precedent as `billing_service` writing on a non-request session. This
+keeps the insert correct even if a deployment wires the worker's DATABASE_URL
+to the non-privileged (RLS-enforced) role.
+"""
+
+import asyncio
+import logging
+import uuid as uuid_module
+from datetime import datetime
+from typing import Any, Dict
+
+from celery import Task
+from sqlalchemy.exc import IntegrityError
+
+from src.worker import celery_app
+
+logger = logging.getLogger(__name__)
+
+
+async def _track_event_async(payload: Dict[str, Any]) -> None:
+	"""Insert one AnalyticsEvent from a JSON-safe payload under tenant context."""
+	from src.database import celery_async_session, set_tenant_context
+	from src.models.analytics_event import AnalyticsEvent
+
+	async with celery_async_session() as db:
+		# Arm RLS tenant context BEFORE the insert so the WITH CHECK policy on
+		# analytics_events passes under an RLS-enforced role.
+		await set_tenant_context(db, payload["tenant_id"])
+
+		event = AnalyticsEvent(
+			id=uuid_module.UUID(payload["id"]),
+			tenant_id=uuid_module.UUID(payload["tenant_id"]),
+			episode_id=uuid_module.UUID(payload["episode_id"]) if payload.get("episode_id") else None,
+			project_id=uuid_module.UUID(payload["project_id"]) if payload.get("project_id") else None,
+			event_type=payload["event_type"],
+			user_agent=payload.get("user_agent"),
+			referer=payload.get("referer"),
+			ip_address=payload.get("ip_address"),
+			device_type=payload.get("device_type"),
+			app_name=payload.get("app_name"),
+			event_metadata=payload.get("event_metadata"),
+			created_at=datetime.fromisoformat(payload["created_at"]),
+		)
+		db.add(event)
+		await db.commit()
+
+
+@celery_app.task(bind=True, name="track_analytics_event", max_retries=3, time_limit=60)
+def track_analytics_event_task(self: Task, payload: Dict[str, Any]) -> Dict[str, Any]:
+	"""
+	Persist a tracked analytics event via Celery (issue #322).
+
+	Transient failures (broker/DB blips) retry with exponential backoff; an
+	``IntegrityError`` (duplicate id, or an episode/project deleted between
+	request and insert) is a permanent drop — retrying can never succeed.
+
+	Returns a dict with ``status`` ('recorded' or 'dropped').
+	"""
+	event_id = payload.get("id")
+	try:
+		asyncio.run(_track_event_async(payload))
+		return {"status": "recorded", "id": event_id}
+
+	except IntegrityError as e:
+		# Permanent — do not retry. Analytics are fire-and-forget; log and drop.
+		logger.warning(f"Analytics event {event_id} dropped (integrity error): {e}")
+		return {"status": "dropped", "id": event_id, "error": str(e)}
+
+	except Exception as e:
+		retry_countdown = 60 * (2 ** self.request.retries)
+		try:
+			raise self.retry(exc=e, countdown=retry_countdown)
+		except self.MaxRetriesExceededError:
+			logger.error(
+				f"Analytics event {event_id} dropped after max retries: {e}"
+			)
+			return {"status": "dropped", "id": event_id, "error": f"Max retries exceeded: {e}"}

--- a/apps/api/src/tasks/content_extraction.py
+++ b/apps/api/src/tasks/content_extraction.py
@@ -69,6 +69,91 @@ async def _extract_content_async(
 		}
 
 
+async def _validate_url_reachability_async(content_source_id: str) -> Dict[str, Any]:
+	"""
+	Verify a URL content source is reachable, off the request path (issue #322).
+
+	Replaces the create-time HEAD that used to block the request for up to
+	~40s: on an unreachable / non-2xx / timeout / redirect-loop target the
+	source is marked ``extraction_status='failed'`` with the error message; a
+	reachable target is left ``pending``. Only meaningful for the
+	``auto_extract=False`` case — the default extraction path already re-fetches
+	the URL and reports failure itself.
+
+	Runs under ``celery_async_session`` (the sync Celery role bypasses RLS,
+	same as ``extract_content_task``).
+	"""
+	from src.database import celery_async_session
+	from src.services.content_service import get_content_source_by_id
+	from src.services.source_validator_service import (
+		SourceValidatorService,
+		URLValidationError,
+	)
+
+	content_uuid = uuid_module.UUID(content_source_id)
+	async with celery_async_session() as db:
+		content_source = await get_content_source_by_id(db, content_uuid)
+		if content_source is None:
+			raise ValueError(f"Content source {content_source_id} not found")
+		if content_source.source_type != "url":
+			return {"status": "skipped", "reason": "not a url source"}
+
+		url = content_source.source_data.get("url")
+		if not url:
+			return {"status": "skipped", "reason": "missing url"}
+
+		try:
+			await SourceValidatorService()._check_url_accessibility(url)
+		except URLValidationError as exc:
+			content_source.extraction_status = "failed"
+			content_source.error_message = str(exc)
+			await db.commit()
+			return {"status": "failed", "error_message": str(exc)}
+
+		return {"status": "reachable"}
+
+
+@celery_app.task(bind=True, name="validate_url_reachability", max_retries=3, time_limit=120)
+def validate_url_reachability_task(
+	self: Task,
+	content_source_id: str,
+) -> Dict[str, Any]:
+	"""
+	Check a URL content source's reachability via Celery (issue #322).
+
+	Dispatched by the create endpoint when ``auto_extract`` is False so the
+	network HEAD never blocks the create request. An unreachable target is a
+	permanent result (the source is marked failed) — only unexpected errors
+	(e.g. transient DB failures) retry.
+
+	Returns a dict with ``status`` ('reachable', 'failed', or 'skipped') and,
+	on failure, ``error_message``.
+	"""
+	logger.info(f"Checking URL reachability for content source {content_source_id}")
+	try:
+		result = asyncio.run(_validate_url_reachability_async(content_source_id))
+		logger.info(
+			f"Reachability check for {content_source_id}: {result['status']}"
+		)
+		return result
+
+	except ValueError as e:
+		# Missing source — permanent, do not retry.
+		logger.error(f"Reachability check error for {content_source_id}: {str(e)}")
+		return {"status": "failed", "error_message": str(e)}
+
+	except Exception as e:
+		logger.error(f"Reachability check error for {content_source_id}: {str(e)}")
+		retry_countdown = 60 * (2 ** self.request.retries)
+		try:
+			raise self.retry(exc=e, countdown=retry_countdown)
+		except self.MaxRetriesExceededError:
+			return {
+				"status": "failed",
+				"error_message": f"Max retries exceeded: {str(e)}",
+			}
+
+
 @celery_app.task(bind=True, name="extract_content", max_retries=3, time_limit=120)
 def extract_content_task(
 	self: Task,

--- a/apps/api/src/worker.py
+++ b/apps/api/src/worker.py
@@ -33,6 +33,7 @@ celery_app = Celery(
         "src.tasks.content_extraction",
         "src.tasks.callbacks",
         "src.tasks.maintenance",
+        "src.tasks.analytics",
     ]
 )
 
@@ -72,6 +73,7 @@ celery_app.conf.task_routes = {
     "src.tasks.s3_upload.*": {"queue": "uploads"},
     "src.tasks.platform_distribution.*": {"queue": "distribution"},
     "extract_content": {"queue": "content_extraction"},
+    "validate_url_reachability": {"queue": "content_extraction"},
     "src.tasks.content_extraction.*": {"queue": "content_extraction"},
     "src.tasks.callbacks.*": {"queue": "callbacks"},
     "on_upload_complete": {"queue": "callbacks"},
@@ -81,6 +83,8 @@ celery_app.conf.task_routes = {
     "on_workflow_failure": {"queue": "callbacks"},
     "reap_stuck_episodes": {"queue": "callbacks"},
     "drain_storage_deletion_outbox": {"queue": "callbacks"},
+    "track_analytics_event": {"queue": "callbacks"},
+    "src.tasks.analytics.*": {"queue": "callbacks"},
 }
 
 # Beat schedule — periodic reaper that fails episodes stuck in a non-terminal

--- a/apps/api/tests/test_analytics.py
+++ b/apps/api/tests/test_analytics.py
@@ -4,7 +4,10 @@ Integration tests for analytics endpoints (GAP-049).
 
 import pytest
 from datetime import datetime, timedelta, timezone
-from uuid import uuid4
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+from src.models.analytics_event import AnalyticsEvent
 
 
 # ---------------------------------------------------------------------------
@@ -24,6 +27,44 @@ async def register_and_login(client, email=None):
 	assert response.status_code == 201, response.text
 	token = response.json()["access_token"]
 	return {"Authorization": f"Bearer {token}"}
+
+
+async def register_and_login_with_tenant(client, email=None):
+	"""Register a new user and return (auth headers, tenant_id)."""
+	if email is None:
+		email = f"test_{uuid4()}@example.com"
+	response = await client.post("/auth/register", json={
+		"email": email,
+		"password": "SecurePass123!",
+		"full_name": "Test User",
+	})
+	assert response.status_code == 201, response.text
+	body = response.json()
+	headers = {"Authorization": f"Bearer {body['access_token']}"}
+	return headers, UUID(body["user"]["tenant_id"])
+
+
+async def _seed_event(test_db, tenant_id, event_type, *, episode_id=None,
+                      project_id=None, created_at=None, metadata=None):
+	"""Insert an AnalyticsEvent directly on the shared test session.
+
+	The track endpoint now queues the insert to Celery (issue #322), so
+	round-trip aggregation tests seed events directly instead of POSTing.
+	Relies on RLS tenant context already armed on `test_db` by a preceding API
+	request (register/create project/episode) — same pattern as
+	test_analytics_aggregation.py.
+	"""
+	from src.utils.datetime_utils import utcnow
+	event = AnalyticsEvent(
+		tenant_id=UUID(str(tenant_id)),
+		episode_id=UUID(str(episode_id)) if episode_id else None,
+		project_id=UUID(str(project_id)) if project_id else None,
+		event_type=event_type,
+		event_metadata=metadata,
+		created_at=created_at or utcnow(),
+	)
+	test_db.add(event)
+	await test_db.commit()
 
 
 async def create_project(client, headers):
@@ -181,6 +222,49 @@ async def test_track_event_without_episode_or_project(client):
 	assert response.status_code == 201, response.text
 
 
+@pytest.mark.asyncio
+async def test_track_event_queues_task_with_payload(client):
+	"""Track queues the insert (off the request path) with the full payload (#322).
+
+	The 201 response is built from the in-process payload — the same id/
+	created_at the task will persist — so no DB write/refresh happens inline.
+	"""
+	headers, tenant_id = await register_and_login_with_tenant(client)
+	project_id = await create_project(client, headers)
+	episode_id = await create_episode(client, headers, project_id)
+
+	with patch("src.tasks.analytics.track_analytics_event_task") as mock_task:
+		response = await client.post("/analytics/events", json={
+			"event_type": "play",
+			"episode_id": episode_id,
+			"project_id": project_id,
+			"metadata": {"completed": True},
+		}, headers=headers)
+
+	assert response.status_code == 201, response.text
+	data = response.json()
+	mock_task.delay.assert_called_once()
+	payload = mock_task.delay.call_args.kwargs["payload"]
+	assert payload["id"] == data["id"]
+	assert payload["tenant_id"] == str(tenant_id)
+	assert payload["event_type"] == "play"
+	assert payload["episode_id"] == episode_id
+	assert payload["project_id"] == project_id
+	assert payload["event_metadata"] == {"completed": True}
+
+
+@pytest.mark.asyncio
+async def test_track_event_broker_down_still_returns_201(client):
+	"""A broker outage must never fail the request — analytics are best-effort."""
+	headers = await register_and_login(client)
+	with patch("src.tasks.analytics.track_analytics_event_task") as mock_task:
+		mock_task.delay.side_effect = RuntimeError("broker unavailable")
+		response = await client.post("/analytics/events", json={
+			"event_type": "share",
+		}, headers=headers)
+	assert response.status_code == 201, response.text
+
+
 # ---------------------------------------------------------------------------
 # GET /analytics/episodes/{episode_id}
 # ---------------------------------------------------------------------------
@@ -202,22 +286,16 @@ async def test_get_episode_analytics_zero_counts(client):
 
 
 @pytest.mark.asyncio
-async def test_get_episode_analytics_counts_correctly(client):
+async def test_get_episode_analytics_counts_correctly(client, test_db):
 	"""Episode analytics should count events correctly."""
-	headers = await register_and_login(client)
+	headers, tenant_id = await register_and_login_with_tenant(client)
 	project_id = await create_project(client, headers)
 	episode_id = await create_episode(client, headers, project_id)
 
-	# Track 2 downloads, 1 play
+	# Seed 2 downloads, 1 play (track insert is now async off the request path).
 	for _ in range(2):
-		await client.post("/analytics/events", json={
-			"event_type": "download",
-			"episode_id": episode_id,
-		}, headers=headers)
-	await client.post("/analytics/events", json={
-		"event_type": "play",
-		"episode_id": episode_id,
-	}, headers=headers)
+		await _seed_event(test_db, tenant_id, "download", episode_id=episode_id)
+	await _seed_event(test_db, tenant_id, "play", episode_id=episode_id)
 
 	response = await client.get(f"/analytics/episodes/{episode_id}", headers=headers)
 	assert response.status_code == 200, response.text
@@ -227,16 +305,13 @@ async def test_get_episode_analytics_counts_correctly(client):
 
 
 @pytest.mark.asyncio
-async def test_get_episode_analytics_tz_aware_date_range(client):
+async def test_get_episode_analytics_tz_aware_date_range(client, test_db):
 	"""Z-suffixed (TZ-aware) date params must not raise against naive created_at (#310)."""
-	headers = await register_and_login(client)
+	headers, tenant_id = await register_and_login_with_tenant(client)
 	project_id = await create_project(client, headers)
 	episode_id = await create_episode(client, headers, project_id)
 
-	await client.post("/analytics/events", json={
-		"event_type": "download",
-		"episode_id": episode_id,
-	}, headers=headers)
+	await _seed_event(test_db, tenant_id, "download", episode_id=episode_id)
 
 	date_from = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
 	date_to = (datetime.now(timezone.utc) + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -249,16 +324,13 @@ async def test_get_episode_analytics_tz_aware_date_range(client):
 
 
 @pytest.mark.asyncio
-async def test_get_episode_analytics_non_utc_offset_converted(client):
+async def test_get_episode_analytics_non_utc_offset_converted(client, test_db):
 	"""Non-UTC offsets must be converted to UTC, not just tz-stripped (#310)."""
-	headers = await register_and_login(client)
+	headers, tenant_id = await register_and_login_with_tenant(client)
 	project_id = await create_project(client, headers)
 	episode_id = await create_episode(client, headers, project_id)
 
-	await client.post("/analytics/events", json={
-		"event_type": "download",
-		"episode_id": episode_id,
-	}, headers=headers)
+	await _seed_event(test_db, tenant_id, "download", episode_id=episode_id)
 
 	# 30 min ago UTC, expressed in +03:00 — naive stripping would yield a
 	# wall time ~2.5h in the future and wrongly exclude the event just tracked.
@@ -316,19 +388,16 @@ async def test_get_project_analytics_zero_counts(client):
 
 
 @pytest.mark.asyncio
-async def test_get_project_analytics_aggregates_correctly(client):
+async def test_get_project_analytics_aggregates_correctly(client, test_db):
 	"""Project analytics should aggregate events from all episodes."""
-	headers = await register_and_login(client)
+	headers, tenant_id = await register_and_login_with_tenant(client)
 	project_id = await create_project(client, headers)
 	episode_id = await create_episode(client, headers, project_id)
 
-	# Track 3 downloads for project
+	# Seed 3 downloads for the project (track insert is now async off-request).
 	for _ in range(3):
-		await client.post("/analytics/events", json={
-			"event_type": "download",
-			"episode_id": episode_id,
-			"project_id": project_id,
-		}, headers=headers)
+		await _seed_event(test_db, tenant_id, "download",
+		                  episode_id=episode_id, project_id=project_id)
 
 	response = await client.get(f"/projects/{project_id}/analytics", headers=headers)
 	assert response.status_code == 200, response.text

--- a/apps/api/tests/test_content.py
+++ b/apps/api/tests/test_content.py
@@ -848,7 +848,12 @@ async def test_content_source_tenant_isolation(client, url_content_source):
 # ============================================================================
 
 def _mock_http_200():
-    """Return a context-manager mock that yields a 200 HEAD response."""
+    """Return a context-manager mock that yields a 200 HEAD response.
+
+    Retained for tests that create URL sources while stubbing the network. Since
+    issue #322 create no longer issues an inline HEAD, so this stub is a
+    harmless no-op for those tests — they assert on creation, not reachability.
+    """
     mock_response = MagicMock()
     mock_response.status_code = 200
 
@@ -908,103 +913,93 @@ async def test_create_url_content_source_no_scheme(client, episode_and_auth):
 
 
 @pytest.mark.asyncio
-async def test_create_url_content_source_unreachable(client, episode_and_auth):
-    """URL that returns 404 should return 422 with descriptive error."""
+async def test_create_url_content_source_unreachable_still_creates(client, episode_and_auth):
+    """An unreachable/non-2xx URL now creates the source (201) — issue #322.
+
+    Create does format + SSRF validation only; reachability moved off the
+    request path, so no inline HEAD is issued and a dead target no longer
+    blocks creation. httpx.AsyncClient must never be constructed during create.
+    """
     episode_id, headers = episode_and_auth
-
-    mock_response = MagicMock()
-    mock_response.status_code = 404
-
-    mock_client = AsyncMock()
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-    mock_client.head = AsyncMock(return_value=mock_response)
+    content_data = {
+        "episode_id": episode_id,
+        "source_type": "url",
+        "source_data": {"url": "https://example.com/missing", "title": "Missing Page"},
+    }
 
     with patch(
-        "src.services.source_validator_service.httpx.AsyncClient",
-        return_value=mock_client,
-    ):
-        content_data = {
-            "episode_id": episode_id,
-            "source_type": "url",
-            "source_data": {
-                "url": "https://example.com/missing",
-                "title": "Missing Page"
-            }
-        }
-
+        "src.services.source_validator_service.httpx.AsyncClient"
+    ) as mock_client_cls:
         response = await client.post(
-            f"/episodes/{episode_id}/content",
-            headers=headers,
-            json=content_data
+            f"/episodes/{episode_id}/content", headers=headers, json=content_data
         )
 
-    assert response.status_code == 422
-    assert "404" in response.json()["detail"]
+    assert response.status_code == 201
+    assert response.json()["extraction_status"] == "pending"
+    mock_client_cls.assert_not_called()  # no inline reachability fetch
 
 
 @pytest.mark.asyncio
-async def test_create_url_content_source_timeout(client, episode_and_auth):
-    """URL that times out should return 422 with timeout message."""
-    import httpx as _httpx
-    episode_id, headers = episode_and_auth
+async def test_create_url_auto_extract_false_dispatches_reachability(client, episode_and_auth):
+    """With auto_extract disabled, a URL source queues the reachability task (#322).
 
-    mock_client = AsyncMock()
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-    mock_client.head = AsyncMock(side_effect=_httpx.TimeoutException("timeout"))
+    The default auto_extract path is covered by extraction's own re-fetch, so
+    reachability is only separately verified off the request path when
+    auto_extract is False.
+    """
+    episode_id, headers = episode_and_auth
+    content_data = {
+        "episode_id": episode_id,
+        "source_type": "url",
+        "source_data": {"url": "https://example.com/article", "title": "Article"},
+    }
 
     with patch(
-        "src.services.source_validator_service.httpx.AsyncClient",
-        return_value=mock_client,
-    ):
-        content_data = {
-            "episode_id": episode_id,
-            "source_type": "url",
-            "source_data": {
-                "url": "https://slow.example.com",
-                "title": "Slow Site"
-            }
-        }
-
+        "src.tasks.content_extraction.validate_url_reachability_task"
+    ) as mock_reach, patch(
+        "src.tasks.content_extraction.extract_content_task"
+    ) as mock_extract:
         response = await client.post(
-            f"/episodes/{episode_id}/content",
+            f"/episodes/{episode_id}/content?auto_extract=false",
             headers=headers,
-            json=content_data
+            json=content_data,
         )
 
-    assert response.status_code == 422
-    assert "timed out" in response.json()["detail"].lower()
+    assert response.status_code == 201
+    mock_reach.delay.assert_called_once()
+    assert mock_reach.delay.call_args.kwargs["content_source_id"] == response.json()["id"]
+    # auto_extract disabled — extraction is NOT dispatched
+    mock_extract.delay.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_create_url_content_source_valid_passes(client, episode_and_auth):
-    """Valid URL returning 200 should create content source successfully."""
-    episode_id, headers = episode_and_auth
+    """A valid URL creates the source (201) and, by default, queues extraction.
 
-    mock_client = _mock_http_200()
+    auto_extract defaults True, so the extraction task (which re-fetches the URL)
+    is dispatched and the separate reachability task is NOT — extraction covers
+    reachability for the default path (issue #322).
+    """
+    episode_id, headers = episode_and_auth
+    content_data = {
+        "episode_id": episode_id,
+        "source_type": "url",
+        "source_data": {"url": "https://example.com/article", "title": "Valid Article"},
+    }
 
     with patch(
-        "src.services.source_validator_service.httpx.AsyncClient",
-        return_value=mock_client,
-    ):
-        content_data = {
-            "episode_id": episode_id,
-            "source_type": "url",
-            "source_data": {
-                "url": "https://example.com/article",
-                "title": "Valid Article"
-            }
-        }
-
+        "src.tasks.content_extraction.extract_content_task"
+    ) as mock_extract, patch(
+        "src.tasks.content_extraction.validate_url_reachability_task"
+    ) as mock_reach:
         response = await client.post(
-            f"/episodes/{episode_id}/content",
-            headers=headers,
-            json=content_data
+            f"/episodes/{episode_id}/content", headers=headers, json=content_data
         )
 
     assert response.status_code == 201
     assert response.json()["source_type"] == "url"
+    mock_extract.delay.assert_called_once()
+    mock_reach.delay.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_teams.py
+++ b/apps/api/tests/test_teams.py
@@ -106,6 +106,56 @@ async def test_list_teams_shows_created_teams(client):
 
 
 @pytest.mark.asyncio
+async def test_list_teams_member_count_without_n_plus_one(client, monkeypatch):
+	"""Listing must batch member counts — never one COUNT per team.
+
+	The list path is proven free of the per-team counter by patching the
+	singular `get_member_count` to raise: if the request still returns 200 with
+	correct counts, the grouped query served them.
+	"""
+	headers = await register_and_login(client)
+	await client.post("/teams", headers=headers, json={"name": "N1 Team A"})
+	await client.post("/teams", headers=headers, json={"name": "N1 Team B"})
+
+	from src.services import team_service as ts
+
+	async def _boom(*args, **kwargs):
+		raise AssertionError("per-team get_member_count called during list")
+
+	monkeypatch.setattr(ts, "get_member_count", _boom)
+
+	response = await client.get("/teams", headers=headers)
+	assert response.status_code == 200
+	data = response.json()
+	assert data["total"] == 2
+	assert all(t["member_count"] == 1 for t in data["teams"])
+
+
+@pytest.mark.asyncio
+async def test_list_teams_limit_and_offset(client):
+	headers = await register_and_login(client)
+	for i in range(3):
+		await client.post("/teams", headers=headers, json={"name": f"Cap Team {i}"})
+
+	page1 = await client.get("/teams?limit=2&offset=0", headers=headers)
+	assert page1.status_code == 200
+	data1 = page1.json()
+	assert len(data1["teams"]) == 2
+	# total reflects the full count beyond the page, so a UI can paginate.
+	assert data1["total"] == 3
+
+	page2 = await client.get("/teams?limit=2&offset=2", headers=headers)
+	assert len(page2.json()["teams"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_teams_limit_out_of_range_rejected(client):
+	headers = await register_and_login(client)
+	assert (await client.get("/teams?limit=0", headers=headers)).status_code == 422
+	assert (await client.get("/teams?limit=501", headers=headers)).status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_get_team(client):
 	headers = await register_and_login(client)
 	create_resp = await client.post("/teams", headers=headers, json={"name": "Get Me"})

--- a/apps/api/tests/unit/test_analytics_track_task.py
+++ b/apps/api/tests/unit/test_analytics_track_task.py
@@ -1,0 +1,127 @@
+"""
+Unit tests for the analytics event Celery task (issue #322).
+
+The per-event INSERT + commit moved off the request path into
+track_analytics_event_task. These cover the async helper (arms tenant context,
+inserts the exact id/created_at, commits once) and the task surface (retry vs
+permanent-drop policy), with celery_async_session and set_tenant_context mocked
+— mirroring test_extract_content_async.py / test_url_reachability_task.py.
+"""
+
+import inspect
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from sqlalchemy.exc import IntegrityError
+
+
+def _make_async_context_manager(db_mock):
+	cm = AsyncMock()
+	cm.__aenter__ = AsyncMock(return_value=db_mock)
+	cm.__aexit__ = AsyncMock(return_value=False)
+	return cm
+
+
+def _payload(**over):
+	p = {
+		"id": str(uuid4()),
+		"tenant_id": str(uuid4()),
+		"episode_id": str(uuid4()),
+		"project_id": None,
+		"event_type": "play",
+		"user_agent": "UA",
+		"referer": None,
+		"ip_address": "hashed-ip",
+		"device_type": "mobile",
+		"app_name": "spotify",
+		"event_metadata": {"completed": True},
+		"created_at": "2026-07-19T12:00:00",
+	}
+	p.update(over)
+	return p
+
+
+@pytest.mark.asyncio
+async def test_track_async_arms_tenant_context_then_inserts_and_commits():
+	"""set_tenant_context is armed BEFORE the insert; id/created_at are preserved."""
+	from src.tasks.analytics import _track_event_async
+
+	mock_db = AsyncMock()
+	calls = []
+
+	async def _stc(db, tid):
+		calls.append(("set_tenant", tid))
+
+	def _add(obj):
+		calls.append(("add", obj))
+
+	mock_db.add = MagicMock(side_effect=_add)
+	payload = _payload()
+
+	with patch("src.database.celery_async_session", return_value=_make_async_context_manager(mock_db)), \
+	     patch("src.database.set_tenant_context", AsyncMock(side_effect=_stc)):
+		await _track_event_async(payload)
+
+	# Tenant context is armed before the row is added (RLS WITH CHECK).
+	assert calls[0] == ("set_tenant", payload["tenant_id"])
+	assert calls[1][0] == "add"
+	added = calls[1][1]
+	assert str(added.id) == payload["id"]
+	assert str(added.tenant_id) == payload["tenant_id"]
+	assert str(added.episode_id) == payload["episode_id"]
+	assert added.project_id is None
+	assert added.event_type == "play"
+	assert added.created_at == datetime.fromisoformat(payload["created_at"])
+	mock_db.commit.assert_awaited_once()
+
+
+def test_task_returns_recorded_on_success():
+	from src.tasks.analytics import track_analytics_event_task
+
+	with patch("src.tasks.analytics._track_event_async", MagicMock()), \
+	     patch("src.tasks.analytics.asyncio.run", MagicMock(return_value=None)):
+		with patch.object(track_analytics_event_task, "update_state"):
+			result = track_analytics_event_task.run(payload=_payload(id="evt-1"))
+
+	assert result["status"] == "recorded"
+	assert result["id"] == "evt-1"
+
+
+def test_task_drops_on_integrity_error_without_retry():
+	"""A duplicate id / vanished FK is permanent — drop, never retry."""
+	from src.tasks.analytics import track_analytics_event_task
+
+	err = IntegrityError("INSERT", {}, Exception("duplicate key"))
+	with patch("src.tasks.analytics._track_event_async", MagicMock()), \
+	     patch("src.tasks.analytics.asyncio.run", MagicMock(side_effect=err)):
+		with patch.object(track_analytics_event_task, "update_state"), \
+		     patch.object(track_analytics_event_task, "retry") as mock_retry:
+			result = track_analytics_event_task.run(payload=_payload())
+
+	assert result["status"] == "dropped"
+	mock_retry.assert_not_called()
+
+
+def test_task_retries_on_transient_error():
+	from src.tasks.analytics import track_analytics_event_task
+
+	with patch("src.tasks.analytics._track_event_async", MagicMock()), \
+	     patch("src.tasks.analytics.asyncio.run", MagicMock(side_effect=ConnectionError("boom"))):
+		with patch.object(track_analytics_event_task, "update_state"), \
+		     patch.object(
+		         track_analytics_event_task,
+		         "retry",
+		         side_effect=track_analytics_event_task.MaxRetriesExceededError(),
+		     ) as mock_retry:
+			result = track_analytics_event_task.run(payload=_payload())
+
+	assert result["status"] == "dropped"
+	mock_retry.assert_called_once()
+
+
+def test_task_signature_accepts_payload():
+	from src.tasks.analytics import track_analytics_event_task
+	assert "payload" in inspect.signature(track_analytics_event_task.run).parameters

--- a/apps/api/tests/unit/test_migration_018_episode_search_indexes.py
+++ b/apps/api/tests/unit/test_migration_018_episode_search_indexes.py
@@ -1,0 +1,135 @@
+"""
+Unit tests for migration 018_episode_search_indexes.
+
+Tests cover:
+- Migration metadata (revision ID '018', chains onto '017', no branch/deps)
+- upgrade() enables pg_trgm and creates GIN gin_trgm_ops expression indexes on
+  episode_metadata->>'title' and ->>'description', plus a btree on created_at
+- All three indexes are built CONCURRENTLY inside an autocommit block (issue
+  #318) with DROP INDEX IF EXISTS rerun guards
+- downgrade() drops all three indexes (pg_trgm extension is intentionally kept)
+"""
+
+import importlib.util
+import os
+from unittest.mock import patch, MagicMock
+
+
+def _load_migration():
+	migration_path = os.path.join(
+		os.path.dirname(__file__),
+		'..', '..', 'alembic', 'versions',
+		'018_episode_search_indexes.py',
+	)
+	migration_path = os.path.normpath(migration_path)
+	spec = importlib.util.spec_from_file_location('migration_018', migration_path)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+def _run_upgrade():
+	"""Run upgrade() with alembic entry points mocked; return (executed_sql, ctx)."""
+	executed = []
+	ctx = MagicMock()
+	with patch('alembic.op.execute', side_effect=lambda s, *a, **k: executed.append(str(s))), \
+	     patch('alembic.op.get_context', return_value=ctx):
+		_load_migration().upgrade()
+	return executed, ctx
+
+
+def _run_downgrade():
+	executed = []
+	ctx = MagicMock()
+	with patch('alembic.op.execute', side_effect=lambda s, *a, **k: executed.append(str(s))), \
+	     patch('alembic.op.get_context', return_value=ctx):
+		_load_migration().downgrade()
+	return executed, ctx
+
+
+# ============================================================================
+# METADATA TESTS
+# ============================================================================
+
+def test_migration_revision_id():
+	assert _load_migration().revision == '018'
+
+
+def test_migration_down_revision():
+	assert _load_migration().down_revision == '017'
+
+
+def test_migration_branch_labels_none():
+	assert _load_migration().branch_labels is None
+
+
+def test_migration_depends_on_none():
+	assert _load_migration().depends_on is None
+
+
+# ============================================================================
+# UPGRADE TESTS
+# ============================================================================
+
+def test_upgrade_enables_pg_trgm():
+	executed, _ = _run_upgrade()
+	assert any("create extension if not exists pg_trgm" in s.lower() for s in executed)
+
+
+def test_upgrade_creates_title_trgm_gin_index():
+	executed, _ = _run_upgrade()
+	joined = " ".join(executed).lower()
+	assert "using gin" in joined
+	assert "gin_trgm_ops" in joined
+	assert "episode_metadata->>'title'" in joined.replace(" ", "")
+
+
+def test_upgrade_creates_description_trgm_gin_index():
+	executed, _ = _run_upgrade()
+	joined = " ".join(executed).lower().replace(" ", "")
+	assert "episode_metadata->>'description'" in joined
+
+
+def test_upgrade_creates_created_at_btree_index():
+	executed, _ = _run_upgrade()
+	joined = " ".join(executed).lower()
+	assert "using btree" in joined
+	assert "created_at" in joined
+
+
+def test_upgrade_builds_indexes_concurrently():
+	executed, _ = _run_upgrade()
+	concurrent_creates = [s for s in executed if "create index concurrently" in s.lower()]
+	# title + description + created_at
+	assert len(concurrent_creates) == 3
+
+
+def test_upgrade_runs_inside_autocommit_block():
+	"""CONCURRENTLY cannot run in a transaction; an autocommit block is required."""
+	_, ctx = _run_upgrade()
+	assert ctx.autocommit_block.called
+
+
+def test_upgrade_emits_rerun_guards():
+	"""Each CONCURRENTLY create is preceded by a DROP INDEX IF EXISTS guard."""
+	executed, _ = _run_upgrade()
+	drop_guards = [s for s in executed if "drop index if exists" in s.lower()]
+	assert len(drop_guards) == 3
+
+
+# ============================================================================
+# DOWNGRADE TESTS
+# ============================================================================
+
+def test_downgrade_drops_all_three_indexes():
+	executed, _ = _run_downgrade()
+	joined = " ".join(executed).lower()
+	assert "idx_episodes_metadata_title_trgm" in joined
+	assert "idx_episodes_metadata_description_trgm" in joined
+	assert "idx_episodes_created_at" in joined
+
+
+def test_downgrade_uses_if_exists_guards():
+	executed, _ = _run_downgrade()
+	drops = [s for s in executed if "drop index if exists" in s.lower()]
+	assert len(drops) == 3

--- a/apps/api/tests/unit/test_source_validation.py
+++ b/apps/api/tests/unit/test_source_validation.py
@@ -390,21 +390,17 @@ def test_validate_text_length_exactly_10_words():
 
 
 @pytest.mark.asyncio
-async def test_validate_url_source_valid():
-	"""Valid URL returning 200 should return (True, None)."""
+async def test_validate_url_source_no_network_head():
+	"""A well-formed public URL validates WITHOUT any network HEAD (issue #322).
+
+	Reachability moved off the request path: create-time validation is format +
+	SSRF only, so httpx.AsyncClient must never be constructed here.
+	"""
 	validator = make_validator()
-	mock_response = MagicMock()
-	mock_response.status_code = 200
-
 	with patch("src.services.source_validator_service.httpx.AsyncClient") as mock_client_cls:
-		mock_client = AsyncMock()
-		mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-		mock_client.__aexit__ = AsyncMock(return_value=None)
-		mock_client.head = AsyncMock(return_value=mock_response)
-		mock_client_cls.return_value = mock_client
-
 		result = await validator.validate_url_source("https://example.com", "Title")
 	assert result == (True, None)
+	mock_client_cls.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -465,23 +461,15 @@ async def test_validate_pdf_source_empty_key():
 
 @pytest.mark.asyncio
 async def test_validate_by_type_url_valid():
-	"""validate_by_type dispatches to URL validation for 'url' type."""
+	"""validate_by_type dispatches URL validation with no network HEAD (#322)."""
 	validator = make_validator()
-	mock_response = MagicMock()
-	mock_response.status_code = 200
-
 	with patch("src.services.source_validator_service.httpx.AsyncClient") as mock_client_cls:
-		mock_client = AsyncMock()
-		mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-		mock_client.__aexit__ = AsyncMock(return_value=None)
-		mock_client.head = AsyncMock(return_value=mock_response)
-		mock_client_cls.return_value = mock_client
-
-		# Should not raise
+		# Should not raise and should not touch the network.
 		await validator.validate_by_type(
 			source_type='url',
 			source_data={'url': 'https://example.com', 'title': 'Test'},
 		)
+	mock_client_cls.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/unit/test_team_service_unit.py
+++ b/apps/api/tests/unit/test_team_service_unit.py
@@ -190,6 +190,70 @@ class TestAcceptInvitationAlreadyMember:
 		assert "already a member" in exc.value.detail.lower()
 
 
+class TestGetMemberCounts:
+	@pytest.mark.asyncio
+	async def test_grouped_counts_active_only(self, test_db, client):
+		owner_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		team_a = await team_service.create_team(test_db, owner_id, TeamCreate(name="Counts A"))
+		team_b = await team_service.create_team(test_db, owner_id, TeamCreate(name="Counts B"))
+
+		# team_a: one extra active member plus a suspended one (suspended excluded).
+		active_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		suspended_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		test_db.add(TeamMember(team_id=team_a.id, user_id=active_id, role="viewer", status="active"))
+		test_db.add(TeamMember(team_id=team_a.id, user_id=suspended_id, role="viewer", status="suspended"))
+		await test_db.commit()
+
+		counts = await team_service.get_member_counts(test_db, [team_a.id, team_b.id])
+		assert counts[team_a.id] == 2  # owner + one active member
+		assert counts[team_b.id] == 1  # owner only
+
+	@pytest.mark.asyncio
+	async def test_empty_team_ids_returns_empty_dict(self, test_db):
+		assert await team_service.get_member_counts(test_db, []) == {}
+
+	@pytest.mark.asyncio
+	async def test_team_with_no_active_members_absent_from_dict(self, test_db, client):
+		owner_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		team = await team_service.create_team(test_db, owner_id, TeamCreate(name="All Suspended"))
+		for m in await team_service.get_members(test_db, team.id):
+			m.status = "suspended"
+		await test_db.commit()
+
+		counts = await team_service.get_member_counts(test_db, [team.id])
+		assert team.id not in counts
+
+
+class TestCountTeamsForUser:
+	@pytest.mark.asyncio
+	async def test_counts_active_memberships(self, test_db, client):
+		owner_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		await team_service.create_team(test_db, owner_id, TeamCreate(name="CT 1"))
+		await team_service.create_team(test_db, owner_id, TeamCreate(name="CT 2"))
+		assert await team_service.count_teams_for_user(test_db, owner_id) == 2
+
+
+class TestGetTeamsForUserPagination:
+	@pytest.mark.asyncio
+	async def test_limit_and_offset_slice_ordered_by_created_at(self, test_db, client):
+		owner_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		names = [f"Page Team {i}" for i in range(3)]
+		for n in names:
+			await team_service.create_team(test_db, owner_id, TeamCreate(name=n))
+
+		page1 = await team_service.get_teams_for_user(test_db, owner_id, limit=2, offset=0)
+		page2 = await team_service.get_teams_for_user(test_db, owner_id, limit=2, offset=2)
+		assert [t.name for t in page1] == names[:2]
+		assert [t.name for t in page2] == names[2:]
+
+	@pytest.mark.asyncio
+	async def test_no_limit_returns_all(self, test_db, client):
+		owner_id = await _register_user(client, email_prefix="team_unit_", full_name="Team Unit Test User")
+		for i in range(3):
+			await team_service.create_team(test_db, owner_id, TeamCreate(name=f"All Team {i}"))
+		assert len(await team_service.get_teams_for_user(test_db, owner_id)) == 3
+
+
 class TestAcceptInvitationSuccess:
 	@pytest.mark.asyncio
 	async def test_accept_creates_active_membership(self, test_db, client):

--- a/apps/api/tests/unit/test_url_reachability_task.py
+++ b/apps/api/tests/unit/test_url_reachability_task.py
@@ -1,0 +1,134 @@
+"""
+Unit tests for the URL reachability Celery task (issue #322).
+
+Reachability moved off the create request path; these cover the async helper
+(_validate_url_reachability_async) and the task surface
+(validate_url_reachability_task) with celery_async_session, the content lookup,
+and the network HEAD all mocked — mirroring test_extract_content_async.py.
+"""
+
+import inspect
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from src.services.source_validator_service import URLValidationError
+
+
+def _make_async_context_manager(db_mock):
+	cm = AsyncMock()
+	cm.__aenter__ = AsyncMock(return_value=db_mock)
+	cm.__aexit__ = AsyncMock(return_value=False)
+	return cm
+
+
+def _url_source(url="https://example.com/a"):
+	src = MagicMock()
+	src.source_type = "url"
+	src.source_data = {"url": url}
+	src.extraction_status = "pending"
+	src.error_message = None
+	return src
+
+
+@pytest.mark.asyncio
+async def test_reachable_url_leaves_status_pending():
+	"""A reachable URL returns 'reachable' and does not touch status/commit."""
+	from src.tasks.content_extraction import _validate_url_reachability_async
+
+	mock_db = AsyncMock()
+	source = _url_source()
+	with patch("src.database.celery_async_session", return_value=_make_async_context_manager(mock_db)), \
+	     patch("src.services.content_service.get_content_source_by_id", AsyncMock(return_value=source)), \
+	     patch("src.services.source_validator_service.SourceValidatorService._check_url_accessibility", AsyncMock()):
+		result = await _validate_url_reachability_async(str(uuid4()))
+
+	assert result["status"] == "reachable"
+	assert source.extraction_status == "pending"
+	mock_db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unreachable_url_marks_failed_and_commits():
+	"""An unreachable URL is marked extraction_status='failed' with the error."""
+	from src.tasks.content_extraction import _validate_url_reachability_async
+
+	mock_db = AsyncMock()
+	source = _url_source()
+	with patch("src.database.celery_async_session", return_value=_make_async_context_manager(mock_db)), \
+	     patch("src.services.content_service.get_content_source_by_id", AsyncMock(return_value=source)), \
+	     patch(
+	         "src.services.source_validator_service.SourceValidatorService._check_url_accessibility",
+	         AsyncMock(side_effect=URLValidationError("URL returned HTTP 404.")),
+	     ):
+		result = await _validate_url_reachability_async(str(uuid4()))
+
+	assert result["status"] == "failed"
+	assert "404" in result["error_message"]
+	assert source.extraction_status == "failed"
+	assert source.error_message == "URL returned HTTP 404."
+	mock_db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_source_raises_value_error():
+	"""A missing content source raises ValueError (permanent — no retry)."""
+	from src.tasks.content_extraction import _validate_url_reachability_async
+
+	mock_db = AsyncMock()
+	with patch("src.database.celery_async_session", return_value=_make_async_context_manager(mock_db)), \
+	     patch("src.services.content_service.get_content_source_by_id", AsyncMock(return_value=None)):
+		with pytest.raises(ValueError, match="not found"):
+			await _validate_url_reachability_async(str(uuid4()))
+
+
+@pytest.mark.asyncio
+async def test_non_url_source_is_skipped():
+	"""A non-URL source is a no-op (defensive — only URL sources are dispatched)."""
+	from src.tasks.content_extraction import _validate_url_reachability_async
+
+	mock_db = AsyncMock()
+	source = _url_source()
+	source.source_type = "text"
+	with patch("src.database.celery_async_session", return_value=_make_async_context_manager(mock_db)), \
+	     patch("src.services.content_service.get_content_source_by_id", AsyncMock(return_value=source)):
+		result = await _validate_url_reachability_async(str(uuid4()))
+
+	assert result["status"] == "skipped"
+
+
+def test_task_signature_accepts_content_source_id():
+	from src.tasks.content_extraction import validate_url_reachability_task
+	assert "content_source_id" in inspect.signature(validate_url_reachability_task.run).parameters
+
+
+def test_task_returns_failed_on_value_error_no_retry():
+	"""ValueError (missing source) is permanent — return failed, do not retry."""
+	from src.tasks.content_extraction import validate_url_reachability_task
+
+	with patch("src.tasks.content_extraction._validate_url_reachability_async", MagicMock()), \
+	     patch("src.tasks.content_extraction.asyncio.run", MagicMock(side_effect=ValueError("Content source x not found"))):
+		with patch.object(validate_url_reachability_task, "update_state"):
+			result = validate_url_reachability_task.run(content_source_id=str(uuid4()))
+
+	assert result["status"] == "failed"
+	assert "not found" in result["error_message"].lower()
+
+
+def test_task_retries_on_transient_error():
+	"""A transient (non-ValueError) error attempts retry."""
+	from src.tasks.content_extraction import validate_url_reachability_task
+
+	with patch("src.tasks.content_extraction._validate_url_reachability_async", MagicMock()), \
+	     patch("src.tasks.content_extraction.asyncio.run", MagicMock(side_effect=ConnectionError("boom"))):
+		with patch.object(validate_url_reachability_task, "update_state"), \
+		     patch.object(
+		         validate_url_reachability_task,
+		         "retry",
+		         side_effect=validate_url_reachability_task.MaxRetriesExceededError(),
+		     ) as mock_retry:
+			result = validate_url_reachability_task.run(content_source_id=str(uuid4()))
+
+	assert result["status"] == "failed"
+	mock_retry.assert_called_once()

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,82 +1,69 @@
-# Issue #321 — [P5.5] Blocking synchronous boto3 calls in async handlers (self-authored plan)
+# Issue #322 — [P5.6] Backend performance: N+1 team counts, inline external URL HEAD blocking creates, per-event analytics commits, unindexed episode search (self-authored plan)
 
-Plan source: self-authored (no plan comment on the issue).
-Verified against `main` @ `1b3d76c`, 2026-07-19.
+Plan source: self-authored (no plan comment on the issue; CodeRabbit "Create Plan" checkbox unchecked).
+Verified against `main` @ `5d0da07`, 2026-07-19.
 
-## Verified current state (issue line refs re-checked against live code — they drifted)
+## Verified current state (issue line refs re-checked against live code)
 
 | Issue claim | Verdict | Evidence |
 |---|---|---|
-| Download handler calls `head_object` synchronously | TRUE | `apps/api/src/routers/episodes.py:407-413` (issue said :362) |
-| Download handler calls `get_object` synchronously | TRUE | `episodes.py:434-446` ×2 (range + non-range; issue said :389-398) |
-| `StorageService.delete_file` calls boto3 directly in `async def` | TRUE | `apps/api/src/services/storage_service.py:132-146` → `delete_object` at :140 |
-| `StorageService.file_exists` calls boto3 directly in `async def` | TRUE | `storage_service.py:177-195` → `head_object` at :188 |
-| `upload_file`/`download_file` already offloaded | TRUE | `storage_service.py:82-98`, :114-130 — `await asyncio.to_thread(...)` is the established idiom |
+| N+1 COUNT per team on list, no pagination cap | TRUE | `apps/api/src/routers/teams.py:55-63` loops `_team_response` (:32-36) → `team_service.get_member_count` per team (`team_service.py:109-117`); `get_teams_for_user` (:75-83) has no limit |
+| `create_content_source` awaits external HEAD, ≤4 hops × 10s | TRUE | `apps/api/src/routers/content.py:96-107` calls `SourceValidatorService.validate_by_type` synchronously → `validate_url_source` (`source_validator_service.py:238-257`) → `_check_url_accessibility` (:112-198): ≤4 sequential HEADs, 10s each |
+| Analytics track: 2 validation SELECTs + commit + refresh per event | TRUE | `apps/api/src/routers/analytics.py:47-62` (2 SELECTs) → `analytics_service.py:24-58` `db.add`/`commit`/`refresh` |
+| Leading-wildcard JSONB ILIKE, no usable index, no created_at index | TRUE | `apps/api/src/services/episode_service.py:165-173` `ilike("%term%")` on `episode_metadata['title'/'description'].astext`; existing GIN is `jsonb_path_ops` (containment-only, migration 002); `idx_episodes_title` btree can't serve leading wildcard; no `created_at` index; `pg_trgm` unused in repo |
 
-In-scope blocking calls: exactly the 4 above (`head_object`×2, `get_object`×2, `delete_object`×1).
-Confirmed NOT in scope (verified by full sweep of `apps/api/src`):
-- `storage_service.py:164` `generate_presigned_url` — CPU-only local signing, no network I/O; existing convention leaves it sync.
-- `episodes.py:415` `os.path.getsize` — local filesystem stat, not network-bound.
-- `tasks/audio_composition.py`, `tasks/s3_upload.py` — plain sync Celery tasks, no event loop.
-- Every other S3 touch point already goes through the offloaded wrappers.
-
-Callers that benefit with no change needed: `rss_feed.py:313` (public audio route → `file_exists`),
-`audio_snippet_service.py:309` (`delete_file`), `tasks/maintenance.py:150` (`asyncio.run` → `delete_file`).
+Key leverage found during exploration:
+- `extract_content_task` already runs on every create (`auto_extract=True` default) and `extract_from_url` **re-fetches the URL itself** with strict SSRF-safe pinned GET — the create-time HEAD is a redundant fail-fast pre-check for the default path.
+- Codebase background idiom is Celery (no in-process buffering anywhere). Task dispatch from routers is always try/except "broker down must never fail the request".
+- RLS precedent for workers: `billing_service.py:277-280` arms tenant context on a non-request session; `analytics_events` has FORCE RLS (migration 014) so a worker-side insert must `set_tenant_context(tenant_id)`.
+- Grouped-COUNT idiom already exists in `analytics_service.py:80-86`.
+- Migration pattern for indexes on populated tables (issue #318): `autocommit_block()` + `DROP INDEX IF EXISTS` + `postgresql_concurrently=True` (see `005_add_fk_indexes.py:39-47`); latest migration is `017`, next is `018`.
 
 ## Steps (TDD: tests first, RED)
 
-1. **Tests (RED) — storage service** — extend `apps/api/tests/unit/test_storage_service.py`:
-   - `delete_file` offloads: patch `asyncio.to_thread` with an AsyncMock whose side_effect invokes the
-     func synchronously; assert awaited once with `service.s3_client.delete_object` and
-     `Bucket`/`Key` kwargs; assert `delete_object` itself was NOT called directly on the mock's thread path.
-   - `file_exists` offloads: same pattern for `service.s3_client.head_object`.
-   - Existing behavior tests (`test_delete_file_success`, `test_file_exists_*`) must keep passing unchanged
-     (plain MagicMock survives `to_thread`).
+1. **Tests (RED) — teams bulk counts + list cap**
+   - `apps/api/tests/unit/test_team_service_unit.py`: tests for new `get_member_counts(db, team_ids)` — grouped counts, active-only, teams with zero active members absent from dict; and `count_teams_for_user`.
+   - `apps/api/tests/test_teams.py`: list with multiple teams returns correct `member_count` per team; with `team_service.get_member_count` (singular) patched to raise, list still returns 200 (proves no per-team COUNT); `limit`/`offset` honored; `total` reflects full count beyond the page.
 
-2. **Implement storage service** — `storage_service.py`:
-   - `delete_file`: `await asyncio.to_thread(self.s3_client.delete_object, Bucket=..., Key=...)`
-   - `file_exists`: `await asyncio.to_thread(self.s3_client.head_object, Bucket=..., Key=...)`
-   - Reuse the verbatim idiom + comment style from `upload_file`/`download_file`
-     ("boto3 is synchronous; run it off the event loop …"), citing `#321`. 4-space indent file.
+2. **Implement teams** — `team_service.py`: add `get_member_counts` (grouped `func.count()` on `team_members`, `team_id.in_(...)`, `status == "active"`, mirroring `analytics_service.py:80-86`), `count_teams_for_user`, and `limit`/`offset` params on `get_teams_for_user`. `routers/teams.py`: list endpoint gains `limit: int = Query(100, ge=1, le=500)`, `offset: int = Query(0, ge=0)`; one teams query + one total COUNT + one grouped member-count query (constant 3 queries); build responses from the counts dict. Keep `_team_response`/`get_member_count` for single-team endpoints. No migration (`team_members.team_id` already indexed).
 
-3. **Tests (RED) — download endpoint** — extend `apps/api/tests/test_download_endpoint.py`:
-   - Wrap `client.get(.../download)` in `patch("asyncio.to_thread", side_effect=<async passthrough>)`;
-     assert it was awaited for `head_object` and `get_object` (≥2 awaits, bound methods of the mocked
-     `s3_client` as first arg).
-   - Existing download tests (full/range/local-file/404/403/416) must keep passing unchanged.
+3. **Tests (RED) — URL reachability off the request path**
+   - `apps/api/tests/unit/test_source_validation.py` (**tabs** — preserve): `validate_url_source` no longer performs HEAD (mocked `httpx.AsyncClient` never called); format/SSRF failures still raise `URLValidationError`. Keep/adjust direct `_check_url_accessibility` tests (method stays, used by the background task).
+   - `apps/api/tests/test_content.py`: GAP-015 unreachable/timeout/redirect-loop creates now return **201** (contract change per AC); assert `extract_content_task.delay` still dispatched for `auto_extract=True`; assert new `validate_url_reachability_task.delay` dispatched when `source_type='url'` and `auto_extract=False`; SSRF/format 422s unchanged.
 
-4. **Implement router** — `episodes.py` (tab-indented file — preserve tabs):
-   - Add `import asyncio`.
-   - `head_response = await asyncio.to_thread(storage.s3_client.head_object, Bucket=..., Key=...)`
-   - Both `s3_response = storage.s3_client.get_object(...)` → `await asyncio.to_thread(storage.s3_client.get_object, ...)`
-   - Keep `iter_s3_body` streaming unchanged (it already offloads per-chunk reads via `to_thread`,
-     `download_utils.py:180-198`).
+4. **Implement URL validation change** — `source_validator_service.py`: `validate_url_source` runs format + SSRF only; `_check_url_accessibility` kept for the task. `src/tasks/content_extraction.py` (module already in worker `include`): add `validate_url_reachability_task` (sync wrapper + `asyncio.run` impl on `celery_async_session`, per file idiom): run `_check_url_accessibility`; on failure set `extraction_status='failed'` + `error_message`; on success leave `pending`. `routers/content.py`: after insert, when `source_type == 'url'` and `auto_extract` is False, dispatch it (lazy import, try/except log — never fail creation). Sweep for other `validate_by_type` callers (e.g. content update endpoint) and apply the same behavior.
 
-5. **Gates** — `cd apps/api && uv run pytest tests/` (coverage ≥85), `ruff check .`, deslop scan,
-   opencode/GLM review pre-PR, demo per AC, PR, post-PR review, CI, docs sync, merge.
+5. **Tests (RED) — analytics queued**
+   - `apps/api/tests/test_analytics.py`: patch the new task; assert 201 body still carries `id`, `created_at`, `event_metadata`; assert task dispatched with full payload (incl. `tenant_id`); 404 validation behavior unchanged; update any round-trip tests that read events back after tracking (seed directly or run the task body inline).
+   - New `apps/api/tests/unit/test_analytics_track_task.py`: worker task inserts `AnalyticsEvent` with the given id/created_at, arms `set_tenant_context(tenant_id)` before insert, commits once, does not retry on `IntegrityError`.
+
+6. **Implement analytics queue** — `analytics_service.py::track_event`: build the event payload (id=`uuid4()`, `created_at=utcnow()`, hashed IP, device/app detection, `tenant_id`) with **no DB write**, return payload. New `src/tasks/analytics.py` (register in `worker.py` `include` + `task_routes`): `track_analytics_event_task` — `celery_async_session()` + `set_tenant_context(tenant_id)` → insert → single commit; retry ×3 backoff on transient errors, no retry on `IntegrityError`. `routers/analytics.py`: keep the 2 validation SELECTs (preserves 404 contract), dispatch in try/except (broker down → log, still 201), return `AnalyticsEventResponse` built from the payload. `refresh` gone everywhere.
+
+7. **Tests (RED) — migration 018 unit test** — `apps/api/tests/unit/test_migration_018_episode_search_indexes.py` (importlib-load by path, mock `alembic.op`, per `test_migration_005/006` convention): assert `CREATE EXTENSION IF NOT EXISTS pg_trgm`; two GIN `gin_trgm_ops` expression indexes on `(episode_metadata->>'title')` and `(episode_metadata->>'description')`; one btree on `created_at`; all three inside `autocommit_block()` with `DROP INDEX IF EXISTS` rerun guards + `postgresql_concurrently=True`; downgrade drops them.
+
+8. **Implement migration 018** — `apps/api/alembic/versions/018_episode_search_indexes.py` following `005_add_fk_indexes.py` pattern. Apply locally with `alembic upgrade head` so integration tests run against the migrated DB.
+
+9. **Gates** — `cd apps/api && uv run pytest tests/` (coverage ≥85), `ruff check .`, deslop scan, opencode/GLM cross-family review pre-PR, demo per AC (Showboat), PR with Known Limitations, post-PR review, CI green + feedback triage, docs sync, merge.
 
 ## Acceptance criteria checklist
-- [ ] AC1 All network-bound boto3 calls in async paths wrapped in `await asyncio.to_thread(...)`
-      (steps 2, 4 — the 4 verified call sites)
-- [ ] AC2 No new sync boto3 calls in async paths (step 5 — grep sweep in quality gate +
-      reviewer checklist item)
+- [x] AC1 Member counts batched in one grouped query + list size capped (steps 1–2) — `get_member_counts`/`count_teams_for_user` + `limit`/`offset` Query params; regression test patches singular `get_member_count` to raise
+- [x] AC2 URL reachability moved to background; create does inline format/SSRF validation only (steps 3–4) — `validate_url_source` drops HEAD; `validate_url_reachability_task` for `auto_extract=False`; unreachable create now 201
+- [x] AC3 Analytics events queued; per-event commit off the request path; `refresh` dropped (steps 5–6) — `build_event_payload` (no DB write) + `track_analytics_event_task`; response built from in-process id/created_at
+- [x] AC4 `pg_trgm` + GIN indexes on episode_metadata title/description expressions and btree on `created_at` (steps 7–8) — migration 018; EXPLAIN confirms `idx_episodes_metadata_title_trgm`/`_description_trgm` (Bitmap Index Scan) and `idx_episodes_created_at` (Index Scan) are used
 
 ## Autonomous decisions (no architectural fork)
-- **`asyncio.to_thread` over presigned-URL redirect.** The issue sanctions both; `to_thread` is the
-  listed-first option and the minimal change. A 302 redirect would change endpoint semantics (auth is
-  checked once at redirect time, URL then reusable), drop server-side Range handling, and force rewriting
-  the existing download test suite. The streaming path already offloads chunk reads — only the initial
-  HEAD/GET block. Not a fork: safe default exists.
-- **`generate_presigned_url` left sync** — CPU-only (no network); matches existing code's own convention
-  and the issue's "network-bound" wording.
-- **Fix `StorageService` internals rather than every caller** — `rss_feed.py:313` and
-  `audio_snippet_service.py:309` are fixed for free; no call-site churn.
-- **Tests assert offload via patched `asyncio.to_thread`** rather than timing-based event-loop probes —
-  deterministic, no flaky sleeps.
+- **`pg_trgm` GIN over full-text search.** AC lists pg_trgm first with FTS as "(or …)" alternative; pg_trgm preserves the exact current substring-match semantics (FTS would change tokenization/ranking behavior and API-visible results). Safe default.
+- **Celery queue for analytics** over in-process buffering or an outbox table. Celery is the only background idiom in this codebase (generation, extraction, RSS refresh all use it); in-process buffers lose events on restart and have no precedent. Trade-off accepted per the codebase's own rule ("broker down must never fail the request"): a broker outage loses queued events with a logged warning — analytics are already fire-and-forget from the frontend (`apps/web/.../episodes/[id]/page.tsx:582`). Will be disclosed in PR Known Limitations.
+- **Keep the 2 request-side validation SELECTs on track.** The hazard is the write path (commit+refresh); the SELECTs preserve the 404 contract and tenant-scoped validation. Only the INSERT moves to the worker.
+- **Response contract preserved on track (201 + id/created_at/event_metadata)** by generating `id`/`created_at` in-process — no DB read needed to answer.
+- **Reachability for `auto_extract=False` URLs** gets a lightweight `validate_url_reachability_task` (placed in the already-included `content_extraction` task module — zero worker config change); the default `auto_extract=True` path is covered by extraction's existing re-fetch, so no double-fetch.
+- **422→201 contract change for unreachable URLs** is mandated by the AC ("inline only format/SSRF validation"); failure now surfaces as `extraction_status='failed'` + `error_message`. Existing GAP-015 tests encoding the old contract get updated.
+- **`TeamListResponse.total` becomes the true full count** (one cheap COUNT query) so the cap is usable by a pagination UI; `limit` default 100 / max 500 keeps the current response shape and passes existing tests (`total==0/2` cases stay valid).
 
 ## Risks / notes
-- `filterwarnings = error` is live (#348) — no new warnings tolerated.
-- Coverage gate ≥85% (#345) — the new tests add branches, not uncovered code.
-- `episodes.py` uses tabs; `storage_service.py` uses 4 spaces — preserve each file's style.
-- `patch("asyncio.to_thread")` patches the module globally for the duration of the test — acceptable in
-  test scope; ensure passthrough side_effect so the handler body still executes.
+- Tests require local PostgreSQL (`TEST_DATABASE_URL`, role `podcastfy_app`) with migrations applied — check `pg_isready` and run `alembic upgrade head` before pytest.
+- `filterwarnings = error` and `--strict-markers` live; coverage gate ≥85%.
+- Indentation: `test_source_validation.py` and parts of `test_content.py` use tabs; `team_service.py` uses 4 spaces — preserve each file's style.
+- Worker-side analytics insert runs under FORCE RLS — must `set_tenant_context` (missing setting → NULL → WITH CHECK failure), precedent `billing_service.py:277-280`.
+- `test_migration_metadata.py` compares table sets only — index-only migration needs no model change.
+- New Celery task module `src/tasks/analytics.py` must be added to `worker.py` `include` or the worker never registers it.


### PR DESCRIPTION
## Summary

Fixes the four backend scaling hazards in **#322** (P5.6 production-readiness audit). Each is independent; all fixed under TDD.

| AC | Hazard | Fix |
|----|--------|-----|
| **AC1** | `GET /teams` ran one COUNT per team (N+1), no page cap | Single grouped `get_member_counts` + `count_teams_for_user`; `limit` (default 100, ≤500) / `offset`. Constant **3 queries** regardless of team count. |
| **AC2** | `create_content_source` awaited an external HEAD (≤4 hops × 10s ≈ 40s) inline | `validate_url_source` now does format + SSRF only. Reachability moved off the request path: the default `auto_extract=True` path is covered by extraction's existing re-fetch; `auto_extract=False` gets a new `validate_url_reachability_task`. |
| **AC3** | Analytics `track` did 2 SELECTs + commit + refresh **per event** on the request path | `build_event_payload` mints id/created_at in-process (no DB write); the insert moves to `track_analytics_event_task` (armed tenant context). The 201 is built from the payload — commit + refresh leave the hot path. |
| **AC4** | Episode search: leading-wildcard JSONB ILIKE + unindexed `created_at` → seq scans | Migration **018**: `pg_trgm` + GIN `gin_trgm_ops` expression indexes on `episode_metadata->>'title'`/`'description'` + btree on `created_at`, all `CONCURRENTLY` in an autocommit block (#318 pattern). |

## Outcome evidence

**AC4** — `EXPLAIN` on a migrated DB (`enable_seqscan=off`) confirms the planner uses the new indexes for the exact expressions `episode_service.list_episodes` generates:

```
Bitmap Heap Scan on episodes
  ->  BitmapOr
        ->  Bitmap Index Scan on idx_episodes_metadata_title_trgm
        ->  Bitmap Index Scan on idx_episodes_metadata_description_trgm
Index Scan Backward using idx_episodes_created_at   (ORDER BY created_at)
```

**AC1** — regression test patches the singular `get_member_count` to raise; the list still returns 200 with correct per-team counts, proving no per-team COUNT.

**AC2/AC3** — tests assert the create/track endpoints dispatch the new tasks (with full payload) and that a broker outage still returns 201.

## Tests

TDD throughout. Backend suite green, coverage **94.66%** (gate 85%). New/updated: `test_team_service_unit`, `test_teams`, `test_source_validation`, `test_content`, `test_url_reachability_task`, `test_analytics`, `test_analytics_track_task`, `test_migration_018_episode_search_indexes`.

## Behavioral / contract changes

- **`GET /teams`** gains `limit`/`offset` query params; `total` is now the full membership count (was the page length). Response shape unchanged.
- **Unreachable/timeout URL content creates now return 201** (was 422). This is mandated by AC2 ("inline only format/SSRF validation"). Failure now surfaces asynchronously as `extraction_status='failed'` + `error_message`. SSRF/format failures still 422.
- **`POST /analytics/events`** returns 201 with an id/created_at generated in-process; the row is written asynchronously (eventual consistency).

## Known limitations

- **Analytics durability**: events are queued to Celery, not written in a transaction with the request. A broker outage drops the event with a logged warning (never fails the request) — analytics are already fire-and-forget from the frontend. Chosen over an outbox table because Celery is this codebase's only background idiom.
- **Read-after-write on analytics**: a client that tracks an event and immediately reads aggregates may not see it yet (worker lag). Acceptable for engagement analytics.
- **`pg_trgm` over full-text search**: preserves exact current substring semantics (FTS would change tokenization/ranking and API-visible results).
- **`pg_trgm` extension is not dropped on downgrade** (a shared extension other objects may depend on).

## RLS note

`track_analytics_event_task` arms `set_tenant_context` before the insert even though the Celery role is BYPASSRLS — a one-line, no-op-under-superuser guard that keeps the insert correct if a deployment ever wires the worker's `DATABASE_URL` to the RLS-enforced role (matches the `billing_service` precedent). The reachability task mirrors its sibling `extract_content_task` (no arming needed for the same role).

Closes #322
