### PR TITLE
fix(#325): populate analytics country so top_countries returns data

### DIFF
--- a/apps/api/src/models/analytics_event.py
+++ b/apps/api/src/models/analytics_event.py
@@ -1,6 +1,8 @@
 """Analytics event model for tracking user engagement"""
 
 import hashlib
+import re
+from typing import Optional
 from sqlalchemy import Column, Text, DateTime, ForeignKey, Index
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
@@ -63,6 +65,34 @@ class AnalyticsEvent(Base):
 def hash_ip(ip: str) -> str:
 	"""SHA-256 hash an IP address for privacy compliance."""
 	return hashlib.sha256(ip.encode()).hexdigest()
+
+
+# ISO 3166-1 alpha-2 shape: exactly two ASCII letters.
+_COUNTRY_CODE_RE = re.compile(r"^[A-Z]{2}$")
+# Cloudflare sentinels that are alpha-2 shaped but mean "no country"
+# (XX = unknown, T1 = Tor exit).
+_COUNTRY_SENTINELS = {"XX", "T1"}
+
+
+def normalize_country(country: Optional[str]) -> Optional[str]:
+	"""Normalize an edge-provided country code for consistent GROUP BY bucketing.
+
+	Trims + uppercases so identical countries aggregate together, then keeps only
+	ISO 3166-1 alpha-2-shaped codes, dropping empties, Cloudflare sentinels
+	(``XX``/``T1``), and anything else to ``None``. The country header
+	(``CF-IPCountry``/``X-Country``) is client-settable — spoofable even behind
+	Cloudflare via ``X-Country`` — so this shape check keeps free-form junk
+	(``FAKE``, ``ZZZZ``) out of ``top_countries``.
+
+	# ponytail: alpha-2 *shape* only, not the full 249-code table — a P3 metric
+	# doesn't warrant a bundled ISO code set; add one if bucket accuracy matters.
+	"""
+	if not country:
+		return None
+	code = country.strip().upper()
+	if not _COUNTRY_CODE_RE.match(code) or code in _COUNTRY_SENTINELS:
+		return None
+	return code
 
 
 def detect_device_type(user_agent: str) -> str:

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -67,6 +67,9 @@ async def track_event(
 	client_ip = request.headers.get("X-Forwarded-For") or request.client.host if request.client else None
 	user_agent = request.headers.get("User-Agent")
 	referer = request.headers.get("Referer")
+	# Country from the edge/CDN (Cloudflare CF-IPCountry, generic X-Country
+	# fallback); normalized + sentinel-filtered in build_event_payload (#325).
+	country = request.headers.get("CF-IPCountry") or request.headers.get("X-Country")
 
 	# Build the event payload in-process (id + created_at minted here) and queue
 	# the insert so the per-event commit is off the request path (issue #322).
@@ -81,6 +84,7 @@ async def track_event(
 			user_agent=user_agent,
 			referer=referer,
 			ip_address=client_ip,
+			country=country,
 			event_metadata=body.metadata,
 		)
 	except ValueError as exc:

--- a/apps/api/src/services/analytics_service.py
+++ b/apps/api/src/services/analytics_service.py
@@ -16,6 +16,7 @@ from ..models.analytics_event import (
 	detect_app_name,
 	detect_device_type,
 	hash_ip,
+	normalize_country,
 )
 
 logger = logging.getLogger(__name__)
@@ -29,6 +30,7 @@ def build_event_payload(
 	user_agent: Optional[str] = None,
 	referer: Optional[str] = None,
 	ip_address: Optional[str] = None,
+	country: Optional[str] = None,
 	event_metadata: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
 	"""Build a JSON-safe engagement-event payload WITHOUT touching the DB.
@@ -52,6 +54,7 @@ def build_event_payload(
 		"user_agent": user_agent,
 		"referer": referer,
 		"ip_address": hash_ip(ip_address) if ip_address else None,
+		"country": normalize_country(country),
 		"device_type": detect_device_type(user_agent or ""),
 		"app_name": detect_app_name(user_agent or ""),
 		"event_metadata": event_metadata,

--- a/apps/api/src/tasks/analytics.py
+++ b/apps/api/src/tasks/analytics.py
@@ -48,6 +48,7 @@ async def _track_event_async(payload: Dict[str, Any]) -> None:
 			user_agent=payload.get("user_agent"),
 			referer=payload.get("referer"),
 			ip_address=payload.get("ip_address"),
+			country=payload.get("country"),
 			device_type=payload.get("device_type"),
 			app_name=payload.get("app_name"),
 			event_metadata=payload.get("event_metadata"),

--- a/apps/api/tests/test_analytics.py
+++ b/apps/api/tests/test_analytics.py
@@ -254,6 +254,33 @@ async def test_track_event_queues_task_with_payload(client):
 
 
 @pytest.mark.asyncio
+async def test_track_event_threads_country_header_into_payload(client):
+	"""CF-IPCountry header is read at the boundary and queued on the payload (#325)."""
+	headers = await register_and_login(client)
+	headers["CF-IPCountry"] = "gb"
+	with patch("src.tasks.analytics.track_analytics_event_task") as mock_task:
+		response = await client.post("/analytics/events", json={
+			"event_type": "download",
+		}, headers=headers)
+	assert response.status_code == 201, response.text
+	payload = mock_task.delay.call_args.kwargs["payload"]
+	assert payload["country"] == "GB"  # normalized
+
+
+@pytest.mark.asyncio
+async def test_track_event_x_country_fallback(client):
+	"""X-Country is the fallback when CF-IPCountry is absent (#325)."""
+	headers = await register_and_login(client)
+	headers["X-Country"] = "US"
+	with patch("src.tasks.analytics.track_analytics_event_task") as mock_task:
+		response = await client.post("/analytics/events", json={
+			"event_type": "download",
+		}, headers=headers)
+	assert response.status_code == 201, response.text
+	assert mock_task.delay.call_args.kwargs["payload"]["country"] == "US"
+
+
+@pytest.mark.asyncio
 async def test_track_event_broker_down_still_returns_201(client):
 	"""A broker outage must never fail the request — analytics are best-effort."""
 	headers = await register_and_login(client)

--- a/apps/api/tests/unit/test_analytics_track_task.py
+++ b/apps/api/tests/unit/test_analytics_track_task.py
@@ -37,6 +37,7 @@ def _payload(**over):
 		"ip_address": "hashed-ip",
 		"device_type": "mobile",
 		"app_name": "spotify",
+		"country": "US",
 		"event_metadata": {"completed": True},
 		"created_at": "2026-07-19T12:00:00",
 	}
@@ -74,6 +75,7 @@ async def test_track_async_arms_tenant_context_then_inserts_and_commits():
 	assert str(added.episode_id) == payload["episode_id"]
 	assert added.project_id is None
 	assert added.event_type == "play"
+	assert added.country == payload["country"]  # #325: country persisted
 	assert added.created_at == datetime.fromisoformat(payload["created_at"])
 	mock_db.commit.assert_awaited_once()
 

--- a/apps/api/tests/unit/test_analytics_unit.py
+++ b/apps/api/tests/unit/test_analytics_unit.py
@@ -110,6 +110,60 @@ class TestAppNameDetection:
 
 
 # ---------------------------------------------------------------------------
+# Country normalization (issue #325)
+# ---------------------------------------------------------------------------
+
+
+class TestCountryNormalization:
+	def test_uppercases_and_trims(self):
+		from src.models.analytics_event import normalize_country
+		assert normalize_country("  gb ") == "GB"
+		assert normalize_country("us") == "US"
+
+	def test_none_and_empty_return_none(self):
+		from src.models.analytics_event import normalize_country
+		assert normalize_country(None) is None
+		assert normalize_country("") is None
+		assert normalize_country("   ") is None
+
+	def test_cloudflare_sentinels_return_none(self):
+		from src.models.analytics_event import normalize_country
+		# XX = unknown, T1 = Tor exit — must not pollute top_countries
+		assert normalize_country("XX") is None
+		assert normalize_country("xx") is None
+		assert normalize_country("T1") is None
+		assert normalize_country(" t1 ") is None
+
+	def test_non_alpha2_shapes_rejected(self):
+		from src.models.analytics_event import normalize_country
+		# Header is client-settable (X-Country spoofable) — free-form junk and
+		# wrong-length codes must not create bogus top_countries buckets.
+		for junk in ("FAKE", "ZZZZ", "U", "USA", "U1", "1S", "U.S"):
+			assert normalize_country(junk) is None, junk
+
+
+# ---------------------------------------------------------------------------
+# build_event_payload threads a normalized country (issue #325)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEventPayloadCountry:
+	def _payload(self, **over):
+		from uuid import uuid4
+		from src.services.analytics_service import build_event_payload
+		return build_event_payload(tenant_id=uuid4(), event_type="download", **over)
+
+	def test_normalizes_country_into_payload(self):
+		assert self._payload(country=" gb ")["country"] == "GB"
+
+	def test_absent_country_defaults_to_none(self):
+		assert self._payload()["country"] is None
+
+	def test_sentinel_country_stored_as_none(self):
+		assert self._payload(country="XX")["country"] is None
+
+
+# ---------------------------------------------------------------------------
 # Event type validation
 # ---------------------------------------------------------------------------
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,22 +1,31 @@
-# Issue #324 — Docs drift & repo hygiene (P6.1)
+# Issue #325 — Populate `country` on analytics events (P6.2 / P3)
 
-Branch: `chore/324-docs-repo-hygiene`. All claims verified against repo state before acting.
+Branch: `fix/325-populate-analytics-country`. Plan verified against current code.
 
-## Plan (no architectural fork — approved autonomously)
+**Problem:** `top_countries` always `[]` because `country` is never written. The
+column, read-side `GROUP BY country` aggregation, and `EpisodeAnalyticsResponse`
+schema all already exist — only the write path has a gap.
 
-- [ ] **README.md** — fix 3 defects
-  - [ ] `:57` "Systemd for service management" → "PM2 for process management" (truth: deployment/README uses PM2; systemd only resurrects PM2 on boot)
-  - [ ] `:277` `data/` labeled "(gitignored)" → clarify committed sample audio is tracked; only new runtime output is ignored
-  - [ ] `:282` `deploy.yml` → `deploy-dev.yml` (actual workflow filename)
-- [ ] **docs/ broken Sphinx tooling** — remove (no `source/` or `conf.py` exist): `Makefile`, `make.bat`, `generate_api_docs.py`, `requirements.txt`
-- [ ] **docs/ stale/alarming agent reports** — delete (git history preserves): `GAP_ANALYSIS.md`, `environment-configuration-report-2025-11-11.md`, `env_inventory.md`. Keep `USER_GUIDE.md`, `missing-credentials-guide.md` (current).
-- [ ] **.apm/ (32 files) + podcast-generator/ (19 files)** — `git rm -r` both, add to `.gitignore` (confusing second project roots; `.claude/commands/apm-*.md` regenerate `.apm/` so removal is safe)
-- [ ] **apps/api/src/middleware/auth.py** — remove stale "Task 2.4" comment (:148); fix `get_active_user` docstring (claims "verified" but only checks active) + delete dead commented email-verification block
-- [ ] **apps/api/src/services/auth_service.py:87** — drop "in Task 2.4" from comment
-- [ ] **apps/api/src/services/content_extraction_service.py:5** — drop "from Task 2.7" from docstring
-- [ ] **apps/api/scripts/test_credentials.py** — rename → `check_credentials.py` (fixes pytest-collection hazard: `test_`-prefixed funcs; deps already lazily imported so no import-time break)
+**Plan is stale:** CodeRabbit's plan targets a `track_event` service function, but
+issue #322 (PR #415) moved ingestion to `build_event_payload` → payload dict →
+`track_analytics_event_task` → `AnalyticsEvent` insert. So `country` must thread
+through **4** places, not 3 (the plan missed the Celery task insert).
 
-## Verify
-- [ ] `pytest tests/` collects cleanly, app imports
-- [ ] No dangling references to deleted files
-- [ ] ruff clean on touched Python
+**Design choice (resolved, no fork):** CDN/edge country header (`CF-IPCountry`,
+fallback `X-Country`), normalized. No new deps, no migration, no MaxMind DB
+lifecycle. Matches existing `X-Forwarded-For` header-reading pattern and the P3
+polish scope. Graceful `NULL` when no header present.
+
+## Tasks
+- [ ] `models/analytics_event.py`: add `normalize_country()` helper (trim,
+      uppercase, reject empty + Cloudflare sentinels `XX`/`T1` → `None`).
+- [ ] `services/analytics_service.py`: `build_event_payload` gains `country`
+      param; payload stores `normalize_country(country)`.
+- [ ] `routers/analytics.py`: read `CF-IPCountry` then `X-Country`, pass through.
+- [ ] `tasks/analytics.py`: set `country=payload.get("country")` on the insert.
+- [ ] Tests (TDD): unit for `normalize_country`; payload includes normalized
+      country; task insert sets country; route threads header → queued payload.
+
+## Acceptance criteria (from issue)
+Populate `country` via CDN country header in the ingestion path so `top_countries`
+returns real data. ✔ satisfied by the populate path (vs. the "drop" alternative).


### PR DESCRIPTION
Closes #325

## Problem
`get_episode_analytics` returns `top_countries`, and the `country` column, the read-side `GROUP BY country` aggregation, and the `EpisodeAnalyticsResponse` schema **all already existed** — but nothing ever wrote `AnalyticsEvent.country`, so `top_countries` was always `[]`. Pure write-side gap; no schema/migration/frontend change needed.

## What changed
Threads an edge/CDN country code through the ingestion path. **Note:** the CodeRabbit plan on the issue was stale — it targeted a `track_event` *service* function, but #322 (PR #415) moved ingestion to `build_event_payload` → JSON payload → `track_analytics_event_task` → model insert. So `country` threads through **4** layers, not 3 (the plan missed the Celery task insert):

1. `routers/analytics.py` — read `CF-IPCountry` (fallback `X-Country`), mirroring the existing `X-Forwarded-For`/`User-Agent`/`Referer` reads.
2. `services/analytics_service.py` — `build_event_payload` gains an optional `country` param; stores `normalize_country(country)`.
3. `models/analytics_event.py` — new `normalize_country()` helper.
4. `tasks/analytics.py` — set `country=payload.get("country")` on the insert.

### Design choice (resolved, no fork)
CDN/edge country header — no new deps, no MaxMind `.mmdb` lifecycle, no migration. Matches the P3 polish scope and the existing header-reading pattern. Records `NULL` gracefully when no header is present.

### Security
The country header is **client-settable** (`X-Country` is spoofable even behind Cloudflare). `normalize_country` therefore trims/uppercases, drops empties + Cloudflare sentinels (`XX`/`T1`), and keeps only **ISO-3166-1 alpha-2-shaped** codes (`^[A-Z]{2}$`) so free-form junk (`FAKE`, `ZZZZ`) can't pollute the metric this fix targets.

## Tests
- Unit: `normalize_country` (trim/upper, None/empty, sentinels, non-alpha-2 junk); `build_event_payload` threads normalized country; task insert persists `country`.
- Route: `CF-IPCountry` and `X-Country` fallback thread into the queued payload.
- Full analytics suite green locally (61 passed) on a CI-matching Postgres+Redis.

## Known limitations
- Alpha-2 **shape** validation only, not the full 249-code ISO set — proportionate for a P3 metric. A determined spoofer could still send a well-formed-but-wrong `AA`; add the code table if bucket accuracy becomes important.
- Backfill: pre-existing events stay `country = NULL` (excluded from the aggregation) — no historical geo data is reconstructable.

## Review
Cross-family review by opencode (GLM) pre-PR: flagged the header-spoofing gap (Minor), now closed with the alpha-2 shape check + test.