### PR TITLE
fix(#441): reach the dev VPS over Tailscale, pin the SSH host key

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -133,16 +133,36 @@ jobs:
           NEXTAUTH_URL: ${{ vars.NEXTAUTH_URL }}
         run: npm run build
 
+      # The VPS firewalls port 22 off the public internet (#441), so the runner
+      # reaches it over Tailscale instead. vars.SERVER_HOST must therefore be
+      # the box's tailnet MagicDNS name (or 100.x address), not the public IP.
+      # Box side: join the tailnet and `ufw allow in on tailscale0 to any port 22`.
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
       - name: Configure SSH
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           SSH_HOST: ${{ vars.SERVER_HOST }}
           SSH_USER: ${{ secrets.SERVER_USER }}
+          # Pinned host key rather than a live ssh-keyscan: keyscan is TOFU (it
+          # trusts whatever answers), and its repeated bursts tripped this box's
+          # fail2ban and banned the runner. SSH_KNOWN_HOSTS must be labelled
+          # with the same host string as SERVER_HOST or it will not verify.
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
         run: |
+          if [ -z "${SSH_KNOWN_HOSTS}" ]; then
+            echo "❌ SSH_KNOWN_HOSTS secret is not set — the deploy cannot verify the server host key."
+            exit 1
+          fi
           mkdir -p ~/.ssh
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H $SSH_HOST >> ~/.ssh/known_hosts
+          printf '%s\n' "${SSH_KNOWN_HOSTS}" >> ~/.ssh/known_hosts
 
       - name: Configure PM2 log rotation
         env:


### PR DESCRIPTION
Workflow half of #441. **Draft — do not merge until the setup below is done**, otherwise
the deploy simply fails at a different step.

## Why now

Six Dependabot merges this session each kicked off a `Deploy to Development` run, and
every one failed identically:

```
deploy  Configure SSH  ssh-keyscan -H $SSH_HOST >> ~/.ssh/known_hosts
deploy  Configure SSH    SSH_HOST: 195.35.14.177
deploy  Configure SSH  ##[error]Process completed with exit code 1.
```

Nothing has actually reached the dev box since 2026-07-21.

## What this changes

`deploy-dev.yml` only, following the codeframe reference implementation cited in #441:

- Adds a `Connect to Tailscale` step before `Configure SSH`, using **OAuth client
  credentials** rather than ephemeral auth keys — auth keys expire, which would
  reintroduce this exact failure on a schedule.
- Replaces the live `ssh-keyscan` with a pinned `SSH_KNOWN_HOSTS` secret, guarded by an
  explicit empty check so a missing secret fails loudly instead of writing an empty
  `known_hosts` and failing three steps later.

Two things improve beyond restoring the deploy:

- **TOFU removed.** `ssh-keyscan` trusts whatever key answers. A pinned known-hosts entry
  does not.
- **fail2ban avoided.** Repeated keyscan bursts got the runner banned from this box
  before; a pinned entry makes no network call at all.

Action pinned to `tailscale/github-action@780049a` (v4.1.3, current release) rather than
the v3.3.0 codeframe uses — the `oauth-client-id` / `oauth-secret` / `tags` inputs are
unchanged between them, and pinning to current avoids Dependabot immediately opening a
bump PR against a freshly-added v3.

`SSH_HOST` is re-declared in five step-level `env:` blocks, all reading
`vars.SERVER_HOST`, so repointing that one variable covers every one of them — no
per-step edits needed.

## Blocked on (cannot be done from CI)

- [ ] Create a Tailscale OAuth client (scope: `auth_keys` write) and an ACL tag `tag:ci`
- [ ] Add repo secrets `TS_OAUTH_CLIENT_ID` and `TS_OAUTH_SECRET`
- [ ] Join the VPS to the tailnet; `ufw allow in on tailscale0 to any port 22`
- [ ] Repoint `vars.SERVER_HOST` from `195.35.14.177` to the MagicDNS name (or `100.x`)
- [ ] Populate `SSH_KNOWN_HOSTS` from a trusted session, **labelled with the same host
      string used in `SERVER_HOST`** — mismatched labels will not verify

## Verification once unblocked

Re-run the workflow, confirm it reaches `Deploy Backend`, then on the box:

```bash
sudo -u podcastfy -H pm2 list   # api / celery / frontend all online
```

## Note

v4 of the action also supports OIDC federated identity (`audience` input), which would
avoid storing a long-lived OAuth secret in repo secrets entirely. Not adopted here since
#441 specifies the OAuth-client pattern already proven in codeframe, but it is the
stronger option if you'd rather set it up once properly.

Refs #441
