### PR TITLE
fix(web): resolve frontend accessibility defects (#323)

### DIFF
--- a/apps/web/__tests__/app/authLayout.test.tsx
+++ b/apps/web/__tests__/app/authLayout.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import AuthLayout from '@/app/(auth)/layout'
+
+// The nav's internals (session, theme, dropdown) are covered by MainNav's own
+// test; here we only care that the layout owns a single <main> landmark placed
+// after the nav — the structure that makes the skip link work (issue #323).
+jest.mock('@/components/navigation/MainNav', () => ({
+  MainNav: () => <nav aria-label="Main navigation">nav</nav>,
+}))
+
+describe('AuthLayout landmark structure', () => {
+  it('renders exactly one <main> and it is the skip-link target', () => {
+    render(<AuthLayout><p>content</p></AuthLayout>)
+
+    const mains = screen.getAllByRole('main')
+    expect(mains).toHaveLength(1)
+    expect(mains[0]).toHaveAttribute('id', 'main-content')
+    expect(mains[0]).toHaveTextContent('content')
+  })
+
+  it('places the nav before the main so "skip to main content" skips the nav', () => {
+    render(<AuthLayout><p>content</p></AuthLayout>)
+
+    const nav = screen.getByRole('navigation')
+    const main = screen.getByRole('main')
+    // nav must appear earlier in the document than main
+    expect(nav.compareDocumentPosition(main) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    // and the nav must not be nested inside the main
+    expect(main.contains(nav)).toBe(false)
+  })
+})

--- a/apps/web/__tests__/app/dashboard/page.test.tsx
+++ b/apps/web/__tests__/app/dashboard/page.test.tsx
@@ -117,22 +117,16 @@ describe('DashboardPage', () => {
     expect(screen.getByLabelText(/project title/i)).toBeInTheDocument()
   })
 
-  it('navigates to the project page when a card is clicked', async () => {
+  it('links the project title to the project page (link, not a role=button card)', async () => {
     global.fetch = mockFetchRouter()
     render(<DashboardPage />)
 
-    await userEvent.click(await screen.findByRole('button', { name: /open project: my first podcast/i }))
-    expect(mockPush).toHaveBeenCalledWith('/projects/1')
-  })
-
-  it('navigates to the project page on Enter key', async () => {
-    global.fetch = mockFetchRouter()
-    render(<DashboardPage />)
-
-    const card = await screen.findByRole('button', { name: /open project: my first podcast/i })
-    card.focus()
-    await userEvent.keyboard('{Enter}')
-    expect(mockPush).toHaveBeenCalledWith('/projects/1')
+    const link = await screen.findByRole('link', { name: /open project: my first podcast/i })
+    expect(link).toHaveAttribute('href', '/projects/1')
+    // the card itself must not masquerade as a button wrapping other controls
+    expect(screen.queryByRole('button', { name: /open project: my first podcast/i })).not.toBeInTheDocument()
+    // Edit/Delete remain reachable as siblings of the title link
+    expect(screen.getByRole('button', { name: 'Edit My First Podcast' })).toBeInTheDocument()
   })
 
   it('creates a project and reloads the list', async () => {

--- a/apps/web/__tests__/app/login/page.test.tsx
+++ b/apps/web/__tests__/app/login/page.test.tsx
@@ -23,6 +23,22 @@ async function fillAndSubmit() {
 describe('LoginPage', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    window.history.replaceState({}, '', '/login')
+  })
+
+  it('shows the registered confirmation and clears the query param', () => {
+    window.history.replaceState({}, '', '/login?registered=true')
+
+    render(<LoginPage />)
+
+    expect(screen.getByRole('status')).toHaveTextContent(/account created/i)
+    // param cleared so a refresh doesn't re-show the banner
+    expect(window.location.search).toBe('')
+  })
+
+  it('does not show the confirmation without ?registered=true', () => {
+    render(<LoginPage />)
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
   })
 
   it('redirects to /dashboard on successful sign-in', async () => {
@@ -48,6 +64,21 @@ describe('LoginPage', () => {
     expect(await screen.findByText('Invalid email or password')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /sign in/i })).toBeEnabled()
     expect(mockPush).not.toHaveBeenCalled()
+  })
+
+  it('announces the error via role=alert and marks the inputs invalid', async () => {
+    mockSignIn.mockResolvedValue({ error: 'CredentialsSignin' })
+
+    render(<LoginPage />)
+    await fillAndSubmit()
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('Invalid email or password')
+
+    const email = screen.getByLabelText(/email/i)
+    expect(email).toHaveAttribute('aria-invalid', 'true')
+    expect(email).toHaveAttribute('aria-describedby', 'login-error')
+    expect(alert).toHaveAttribute('id', 'login-error')
   })
 
   it('shows a generic error when signIn throws', async () => {

--- a/apps/web/__tests__/app/projects/[id]/page.test.tsx
+++ b/apps/web/__tests__/app/projects/[id]/page.test.tsx
@@ -148,22 +148,15 @@ describe('ProjectPage', () => {
     )
   })
 
-  it('navigates to the episode page when a card is clicked', async () => {
+  it('links the episode title to the episode page (link, not a role=button card)', async () => {
     global.fetch = mockFetchRouter()
     render(<ProjectPage />)
 
-    await userEvent.click(await screen.findByRole('button', { name: /open episode: pilot/i }))
-    expect(mockPush).toHaveBeenCalledWith('/episodes/e1')
-  })
-
-  it('navigates to the episode page on Enter key', async () => {
-    global.fetch = mockFetchRouter()
-    render(<ProjectPage />)
-
-    const card = await screen.findByRole('button', { name: /open episode: pilot/i })
-    card.focus()
-    await userEvent.keyboard('{Enter}')
-    expect(mockPush).toHaveBeenCalledWith('/episodes/e1')
+    const link = await screen.findByRole('link', { name: /open episode: pilot/i })
+    expect(link).toHaveAttribute('href', '/episodes/e1')
+    // the card itself must not masquerade as a button wrapping the badge + controls
+    expect(screen.queryByRole('button', { name: /open episode: pilot/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit Pilot' })).toBeInTheDocument()
   })
 
   it('creates an episode and navigates to it', async () => {

--- a/apps/web/__tests__/app/signup/page.test.tsx
+++ b/apps/web/__tests__/app/signup/page.test.tsx
@@ -57,4 +57,21 @@ describe('SignupPage', () => {
     expect(screen.getByRole('button', { name: /sign up/i })).toBeEnabled()
     expect(mockPush).not.toHaveBeenCalled()
   })
+
+  it('announces the error via role=alert and marks the inputs invalid', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: false, json: async () => ({ detail: 'Email taken' }) }) as jest.Mock
+
+    render(<SignupPage />)
+    await fillAndSubmit()
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('Email taken')
+    expect(alert).toHaveAttribute('id', 'signup-error')
+
+    const email = screen.getByLabelText(/email/i)
+    expect(email).toHaveAttribute('aria-invalid', 'true')
+    expect(email).toHaveAttribute('aria-describedby', 'signup-error')
+  })
 })

--- a/apps/web/__tests__/components/ToastProvider.test.tsx
+++ b/apps/web/__tests__/components/ToastProvider.test.tsx
@@ -16,17 +16,36 @@ jest.mock('sonner', () => ({
   ),
 }))
 
+let mockResolvedTheme: 'light' | 'dark' = 'light'
+jest.mock('@/components/providers/theme-provider', () => ({
+  useTheme: () => ({ resolvedTheme: mockResolvedTheme }),
+}))
+
 describe('ToastProvider', () => {
   it('renders the Toaster with correct default props', () => {
+    mockResolvedTheme = 'light'
     render(<ToastProvider />)
 
     const toaster = screen.getByTestId('toaster')
     expect(toaster).toBeInTheDocument()
     expect(toaster).toHaveAttribute('data-position', 'top-right')
     expect(toaster).toHaveAttribute('data-rich-colors', 'true')
-    expect(toaster).toHaveAttribute('data-theme', 'light')
     expect(toaster).toHaveAttribute('data-expand', 'true')
     expect(toaster).toHaveAttribute('data-visible-toasts', '3')
     expect(toaster).toHaveAttribute('data-close-button', 'true')
+  })
+
+  it('binds the toaster theme to the resolved theme (dark mode is not stuck on light)', () => {
+    mockResolvedTheme = 'dark'
+    render(<ToastProvider />)
+
+    expect(screen.getByTestId('toaster')).toHaveAttribute('data-theme', 'dark')
+  })
+
+  it('uses light theme when the resolved theme is light', () => {
+    mockResolvedTheme = 'light'
+    render(<ToastProvider />)
+
+    expect(screen.getByTestId('toaster')).toHaveAttribute('data-theme', 'light')
   })
 })

--- a/apps/web/src/app/(auth)/dashboard/page.tsx
+++ b/apps/web/src/app/(auth)/dashboard/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect, useCallback } from "react"
+import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useSession } from "next-auth/react"
 import { useForm } from "react-hook-form"
@@ -213,27 +214,32 @@ export default function DashboardPage() {
             {projects.map((project) => (
               <Card
                 key={project.id}
-                className="cursor-pointer hover:shadow-lg transition-shadow focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                role="button"
-                tabIndex={0}
-                aria-label={`Open project: ${project.title}`}
-                onClick={() => router.push(`/projects/${project.id}`)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault()
-                    router.push(`/projects/${project.id}`)
-                  }
-                }}
+                className="hover:shadow-lg transition-shadow"
               >
                 <CardHeader>
                   <div className="flex justify-between items-start gap-2">
                     <div className="min-w-0">
-                      <CardTitle className="truncate">{project.title}</CardTitle>
+                      {/*
+                        Only the title is the activatable region — the whole
+                        card used to be role=button while wrapping the Edit/Delete
+                        buttons, which is invalid ARIA (a control nesting other
+                        controls). A next/link around the title alone fixes both
+                        the nesting and the full-reload from raw <a href> (#323).
+                      */}
+                      <CardTitle className="truncate">
+                        <Link
+                          href={`/projects/${project.id}`}
+                          aria-label={`Open project: ${project.title}`}
+                          className="rounded hover:underline focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                        >
+                          {project.title}
+                        </Link>
+                      </CardTitle>
                       <CardDescription>
                         {project.description || "No description"}
                       </CardDescription>
                     </div>
-                    <div className="flex gap-1 shrink-0" onClick={(e) => e.stopPropagation()}>
+                    <div className="flex gap-1 shrink-0">
                       <Button
                         variant="ghost"
                         size="sm"

--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -8,7 +8,7 @@ export default function AuthLayout({
   return (
     <div className="min-h-screen bg-background">
       <MainNav />
-      <main>{children}</main>
+      <main id="main-content">{children}</main>
     </div>
   )
 }

--- a/apps/web/src/app/(auth)/projects/[id]/page.tsx
+++ b/apps/web/src/app/(auth)/projects/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect, useCallback } from "react"
+import Link from "next/link"
 import { useRouter, useParams } from "next/navigation"
 import { useSession } from "next-auth/react"
 import { useForm } from "react-hook-form"
@@ -285,20 +286,20 @@ export default function ProjectPage() {
         </Button>
 
         <nav className="flex gap-4 mb-4">
-          <a
+          <Link
             href={`/projects/${params.id}/analytics`}
             className="flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground"
           >
             <HugeiconsIcon icon={Analytics01Icon} size={16} />
             Analytics
-          </a>
-          <a
+          </Link>
+          <Link
             href={`/projects/${params.id}/distribution`}
             className="flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground"
           >
             <HugeiconsIcon icon={RssIcon} size={16} />
             Distribution
-          </a>
+          </Link>
         </nav>
 
         <div className="flex justify-between items-center mb-8">
@@ -338,25 +339,29 @@ export default function ProjectPage() {
             {episodes.map((episode) => (
               <Card
                 key={episode.id}
-                className="cursor-pointer hover:shadow-lg transition-shadow focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                role="button"
-                tabIndex={0}
-                aria-label={`Open episode: ${episode.title}`}
-                onClick={() => router.push(`/episodes/${episode.id}`)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault()
-                    router.push(`/episodes/${episode.id}`)
-                  }
-                }}
+                className="hover:shadow-lg transition-shadow"
               >
                 <CardHeader>
                   <div className="flex justify-between items-start">
                     <div>
-                      <CardTitle>{episode.title}</CardTitle>
+                      {/*
+                        Only the title links to the episode — the card used to be
+                        role=button while wrapping the status badge and Edit/Delete
+                        buttons, which is invalid ARIA (a control nesting controls).
+                        A next/link on the title alone fixes the nesting (#323).
+                      */}
+                      <CardTitle>
+                        <Link
+                          href={`/episodes/${episode.id}`}
+                          aria-label={`Open episode: ${episode.title}`}
+                          className="rounded hover:underline focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                        >
+                          {episode.title}
+                        </Link>
+                      </CardTitle>
                       <CardDescription>{episode.description || "No description"}</CardDescription>
                     </div>
-                    <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+                    <div className="flex items-center gap-1">
                       {getStatusBadge(episode.generation_status)}
                       <Button
                         variant="ghost"

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -41,7 +41,14 @@ export default async function RootLayout({
         <ThemeProvider>
           <AuthProvider>
             <ToastProvider />
-            <main id="main-content">{children}</main>
+            {/*
+              The skip-link target (<main id="main-content">) is owned by each
+              route, not this root layout — otherwise it would wrap the (auth)
+              group's <MainNav>, so "skip to main content" would land the user
+              *before* the nav, and the (auth) layout's own <main> nested a
+              second landmark inside this one (issue #323).
+            */}
+            {children}
           </AuthProvider>
         </ThemeProvider>
       </body>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
+import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { signIn } from "next-auth/react"
 import { Button } from "@/components/ui/button"
@@ -14,6 +15,19 @@ export default function LoginPage() {
   const [password, setPassword] = useState("")
   const [error, setError] = useState("")
   const [loading, setLoading] = useState(false)
+  const [registered, setRegistered] = useState(false)
+
+  // Signup redirects here with ?registered=true. Read window.location.search
+  // (not useSearchParams, which forces a build-time Suspense boundary — same
+  // pattern as the distribution page) and clear the param so a refresh doesn't
+  // re-show the banner (#323).
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    if (params.get("registered") === "true") {
+      setRegistered(true)
+      window.history.replaceState({}, "", window.location.pathname)
+    }
+  }, [])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -40,7 +54,7 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background">
+    <main id="main-content" className="min-h-screen flex items-center justify-center bg-background">
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle>Podcastfy Studio</CardTitle>
@@ -48,6 +62,11 @@ export default function LoginPage() {
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-4">
+            {registered && (
+              <div role="status" className="rounded-md bg-muted p-2 text-sm text-foreground">
+                Account created. Please sign in.
+              </div>
+            )}
             <div>
               <Label htmlFor="email" className="mb-1">
                 Email
@@ -59,6 +78,8 @@ export default function LoginPage() {
                 onChange={(e) => setEmail(e.target.value)}
                 required
                 disabled={loading}
+                aria-invalid={error ? "true" : undefined}
+                aria-describedby={error ? "login-error" : undefined}
               />
             </div>
             <div>
@@ -72,23 +93,27 @@ export default function LoginPage() {
                 onChange={(e) => setPassword(e.target.value)}
                 required
                 disabled={loading}
+                aria-invalid={error ? "true" : undefined}
+                aria-describedby={error ? "login-error" : undefined}
               />
             </div>
             {error && (
-              <div className="text-destructive text-sm">{error}</div>
+              <div id="login-error" role="alert" aria-live="assertive" className="text-destructive text-sm">
+                {error}
+              </div>
             )}
             <Button type="submit" className="w-full" disabled={loading}>
               {loading ? "Signing in..." : "Sign In"}
             </Button>
             <div className="text-center text-sm text-muted-foreground">
               Don&apos;t have an account?{" "}
-              <a href="/signup" className="text-primary hover:underline">
+              <Link href="/signup" className="text-primary hover:underline">
                 Sign up
-              </a>
+              </Link>
             </div>
           </form>
         </CardContent>
       </Card>
-    </div>
+    </main>
   )
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -19,11 +19,11 @@ export default function Home() {
   }, [session, status, router])
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background">
+    <main id="main-content" className="min-h-screen flex items-center justify-center bg-background">
       <div className="text-center">
         <h1 className="text-2xl font-bold text-foreground mb-2">Podcastfy Studio</h1>
         <p className="text-muted-foreground">Loading...</p>
       </div>
-    </div>
+    </main>
   )
 }

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -45,7 +46,7 @@ export default function SignupPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background">
+    <main id="main-content" className="min-h-screen flex items-center justify-center bg-background">
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle>Create Account</CardTitle>
@@ -76,6 +77,8 @@ export default function SignupPage() {
                 onChange={(e) => setEmail(e.target.value)}
                 required
                 disabled={loading}
+                aria-invalid={error ? "true" : undefined}
+                aria-describedby={error ? "signup-error" : undefined}
               />
             </div>
             <div>
@@ -90,23 +93,27 @@ export default function SignupPage() {
                 required
                 minLength={8}
                 disabled={loading}
+                aria-invalid={error ? "true" : undefined}
+                aria-describedby={error ? "signup-error" : undefined}
               />
             </div>
             {error && (
-              <div className="text-destructive text-sm">{error}</div>
+              <div id="signup-error" role="alert" aria-live="assertive" className="text-destructive text-sm">
+                {error}
+              </div>
             )}
             <Button type="submit" className="w-full" disabled={loading}>
               {loading ? "Creating account..." : "Sign Up"}
             </Button>
             <div className="text-center text-sm text-muted-foreground">
               Already have an account?{" "}
-              <a href="/login" className="text-primary hover:underline">
+              <Link href="/login" className="text-primary hover:underline">
                 Sign in
-              </a>
+              </Link>
             </div>
           </form>
         </CardContent>
       </Card>
-    </div>
+    </main>
   )
 }

--- a/apps/web/src/components/navigation/MainNav.tsx
+++ b/apps/web/src/components/navigation/MainNav.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useSession, signOut } from "next-auth/react"
+import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
@@ -46,19 +47,19 @@ export function MainNav() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center gap-4">
-            <a href="/dashboard" className="text-2xl font-bold text-primary">
+            <Link href="/dashboard" className="text-2xl font-bold text-primary">
               Podcastfy Studio
-            </a>
+            </Link>
             <div className="hidden sm:flex items-center gap-1">
               {NAV_LINKS.map((link) => (
-                <a
+                <Link
                   key={link.href}
                   href={link.href}
                   className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-all hover:bg-muted hover:text-foreground"
                 >
                   <HugeiconsIcon icon={link.icon} size={16} />
                   {link.label}
-                </a>
+                </Link>
               ))}
             </div>
           </div>

--- a/apps/web/src/components/providers/toast-provider.tsx
+++ b/apps/web/src/components/providers/toast-provider.tsx
@@ -1,13 +1,15 @@
 "use client"
 
 import { Toaster } from "sonner"
+import { useTheme } from "@/components/providers/theme-provider"
 
 export function ToastProvider() {
+  const { resolvedTheme } = useTheme()
   return (
     <Toaster
       position="top-right"
       richColors
-      theme="light"
+      theme={resolvedTheme}
       expand={true}
       visibleToasts={3}
       closeButton={true}

--- a/tests/e2e/specs/10-integration.spec.ts
+++ b/tests/e2e/specs/10-integration.spec.ts
@@ -46,7 +46,7 @@ test.describe('End-to-End Integration Workflows', () => {
 
 			// 6. Back to dashboard, project listed, then logout
 			await page.goto('/dashboard');
-			await expect(page.getByRole('button', { name: `Open project: ${project.title}` })).toBeVisible();
+			await expect(page.getByRole('link', { name: `Open project: ${project.title}` })).toBeVisible();
 			await logout(page);
 			await expect(page).toHaveURL(/\/login/);
 		});
@@ -335,7 +335,7 @@ test.describe('End-to-End Integration Workflows', () => {
 				// User B's dashboard must not list User A's project.
 				await userBPage.goto('/dashboard');
 				await expect(
-					userBPage.getByRole('button', { name: `Open project: ${userAProject.title}` })
+					userBPage.getByRole('link', { name: `Open project: ${userAProject.title}` })
 				).toHaveCount(0);
 
 				// User B cannot open User A's project directly.

--- a/tests/e2e/utils/project-helpers.ts
+++ b/tests/e2e/utils/project-helpers.ts
@@ -32,8 +32,8 @@ export async function createProject(page: Page, project: ProjectData): Promise<s
   await dialog.locator('button[type="submit"]').click();
   await expect(dialog).toBeHidden({ timeout: 10000 });
 
-  // The new project appears as a clickable card; navigate via it.
-  const card = page.getByRole('button', { name: `Open project: ${project.title}` });
+  // The new project appears as a card whose title is a link; navigate via it.
+  const card = page.getByRole('link', { name: `Open project: ${project.title}` });
   await expect(card).toBeVisible({ timeout: 10000 });
   await card.click();
 


### PR DESCRIPTION
Fixes #323.

Resolves the frontend accessibility defects flagged by the production-readiness audit (P5.7).

## Acceptance criteria

| Criterion | How |
|---|---|
| Single `<main>` with the skip target after nav | Root layout no longer wraps `children` in `<main>` (that pulled the `(auth)` `<MainNav>` *inside* `#main-content` and nested a second `<main>`). Each route now owns exactly one `<main id="main-content">`: the `(auth)` layout places it after `<MainNav>`; login/signup/landing convert their wrapper to `<main>`. |
| Toaster theme follows resolved theme | `ToastProvider` reads `resolvedTheme` from `useTheme()` instead of hardcoded `theme="light"` — toasts are now legible in dark mode. |
| Auth errors announced | Login & signup error containers get `role="alert"` + `aria-live="assertive"` with an `id`; email/password inputs get `aria-invalid` and `aria-describedby` pointing at it when an error is present. |
| Cards don't nest controls in an activatable region | Project/episode cards drop `role="button"`/`tabIndex`/key handlers. The **title** is now a `next/link` (the only activatable region); Edit/Delete are siblings — valid ARIA, no more `stopPropagation` hack. |
| Use `next/link` | Login/signup footer links, `MainNav` logo + nav links, and the project sub-nav (Analytics/Distribution) are now `next/link` — no full reloads. |
| Show post-signup confirmation | Login reads `?registered=true` (via `window.location.search`, matching the distribution page's build-safe pattern), shows a `role="status"` banner, and clears the param. |

## Tests
- New/updated jest coverage for every criterion (toaster theme in light+dark, `(auth)` layout landmark structure, auth-error announcement + aria wiring, card→link restructure, registered confirmation).
- Full suite green: **497 tests**, `tsc --noEmit` clean, `next build` succeeds, eslint clean on changed files.

## Review
- Cross-family review via **opencode (GLM)** timed out (no output after 300s); fell back to an independent in-family **code-reviewer** pass → **No blocking issues**.

## Known limitations
- Next's built-in `/_not-found` page (no `not-found.tsx` in this repo) no longer receives a `#main-content` target now that `<main>` ownership moved to routes. It's a nav-less framework-default 404; adding a custom `not-found.tsx` was out of scope for #323. Reviewer confirmed non-blocking.
