### PR TITLE
docs(#446): reachability assessment for the podcastfy-capped advisories + fork effort review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,17 @@ bump the version in `apps/api/pyproject.toml`, run `uv sync`, and re-check the c
 **0.4.2/0.4.3 were evaluated 2026-07-13 and deferred** (#363): 0.4.2+ imports `playwright` at module
 top without declaring it (breaks app startup), offers no benefit to our call paths, and does not clear
 the langchain CVEs on the pip-audit ignore list. See `apps/api/docs/podcastfy-0.4.3-evaluation.md` for
-the full evaluation and re-evaluation triggers (chiefly: upstream langchain 1.x support).
+the full evaluation and re-evaluation triggers (chiefly: upstream langchain 1.x support). Upstream is
+dormant — 0.4.3 shipped 2025-12-09 and nothing since — so that trigger has not fired.
+
+**The pin's advisory load was assessed 2026-08-13** (#446): 21 of 22 capped advisories are
+unreachable (the litellm ones, including both criticals, are proxy-server issues and we never run a
+proxy). The exception is GHSA-3644 — podcastfy's `hub.pull()` fetches prompts from LangChain Hub on
+the generation path, so **every episode makes an outbound call to a third-party Hub account**.
+Accepted (pulls are commit-pinned). See `apps/api/docs/podcastfy-advisory-reachability.md`; the claims
+are enforced by `apps/api/tests/test_dependency_reachability.py`, so adding an image source type or
+importing litellm directly will fail CI by design. Fork costing lives in
+`apps/api/docs/podcastfy-fork-effort-review.md` (langchain is confined to one file; Stage 2 ≈ 3–5 days).
 
 Engine capabilities (provided by the dependency): multi-modal input (websites, YouTube, PDFs, images,
 text, topics); 100+ LLMs via LiteLLM + Gemini; TTS via OpenAI, ElevenLabs, Gemini multi-speaker, and

--- a/apps/api/docs/podcastfy-advisory-reachability.md
+++ b/apps/api/docs/podcastfy-advisory-reachability.md
@@ -1,0 +1,145 @@
+# Reachability of the podcastfy-capped advisories
+
+**Date:** 2026-08-13 · **Issue:** #446 · **Companion:** [podcastfy-fork-effort-review.md](./podcastfy-fork-effort-review.md)
+
+`scripts/security-audit.sh` ignores 24 advisory IDs because `podcastfy==0.4.1` caps the
+whole langchain/litellm tree (see [podcastfy-0.4.3-evaluation.md](./podcastfy-0.4.3-evaluation.md)
+and #363). Ignoring an advisory is only defensible if the vulnerable code is genuinely
+unreachable from our call paths. This document records that assessment.
+
+**Headline: 21 of 22 open Dependabot alerts are unreachable. One is reachable.**
+
+The "2 critical" figure in #446's original title is misleading — both criticals are inert.
+The one advisory that matters is a *high* that the blanket "structurally capped" framing
+was hiding.
+
+## Verification method
+
+Claims here are verified, not assumed:
+
+```bash
+# no litellm usage in our source at all — it is purely transitive
+grep -rn "litellm" apps/api/src --include="*.py"        # -> no matches
+
+# the cap is real, not an artifact of the lockfile
+uv lock --upgrade-package 'litellm>=1.81.0'             # -> unsatisfiable (needs openai>=2.20 vs podcastfy's openai<2)
+uv lock --upgrade-package 'langsmith>=0.7.31'           # -> unsatisfiable
+uv lock --upgrade-package 'pytest>=9.0.3'               # -> unsatisfiable
+uv lock --upgrade-package 'langchain-core>=1.2.11'      # -> unsatisfiable
+```
+
+The import-graph claims are enforced by `tests/test_dependency_reachability.py`, so they
+cannot silently rot.
+
+## Unreachable (21)
+
+### LiteLLM proxy server — 11 advisories, including both criticals
+
+| ID | Sev | Summary |
+|---|---|---|
+| GHSA-4xpc-pv4p-pm3w | critical | Auth bypass via Host header injection |
+| GHSA-jjhc-v7c2-5hh6 | critical | Auth bypass via OIDC userinfo cache key collision |
+| GHSA-53mr-6c8q-9789 | high | Privilege escalation via unrestricted proxy config endpoints |
+| GHSA-69x8-hrgq-fjj8 | high | Password hash exposure / pass-the-hash bypass |
+| GHSA-7488-6r32-c95q | high | MCP auth bypass via OAuth2 passthrough fallback |
+| GHSA-qrc4-49gv-mv9m | high | internal_user can create over-scoped API keys |
+| GHSA-v4p8-mg3p-g94g | high | Authenticated command execution via MCP stdio test endpoints |
+| GHSA-wpfp-gwwc-vwq6 | high | User can modify own `user_role` via `/user/update` |
+| GHSA-5jmr-gcrj-2c9q | medium | Path traversal in Skills archive extraction |
+| GHSA-4g5m-c9r5-49xf | low | Local file read via request-supplied OIDC file references |
+| GHSA-72m8-9m7m-h278 | low | Custom Code Guardrails endpoint bypass |
+
+Every one requires running **litellm as a proxy server** with its management API exposed.
+We never do: no litellm import in our source, no proxy config file, no proxy process in
+PM2 or the deploy workflow. `litellm/proxy/` ships on disk but never executes.
+
+In fact litellm itself is never imported — podcastfy reaches it through
+`langchain_community.chat_models.ChatLiteLLM`, which imports lazily. Verified with the
+full engine loaded (`podcastfy.client` + `ContentGenerator`): `litellm` absent from
+`sys.modules`.
+
+> **GHSA-jjhc** additionally requires `enable_jwt_auth: true`, which upstream notes is off
+> by default: *"Most instances are not affected."*
+
+### Unused features — 9 advisories
+
+| ID | Sev | Package | Why unreachable |
+|---|---|---|---|
+| GHSA-qv8j-hgpc-vrq8 | high | google-cloud-aiplatform | No vertex/aiplatform usage in our source |
+| GHSA-wh2j-26j7-9728 | high | google-cloud-aiplatform | Same |
+| GHSA-pc6w-59fv-rh23 | high | langchain-community | XXE in loaders we never call |
+| GHSA-qh6h-p6c9-ff54 | high | langchain-core | Legacy `load_prompt` — never called |
+| GHSA-f4xh-w4cj-qxq8 | high | langsmith | `TracingMiddleware` — tracing never configured |
+| GHSA-rr7j-v2q5-chgv | medium | langsmith | Streaming redaction — tracing never configured |
+| GHSA-gr75-jv2w-4656 | medium | langchain | File-search middleware — not used |
+| GHSA-fv5p-p927-qmxr | medium | langchain-text-splitters | `HTMLHeaderTextSplitter.split_text_from_url` — not used |
+| GHSA-2g6r-c272-w58r | low | langchain-core | SSRF via `image_url` token counting — see below |
+
+**GHSA-2g6r** deserves a note. podcastfy *does* build `image_url` message parts
+(`content_generator.py:805`), but only when `image_paths` is non-empty.
+`generate_podcast_task` accepts that kwarg and no caller ever populates it, because
+`SourceType` is `Literal['url', 'pdf', 'text']` — there is no image source to populate it
+from. **If an image source type is ever added, this advisory goes live.** Guarded by
+`test_no_image_source_type_keeps_the_image_url_path_unreachable` and
+`test_no_caller_passes_image_paths_to_the_generation_task`.
+
+### Test-only — 1 advisory
+
+`GHSA-6w46-j5rx-g56g` (medium, pytest `tmpdir` handling). pytest is in the *runtime*
+closure only because podcastfy declares it as a runtime dependency — a packaging defect
+upstream, not something we execute in production.
+
+## Reachable (1) — accepted risk
+
+### GHSA-3644-q5cj-c5c7 · high · langsmith 0.3.45 (fix: 0.8.0, unreachable)
+
+> LangSmith SDK: Public prompt pull deserializes untrusted manifests without validation.
+
+**This is on the main generation path.** podcastfy fetches its prompt templates from
+LangChain Hub at runtime:
+
+```python
+# podcastfy/content_generator.py:565-566, 790
+clean_transcript_prompt = hub.pull(f"{...['cleaner_prompt_template']}:{...['cleaner_prompt_commit']}")
+rewrite_prompt          = hub.pull(f"{...['rewriter_prompt_template']}:{...['rewriter_prompt_commit']}")
+prompt_template         = hub.pull(f"{template}:{commit}")
+```
+
+against a third-party account (`podcastfy/config.yaml`):
+
+```yaml
+prompt_template:         "souzatharsis/podcastfy_multimodal_cleanmarkup"   # commit b2365f11
+longform_prompt_template:"souzatharsis/podcastfy_longform"                 # commit acfdbc91
+cleaner_prompt_template: "souzatharsis/podcastfy_longform_clean"           # commit 8c110a0b
+rewriter_prompt_template:"souzatharsis/podcast_rewriter"                   # commit 8ee296fb
+```
+
+**Decision: accepted, not mitigated.** Rationale:
+
+- Every pull is **pinned to a specific commit**, so exploitation requires an attacker to
+  alter the content behind an existing pinned commit, not merely to push a new revision.
+  That is a materially higher bar than the advisory's unpinned worst case.
+- No fix is reachable — langsmith is capped at 0.3.45 by podcastfy's `langchain-community
+  <0.4`, and upstream podcastfy is dormant (0.4.3, 2025-12-09; nothing in 8 months).
+- Mitigating it properly means removing the runtime hub dependency, which changes
+  generation behaviour and belongs with the fork decision, not with a dependency bump.
+
+**Two non-security consequences of the same code, worth knowing:**
+
+1. **Availability.** Generation depends on LangChain Hub being up and on a third party's
+   account continuing to exist. The two pulls at :565-566 are wrapped in `try/except` and
+   degrade to the raw transcript; the pull at **:790 is not wrapped** and will propagate.
+2. **Egress.** Every episode makes outbound calls to LangChain Hub. Any future network
+   lockdown must allowlist it or generation breaks.
+
+## Re-check triggers
+
+Re-run this assessment when any of these change:
+
+- podcastfy is bumped or forked → the whole cap disappears; redo from scratch
+- an **image** source type is added → GHSA-2g6r goes live (tests will fail)
+- litellm is imported directly, or a litellm proxy is deployed → 11 advisories go live
+  (test will fail)
+- LangSmith tracing is enabled (`LANGCHAIN_TRACING_V2`, `LANGSMITH_API_KEY`) → 2 langsmith
+  advisories go live
+- Vertex AI / `aiplatform` is adopted → 2 advisories go live

--- a/apps/api/docs/podcastfy-fork-effort-review.md
+++ b/apps/api/docs/podcastfy-fork-effort-review.md
@@ -1,0 +1,137 @@
+# Effort review: forking / vendoring podcastfy
+
+**Date:** 2026-08-13 · **Issue:** #446 · **Companion:** [podcastfy-advisory-reachability.md](./podcastfy-advisory-reachability.md)
+
+Requested so the fork decision can be made on its own merits rather than being forced by
+security pressure. Per the reachability analysis, the security pressure is **low**: 21 of
+22 advisories are inert and the one reachable item is commit-pinned. Nothing here is
+urgent. This is a planning document.
+
+## The finding that should drive the decision
+
+**The entire advisory surface traces to one file.**
+
+```
+langchain touchpoints across all 19 podcastfy modules: content_generator.py only (25 references)
+```
+
+`grep -rln langchain` over the installed package returns exactly one file. The other 18
+modules — every TTS provider, every content extractor, all config handling — do not import
+langchain at all. What those 25 references do:
+
+| Use | Symbols |
+|---|---|
+| Model selection | `ChatLiteLLM`, `ChatGoogleGenerativeAI`, `Llamafile` |
+| Prompt templating | `ChatPromptTemplate`, `HumanMessagePromptTemplate` |
+| Output handling | `StrOutputParser`, LCEL `\|` chaining |
+| Prompt fetching | `hub.pull` ×3 |
+
+That is: *pick a model, format a prompt, call it, get a string back.* All 22 alerts —
+langchain, langchain-community, langchain-core, langchain-text-splitters, langsmith,
+litellm, google-cloud-aiplatform — are the transitive cost of that thin slice.
+
+The corollary matters: **a fork is not "own 3,254 lines." It is "replace ~25 lines of glue
+in one file, and inherit the rest unchanged."**
+
+## What we actually use
+
+podcastfy is small: **19 files, 3,254 LOC**.
+
+| Module | LOC | We use it? |
+|---|---:|---|
+| `content_generator.py` | 911 | **Yes** — `ContentGenerator`, and the only langchain consumer |
+| `client.py` | 389 | **Yes** — `generate_podcast` orchestration |
+| `text_to_speech.py` | 360 | Yes (via `generate_podcast`) |
+| `tts/providers/geminimulti.py` | 337 | Yes — `gemini_multi` |
+| `utils/config_conversation.py` | 244 | Yes |
+| `content_parser/website_extractor.py` | 165 | **Yes** — imported directly |
+| `utils/config.py` | 153 | Yes — also the `.env` loader (see reachability doc) |
+| `tts/base.py` | 123 | Yes |
+| `content_parser/content_extractor.py` | 133 | Yes (via client) |
+| `tts/providers/gemini.py` | 101 | Yes |
+| `content_parser/youtube_transcriber.py` | 68 | Yes — YouTube URLs route here |
+| `content_parser/pdf_extractor.py` | 67 | **Yes** — imported directly |
+| `tts/providers/edge.py` | 50 | Yes |
+| `tts/factory.py` | 46 | Yes |
+| `tts/providers/openai.py` | 42 | Yes |
+| `utils/logger.py` | 34 | Yes |
+| `tts/providers/elevenlabs.py` | 29 | Yes |
+
+Effectively all of it. There is no dead weight to drop — the savings do not come from
+deleting code, they come from **replacing the langchain layer**.
+
+## What forking buys
+
+1. **All 22 advisories become fixable.** The cap is `podcastfy==0.4.1`'s
+   `openai<2.0.0` + `langchain-community<0.4`. Remove the pin and litellm/langchain/
+   langsmith can all move to patched versions. Note this is true even if we keep using
+   litellm — the cap is podcastfy's, not litellm's.
+2. **Drops the runtime LangChain Hub dependency** (GHSA-3644, plus the egress and
+   third-party-availability exposure documented in the reachability doc).
+3. **Removes packaging defects we inherit.** podcastfy declares **35 runtime
+   dependencies**, including `pytest`, `pytest-xdist`, `nbsphinx`,
+   `sphinx-autodoc-typehints`, `cython`, `pandoc`, `pandas`, `fuzzywuzzy`,
+   `python-levenshtein`. Docs and test tooling in the production closure is why `pytest`
+   appears in our CVE list at all, and why `setuptools<76` is capped.
+4. **Unblocks signature coupling.** #204's pin exists because task kwargs are coupled to
+   the upstream call signature. Owning it removes that constraint permanently.
+5. **Upstream is dormant.** 0.4.3 shipped 2025-12-09; nothing in 8 months, and 0.4.0→0.4.2
+   had a 13-month gap. We are already de facto unmaintained.
+
+## What forking costs
+
+1. **Ownership of ~3,250 LOC**, most of which is provider glue that breaks when vendor
+   APIs change (5 TTS providers, 4 content extractors).
+2. **The 911-line `content_generator.py`** is the complex piece — longform chunking with
+   contextual linking is the non-trivial logic, and it is the file we would be modifying.
+3. **Output-equivalence risk.** Replacing `hub.pull` prompts with local copies changes
+   generated content unless the pinned prompts are captured verbatim. Needs a
+   before/after comparison on real episodes, which is subjective to evaluate.
+4. **No upstream bug fixes** — though at 8 months dormant, this cost is close to zero.
+5. **Test burden.** podcastfy ships its own tests we would not inherit cleanly; we would
+   be writing coverage for 3k LOC to meet the repo's 85% gate, or carving the vendored
+   package out of coverage.
+
+## Staged options
+
+Ordered by cost. Each stage is independently shippable and none forecloses the next.
+
+### Stage 0 — Do nothing (current state)
+Advisories documented and enforced by `tests/test_dependency_reachability.py`.
+**Cost: zero.** Appropriate while the reachability finding holds.
+
+### Stage 1 — Neutralise `hub.pull` without forking
+Capture the four pinned prompts to local files and override
+`content_generator_config` (or wrap `ContentGenerator`) so no runtime hub call occurs.
+Removes GHSA-3644 exposure, the egress dependency, and the unwrapped `:790` failure mode.
+**Estimate: 0.5–1 day**, most of it verifying generated output is unchanged.
+**Does not** unpin anything — the other 21 advisories stay ignored (but stay inert).
+
+### Stage 2 — Vendor podcastfy, replace the langchain layer
+Copy the 19 modules into `apps/api/src/vendor/podcastfy/` (or a sibling package), then
+rewrite the 25 langchain touchpoints in `content_generator.py` against the LiteLLM SDK (or
+provider SDKs) directly. Drop `langchain*`, `langsmith`, and the docs/test deps from the
+closure; upgrade litellm freely.
+**Estimate: 3–5 days** — 1 day vendoring and wiring, 1–2 days on the LLM layer, 1–2 days
+on output-equivalence testing across the source types (url/pdf/text, short and longform).
+**Clears all 22 advisories permanently.**
+
+### Stage 3 — Full rewrite of the pieces we use
+Keep only the behaviours we expose and write them fresh. Highest control, highest cost,
+and hard to justify while Stage 2 leaves us with working code.
+**Estimate: 2–3 weeks.** Not recommended.
+
+## Recommendation
+
+**Stage 0 now; Stage 2 when there is a reason beyond security.** The security case does not
+justify a fork today — that was the question #446 was raised to answer, and the answer is
+no. But three non-security forces point the same way, and any one of them should trigger
+Stage 2:
+
+- adding an **image** source type (makes GHSA-2g6r live and changes the analysis)
+- needing a podcastfy behaviour change that the pinned call signature blocks (#204)
+- the `setuptools<76` / `openai<2` caps blocking an unrelated upgrade we actually want
+
+Stage 1 is a reasonable middle step if the LangChain Hub *availability* risk becomes a
+concern — a third-party account outage currently degrades or fails generation — but it is
+not security-motivated.

--- a/apps/api/scripts/security-audit.sh
+++ b/apps/api/scripts/security-audit.sh
@@ -18,6 +18,15 @@ uv export --format requirements-txt --no-hashes --no-emit-project -o "$reqs" -q
 # 0.4.2/0.4.3 do NOT (evaluated & deferred in #363, see
 # docs/podcastfy-0.4.3-evaluation.md) — not an override. Re-check this list on
 # every podcastfy bump.
+#
+# Reachability was assessed on 2026-08-13 (#446) — being capped is why we CAN'T fix
+# these; being unreachable is why it's acceptable not to. 21 of 22 open alerts are
+# unreachable (the 11 litellm ones are proxy-server issues and we never run a proxy;
+# the rest are unused features). The exception is GHSA-3644-q5cj-c5c7 (langsmith),
+# which IS on the generation hot path via podcastfy's hub.pull() — accepted because
+# every pull is commit-pinned. Full classification and re-check triggers:
+#   docs/podcastfy-advisory-reachability.md
+# The import-graph claims are enforced by tests/test_dependency_reachability.py.
 uvx pip-audit -r "$reqs" --no-deps --disable-pip --strict \
   --ignore-vuln CVE-2026-35029 \
   --ignore-vuln CVE-2026-42271 \

--- a/apps/api/tests/test_dependency_reachability.py
+++ b/apps/api/tests/test_dependency_reachability.py
@@ -1,0 +1,113 @@
+"""Reachability guards for advisories in the podcastfy dependency closure (#446).
+
+`scripts/security-audit.sh` ignores 24 advisory IDs that no bump can clear, because
+`podcastfy==0.4.1` caps the whole langchain/litellm tree. Ignoring them is only
+defensible while the vulnerable code is genuinely unreachable from our call paths.
+
+That "unreachable" claim is a property of the import graph and the API surface, both
+of which drift. These tests turn it into an enforced invariant: if a future change
+makes the vulnerable code reachable, the ignore list becomes a lie and CI says so.
+
+See apps/api/docs/podcastfy-advisory-reachability.md for the full classification.
+"""
+
+import subprocess
+import sys
+import textwrap
+from typing import get_args
+
+
+def _run_probe(source: str) -> str:
+    """Run an import probe in a clean interpreter.
+
+    A subprocess is required, not stylistic: `sys.modules` is process-global, so any
+    earlier test that imported litellm would make an in-process assertion pass or
+    fail based on test ordering rather than on our actual import graph.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source)],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert result.returncode == 0, (
+        f"probe failed (exit {result.returncode})\nstdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    return result.stdout
+
+
+def test_litellm_proxy_is_not_reachable_from_the_generation_stack():
+    """11 of the ignored advisories — including both criticals — are LiteLLM *proxy*
+    issues (auth bypass, proxy config endpoints, /user/update, MCP test endpoints).
+
+    They require running litellm as a proxy server. We import podcastfy's engine and
+    never start a proxy, so the vulnerable modules must never even load. podcastfy
+    reaches litellm only via langchain_community's ChatLiteLLM, which imports it
+    lazily — so in practice litellm itself stays unimported too.
+    """
+    output = _run_probe(
+        """
+        import sys
+        # The real generation entry points used by src/tasks/podcast_generation.py
+        from podcastfy.client import generate_podcast          # noqa: F401
+        from podcastfy.content_generator import ContentGenerator  # noqa: F401
+
+        proxy = sorted(m for m in sys.modules if m.startswith("litellm.proxy"))
+        print("PROXY_MODULES=" + (",".join(proxy) if proxy else "NONE"))
+        """
+    )
+    assert "PROXY_MODULES=NONE" in output, (
+        "litellm.proxy is now reachable from the generation stack. The proxy-only "
+        "advisories ignored in scripts/security-audit.sh (incl. GHSA-4xpc-pv4p-pm3w "
+        "and GHSA-jjhc-v7c2-5hh6, both critical) can no longer be treated as inert. "
+        f"Probe output: {output!r}"
+    )
+
+
+def test_no_image_source_type_keeps_the_image_url_path_unreachable():
+    """GHSA-2g6r (SSRF via image_url token counting) needs image input.
+
+    podcastfy builds `image_url` message parts (content_generator.py:805) only when
+    `image_paths` is non-empty. `generate_podcast_task` accepts that kwarg but no
+    caller populates it, because there is no image source type to populate it from.
+    If an 'image' source is ever added, that advisory becomes live.
+    """
+    from src.schemas.content import SourceType
+
+    assert "image" not in get_args(SourceType), (
+        "An image source type was added. podcastfy's image_url path (and therefore "
+        "GHSA-2g6r) may now be reachable — re-check the ignore list in "
+        "scripts/security-audit.sh before shipping."
+    )
+
+
+def test_no_caller_passes_image_paths_to_the_generation_task():
+    """Second half of the guard above: the kwarg itself must stay unpopulated.
+
+    Checked against the routers/services source rather than at runtime, since the
+    point is that no code path exists that could supply it.
+    """
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parents[1] / "src"
+    scanned = list((src / "routers").rglob("*.py")) + list(
+        (src / "services").rglob("*.py")
+    )
+    # Without this the test passes vacuously if the layout moves and the globs
+    # match nothing — a green "no offenders" that checked no files at all.
+    assert len(scanned) > 10, (
+        f"expected to scan the routers/services tree, found {len(scanned)} files "
+        f"under {src} — has the layout changed?"
+    )
+
+    offenders = [
+        f"{path.relative_to(src)}:{i}"
+        for path in scanned
+        for i, line in enumerate(path.read_text().splitlines(), 1)
+        if "image_paths" in line
+    ]
+    assert not offenders, (
+        "A router or service now passes image_paths into podcastfy, making the "
+        f"image_url path (GHSA-2g6r) reachable: {offenders}"
+    )


### PR DESCRIPTION
Closes #446.

#446 asked whether the advisory load behind the `podcastfy==0.4.1` pin justifies forking.
**It does not** — and the issue's own "2 critical" framing turned out to be misleading in
our favour.

## Reachability: 21 of 22 unreachable

Being *capped* is why we can't fix these. Being *unreachable* is why not fixing them is
acceptable. That second half had never been assessed.

- **11 litellm advisories — including both criticals — are LiteLLM _proxy server_ issues**
  (auth bypass via Host header, proxy config endpoints, `/user/update`, MCP stdio test
  endpoints). They require running litellm as a proxy. We never do: no litellm import in
  our source, no proxy config, no proxy process. In fact **litellm is never imported at
  all** — podcastfy reaches it lazily through `langchain_community`'s `ChatLiteLLM`.
- **9 are unused features** — no vertex/aiplatform, tracing never configured, no
  `load_prompt`, no `split_text_from_url`, and no image source type (`SourceType` is
  `Literal['url','pdf','text']`, so podcastfy's `image_url` path can't be reached).
- **1 is test-only** (`pytest` tmpdir) — in the runtime closure only because podcastfy
  declares `pytest`, `pytest-xdist`, `nbsphinx` and `sphinx-autodoc-typehints` as
  **runtime** dependencies.

Claims are verified, not assumed — each cap was confirmed against the resolver
(`uv lock --upgrade-package 'litellm>=1.81.0'` → unsatisfiable, etc.).

## The one that is reachable

**GHSA-3644 (high, langsmith)** — podcastfy's `hub.pull()` runs on the **main generation
path** (`content_generator.py:565, 566, 790`), fetching prompt templates from LangChain Hub
at runtime from a third-party account.

**Accepted, not mitigated**: every pull is pinned to a commit hash, which raises the bar
well above the advisory's unpinned worst case, and no fix is reachable while podcastfy caps
langsmith at 0.3.45.

Two non-security consequences of the same code are documented because they're arguably more
operationally relevant: **every episode makes outbound calls to LangChain Hub**, and the
pull at `:790` is **not** wrapped in `try/except` (the pair at `:565-566` are).

## Enforcement

`tests/test_dependency_reachability.py` turns the claims into invariants that fail loudly
if they stop holding. Two deliberate design points:

- The `litellm.proxy` guard runs in a **subprocess** — `sys.modules` is process-global, so
  an in-process assertion would pass or fail based on test ordering rather than our import
  graph.
- The `image_paths` scan **asserts it actually scanned files** before concluding "no
  offenders" — otherwise a layout change would make it pass vacuously on an empty glob.

All three were verified to fail when their invariant is broken, then restored.

## Fork effort review

The decisive measurement: **langchain is confined to one file.** `grep -rln langchain` over
the installed package returns only `content_generator.py` (25 touchpoints) out of 19
modules. Those 25 references amount to *pick a model, format a prompt, call it, get a string
back* — and the entire 22-advisory surface is the transitive cost of that thin slice.

So a fork is not "own 3,254 LOC"; it's "replace ~25 lines of glue and inherit the rest".

Staged options are costed in `docs/podcastfy-fork-effort-review.md`:

| Stage | Scope | Estimate |
|---|---|---|
| 0 | Do nothing (documented + enforced) | zero |
| 1 | Neutralise `hub.pull` with local prompts | 0.5–1 day |
| 2 | Vendor + replace the langchain layer — clears all 22 | 3–5 days |
| 3 | Full rewrite | 2–3 weeks (not recommended) |

**Recommendation: Stage 0 now, Stage 2 when a non-security reason arrives** — an image
source type, a behaviour change blocked by the #204 signature pin, or the `setuptools<76` /
`openai<2` caps blocking an upgrade we want.

## Verification

- `bash scripts/security-audit.sh` → `No known vulnerabilities found, 24 ignored` (exit 0)
- `ruff check` on the new test → clean
- 3/3 new tests pass; each verified to fail when its invariant is broken

## Known limitations

- Docs + tests only; **no production code changes**.
- The full backend suite was not run locally (no test database reachable in this
  environment) — CI is authoritative. The new tests were run in isolation.
- The reachability finding is a point-in-time assessment. Re-check triggers are listed at
  the end of `docs/podcastfy-advisory-reachability.md`; the mechanical ones are enforced by
  the new tests.