### PR TITLE
fix(deps): bump next-auth to 4.24.15 — clears all 4 npm advisories

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,7 +29,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "next": "^16.2.10",
-    "next-auth": "^4.24.0",
+    "next-auth": "^4.24.15",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-hook-form": "^7.81.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "next": "^16.2.10",
-        "next-auth": "^4.24.0",
+        "next-auth": "^4.24.15",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-hook-form": "^7.81.0",
@@ -62,6 +62,51 @@
         "tailwindcss": "^3.4.1",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5"
+      }
+    },
+    "apps/web/node_modules/next-auth": {
+      "version": "4.24.15",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.15.tgz",
+      "integrity": "sha512-NnjYtjrSOAx/TIVFGTX4IfI/9yHnNpi4B7FuLUwuV20v2Zxgr2OGP/YN0ynJuI7y8QOnTBPitfOdEXZrVvhIuA==",
+      "license": "ISC",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@panva/hkdf": "^1.0.2",
+        "cookie": "^0.7.0",
+        "jose": "^4.15.5",
+        "oauth": "^0.9.15",
+        "openid-client": "^5.4.0",
+        "preact": "^10.6.3",
+        "preact-render-to-string": "^5.1.19",
+        "uuid": "^11.1.1"
+      },
+      "peerDependencies": {
+        "@auth/core": "0.34.3",
+        "next": "^12.2.5 || ^13 || ^14 || ^15 || ^16",
+        "nodemailer": "^7.0.7",
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@auth/core": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -9741,38 +9786,6 @@
         }
       }
     },
-    "node_modules/next-auth": {
-      "version": "4.24.14",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.14.tgz",
-      "integrity": "sha512-YRz6xFDXKUwiXSMMChbrBEWyFktZ1qZXEgeSHQQ3nsy08B4c/xLk6REeutRsIFwkjY/1+ShHnu07DN3JeJguig==",
-      "license": "ISC",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@panva/hkdf": "^1.0.2",
-        "cookie": "^0.7.0",
-        "jose": "^4.15.5",
-        "oauth": "^0.9.15",
-        "openid-client": "^5.4.0",
-        "preact": "^10.6.3",
-        "preact-render-to-string": "^5.1.19",
-        "uuid": "^8.3.2"
-      },
-      "peerDependencies": {
-        "@auth/core": "0.34.3",
-        "next": "^12.2.5 || ^13 || ^14 || ^15 || ^16",
-        "nodemailer": "^7.0.7",
-        "react": "^17.0.2 || ^18 || ^19",
-        "react-dom": "^17.0.2 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@auth/core": {
-          "optional": true
-        },
-        "nodemailer": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
@@ -10390,6 +10403,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12461,15 +12475,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/scripts/npm-security-audit.sh
+++ b/scripts/npm-security-audit.sh
@@ -9,18 +9,19 @@ cd "$(dirname "$0")/.."
 # Allowlisted advisories. npm has no native per-advisory ignore, so we filter the
 # JSON ourselves rather than pulling in audit-ci/better-npm-audit for this.
 #
-# All four are next-auth v4 and its uuid dependency. EVERY v4 release is affected
-# (`next-auth <=4.24.14`, and 4.24.14 is the last v4), so no bump clears them —
-# the fix is the Auth.js v5 / BetterAuth migration tracked in #442, not an
-# override. We use CredentialsProvider only, with no OAuth providers configured,
-# which bounds exposure on the provider-binding advisory. Re-check this list on
-# every next-auth bump, and drop it entirely once #442 lands.
-ALLOWED_ADVISORIES=(
-  GHSA-x445-f3h2-j279  # next-auth: OAuth state/nonce/PKCE cookies not bound to provider
-  GHSA-xmf8-cvqr-rfgj  # next-auth: getToken() uncaught exception on malformed Bearer header
-  GHSA-7rqj-j65f-68wh  # next-auth: email normalizer homoglyph @ bypass
-  GHSA-w5hq-g745-h8pq  # uuid <11.1.1: missing buffer bounds check (transitive via next-auth)
-)
+# CURRENTLY EMPTY — every known high+ advisory is fixed in the lockfile, so this
+# gate is equivalent to a plain `npm audit --audit-level=high` today. The
+# mechanism is kept because unfixable advisories recur (see the 22-entry
+# structural ignore list in apps/api/scripts/security-audit.sh for the Python
+# side); an empty list means nothing is being hidden right now.
+#
+# Only add an entry when NO release fixes it. Verify that claim against the
+# registry (`npm view <pkg> versions`) rather than the advisory's affected range:
+# a range of `<=X` means X+1 is the fix, not that every release is affected. That
+# misreading is what previously masked next-auth 4.24.15.
+#
+# Each entry must carry: why no bump fixes it, an issue link, and a re-check trigger.
+ALLOWED_ADVISORIES=()
 
 audit_json="$(mktemp)"
 trap 'rm -f "$audit_json"' EXIT
@@ -33,7 +34,9 @@ npm audit --audit-level=high --json > "$audit_json" || true
 
 ALLOWED="${ALLOWED_ADVISORIES[*]}" node -e '
 const fs = require("fs");
-const allowed = new Set(process.env.ALLOWED.trim().split(/\s+/));
+// filter(Boolean): an empty ALLOWED yields [""] from split, which would put an
+// empty string in the set and match any advisory with a blank id.
+const allowed = new Set(process.env.ALLOWED.trim().split(/\s+/).filter(Boolean));
 
 let report;
 try {


### PR DESCRIPTION
## What enabling Dependabot alerts found

With alerts on, the API reports `first_patched_version: 4.24.15` for all three next-auth
advisories. **That version exists** — published 2026-07-20:

```
$ npm view next-auth@4.24.15 version
4.24.15
```

This corrects the reasoning in #442 and in the allowlist I added in #440. I read the
advisory range `next-auth <=4.24.14` as "every v4 release is affected, so only a v5
migration can fix it". It actually means **4.24.15 is the patched release**. `npm audit`
reports the vulnerable range, not the absence of a fix — the two look identical when the
fix is the very next patch.

## Changes

| Package | From | To | Clears |
|---|---|---|---|
| next-auth | 4.24.14 | 4.24.15 | GHSA-7rqj-j65f-68wh (critical), GHSA-xmf8-cvqr-rfgj (high), GHSA-x445-f3h2-j279 (medium) |
| uuid | 8.3.2 | 11.1.1 | GHSA-w5hq-g745-h8pq (medium) — pulled in by 4.24.15 |

Peer requirements are identical between 4.24.14 and 4.24.15 (`next ^12.2.5 || ^13 || ^14
|| ^15 || ^16`, `react ^17.0.2 || ^18 || ^19`), and we're on next 16.3.0 / react 19.2.7 —
so nothing else has to move.

Note `npm update next-auth` did **not** pick this up despite `^4.24.0` permitting it;
an explicit `npm install next-auth@4.24.15 --workspace=web` was required.

## Result

```
$ npm audit --audit-level=high
found 0 vulnerabilities
```

The allowlist in `scripts/npm-security-audit.sh` is now **empty**, so the gate is
equivalent to a plain `npm audit --audit-level=high` — nothing is being suppressed. The
mechanism is retained because unfixable advisories recur (the Python side carries 22
structural ignores), and the comment now instructs verifying "no fix exists" against
`npm view <pkg> versions` rather than trusting the affected range.

Also fixes a latent bug in the filter: an empty allowlist yielded `[""]` from `split()`,
seeding the set with an empty string that would have matched any advisory with a blank id.

## Verification

- `apps/web` typecheck: exit 0
- jest: **497/497** passing
- gate: passes on a clean tree; still fails closed when `npm audit` cannot run (ENOLOCK)

## Follow-up

#442 needs rescoping — the security urgency is gone. An Auth.js v5 / BetterAuth migration
may still be wanted on its own merits, but it no longer blocks the audit gate.